### PR TITLE
FIX: Correct ESRP Location for dist

### DIFF
--- a/eng/pipelines/official-release-pipeline.yml
+++ b/eng/pipelines/official-release-pipeline.yml
@@ -38,7 +38,7 @@ jobs:
   #     Intent: 'PackageDistribution'
   #     ContentType: 'PyPI'
   #     ContentSource: 'Folder'
-  #     FolderLocation: '$(System.DefaultWorkingDirectory)/dist'
+  #     FolderLocation: '$(Build.SourcesDirectory)/dist'
   #     WaitForReleaseCompletion: true
   #     Owners: '$(owner)'
   #     Approvers: '$(approver)'


### PR DESCRIPTION
This pull request updates the `FolderLocation` value in the `official-release-pipeline.yml` file to improve the accuracy of the build process by using the correct directory variable.

Pipeline configuration update:

* [`eng/pipelines/official-release-pipeline.yml`](diffhunk://#diff-f296aaefe400fe34ca36f70a6678007397eeda60a5d3edde7594389f2391cc6fL41-R41): Changed the `FolderLocation` from `$(System.DefaultWorkingDirectory)/dist` to `$(Build.SourcesDirectory)/dist` to ensure the correct directory is used during the release pipeline.