### PR TITLE
FIX: Datetime UTC

### DIFF
--- a/mssql_python/type.py
+++ b/mssql_python/type.py
@@ -97,7 +97,7 @@ def TimestampFromTicks(ticks: int) -> datetime.datetime:
     """
     Generates a timestamp object from ticks.
     """
-    return datetime.datetime.fromtimestamp(ticks, datetime.UTC)
+    return datetime.datetime.fromtimestamp(ticks, datetime.timezone.utc)
 
 
 def Binary(string: str) -> bytes:


### PR DESCRIPTION
This pull request includes a minor change to the `mssql_python/type.py` file. The change ensures compatibility by replacing `datetime.UTC` with `datetime.timezone.utc` in the `TimestampFromTicks` function.

* [`mssql_python/type.py`](diffhunk://#diff-57fcb124a0b5958b9034fbd0c3ee1bc65e4140e1671e642d5dcb5aabd60d55a7L100-R100): Updated the `TimestampFromTicks` function to use `datetime.timezone.utc` instead of `datetime.UTC`, aligning with Python's standard library conventions.