### PR TITLE
FEAT: Integrate python <->C++ flow with C++ connection class

### DIFF
--- a/mssql_python/connection.py
+++ b/mssql_python/connection.py
@@ -59,7 +59,6 @@ class Connection:
         self._attrs_before = attrs_before or {}
         self._conn = ddbc_bindings.Connection(self.connection_str, autocommit)
         self._conn.connect(self._attrs_before)
-        self._autocommit = autocommit
         self.setautocommit(autocommit)
 
     def _construct_connection_string(self, connection_str: str = "", **kwargs) -> str:
@@ -133,7 +132,6 @@ class Connection:
             DatabaseError: If there is an error while setting the autocommit mode.
         """
         self._conn.set_autocommit(value)
-        self._autocommit = value
 
     def cursor(self) -> Cursor:
         """

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -422,6 +422,7 @@ class Cursor:
         Reset the DDBC statement handle.
         """
         if self.hstmt:
+            self.hstmt.free()
             self.hstmt = None
             if ENABLE_LOGGING:
                 logger.debug("SQLFreeHandle succeeded")     
@@ -439,6 +440,7 @@ class Cursor:
             raise Exception("Cursor is already closed.")
 
         if self.hstmt:
+            self.hstmt.free()
             self.hstmt = None
             if ENABLE_LOGGING:
                 logger.debug("SQLFreeHandle succeeded")
@@ -548,7 +550,6 @@ class Cursor:
             reset_cursor: Whether to reset the cursor before execution.
         """
         self._check_closed()  # Check if the cursor is closed
-
         if reset_cursor:
             self._reset_cursor()
 

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -48,8 +48,6 @@ class Cursor:
         Args:
             connection: Database connection object.
         """
-        if connection.hdbc is None:
-            raise Exception("Connection is closed. Cannot create a cursor.")
         self.connection = connection
         # self.connection.autocommit = False
         self.hstmt = None
@@ -417,19 +415,14 @@ class Cursor:
         """
         Allocate the DDBC statement handle.
         """
-        ret, handle = ddbc_bindings.DDBCSQLAllocHandle(
-            ddbc_sql_const.SQL_HANDLE_STMT.value,
-            self.connection.hdbc
-        )
-        check_error(ddbc_sql_const.SQL_HANDLE_STMT.value, handle, ret)
-        self.hstmt = handle
+        self.connection._conn.alloc_statement_handle()
+        print(f"Statement handle: {self.hstmt}")
 
     def _reset_cursor(self) -> None:
         """
         Reset the DDBC statement handle.
         """
         if self.hstmt:
-            self.hstmt.free()  # Free the existing statement handle
             self.hstmt = None
             if ENABLE_LOGGING:
                 logger.debug("SQLFreeHandle succeeded")     
@@ -447,7 +440,6 @@ class Cursor:
             raise Exception("Cursor is already closed.")
 
         if self.hstmt:
-            self.hstmt.free()
             self.hstmt = None
             if ENABLE_LOGGING:
                 logger.debug("SQLFreeHandle succeeded")

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -415,8 +415,7 @@ class Cursor:
         """
         Allocate the DDBC statement handle.
         """
-        self.connection._conn.alloc_statement_handle()
-        print(f"Statement handle: {self.hstmt}")
+        self.hstmt = self.connection._conn.alloc_statement_handle()
 
     def _reset_cursor(self) -> None:
         """

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -78,6 +78,7 @@ void Connection::disconnect() {
     }
 }
 
+// TODO: Add an exception class in C++ for error handling, DB spec compliant
 void Connection::checkError(SQLRETURN ret) const{
     if (!SQL_SUCCEEDED(ret)) {
         ErrorInfo err = SQLCheckError_Wrap(SQL_HANDLE_DBC, _dbcHandle, ret);
@@ -88,7 +89,7 @@ void Connection::checkError(SQLRETURN ret) const{
 
 void Connection::commit() {
     if (!_dbcHandle) {
-        throw std::runtime_error("Connection handle not allocated");
+        ThrowStdException("Connection handle not allocated");
     }
     LOG("Committing transaction");
     SQLRETURN ret = SQLEndTran_ptr(SQL_HANDLE_DBC, _dbcHandle->get(), SQL_COMMIT);
@@ -97,7 +98,7 @@ void Connection::commit() {
 
 void Connection::rollback() {
     if (!_dbcHandle) {
-        throw std::runtime_error("Connection handle not allocated");
+        ThrowStdException("Connection handle not allocated");
     }
     LOG("Rolling back transaction");
     SQLRETURN ret = SQLEndTran_ptr(SQL_HANDLE_DBC, _dbcHandle->get(), SQL_ROLLBACK);
@@ -106,7 +107,7 @@ void Connection::rollback() {
 
 void Connection::setAutocommit(bool enable) {
     if (!_dbcHandle) {
-        throw std::runtime_error("Connection handle not allocated");
+        ThrowStdException("Connection handle not allocated");
     }
     SQLINTEGER value = enable ? SQL_AUTOCOMMIT_ON : SQL_AUTOCOMMIT_OFF;
     LOG("Set SQL Connection Attribute");
@@ -117,7 +118,7 @@ void Connection::setAutocommit(bool enable) {
 
 bool Connection::getAutocommit() const {
     if (!_dbcHandle) {
-        throw std::runtime_error("Connection handle not allocated");
+        ThrowStdException("Connection handle not allocated");
     }
     LOG("Get SQL Connection Attribute");
     SQLINTEGER value;
@@ -129,7 +130,7 @@ bool Connection::getAutocommit() const {
 
 SqlHandlePtr Connection::allocStatementHandle() {
     if (!_dbcHandle) {
-        throw std::runtime_error("Connection handle not allocated");
+        ThrowStdException("Connection handle not allocated");
     }
     LOG("Allocating statement handle");
     SQLHANDLE stmt = nullptr;
@@ -180,7 +181,7 @@ void Connection::applyAttrsBefore(const py::dict& attrs) {
         if (key == SQL_COPT_SS_ACCESS_TOKEN) {   
             SQLRETURN ret = setAttribute(key, py::reinterpret_borrow<py::object>(item.second));
             if (!SQL_SUCCEEDED(ret)) {
-                throw std::runtime_error("Failed to set access token before connect");
+                ThrowStdException("Failed to set access token before connect");
             }
         }
     }

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -95,7 +95,7 @@ SQLRETURN Connection::setAutocommit(bool enable) {
         throw std::runtime_error("Connection handle not allocated");
     }
     SQLINTEGER value = enable ? SQL_AUTOCOMMIT_ON : SQL_AUTOCOMMIT_OFF;
-    LOG("Set SQL Connection Attribute");
+    LOG("Set SQL Connection Attribute - Autocommit");   
     SQLRETURN ret = SQLSetConnectAttr_ptr(_dbc_handle->get(), SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)value, 0);
     if (!SQL_SUCCEEDED(ret)) {
         throw std::runtime_error("Failed to set autocommit mode.");
@@ -167,7 +167,7 @@ SqlHandlePtr Connection::allocStatementHandle() {
 }
 
 SQLRETURN Connection::set_attribute(SQLINTEGER attribute, py::object value) {
-    LOG("Setting SQL attribute {}");
+    LOG("Setting SQL attribute");
 
     SQLPOINTER ptr = nullptr;
     SQLINTEGER length = 0;
@@ -188,7 +188,10 @@ SQLRETURN Connection::set_attribute(SQLINTEGER attribute, py::object value) {
 
     SQLRETURN ret = SQLSetConnectAttr_ptr(_dbc_handle->get(), attribute, ptr, length);
     if (!SQL_SUCCEEDED(ret)) {
-        LOG("Failed to set attribute {}");
+        LOG("Failed to set attribute");
+    }
+    else {
+        LOG("Set attribute successfully");
     }
     return ret;
 }

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -5,7 +5,6 @@
 //             taken up in future
 
 #include "connection.h"
-#include <iostream>
 #include <vector>
 #include <pybind11/pybind11.h>
 
@@ -19,9 +18,7 @@
 Connection::Connection(const std::wstring& conn_str, bool autocommit)
     : _conn_str(conn_str) , _autocommit(autocommit) {}
 
-Connection::~Connection() {
-    close();    // Ensure the connection is closed when the object is destroyed.
-}
+Connection::~Connection() {}
 
 SQLRETURN Connection::connect(const py::dict& attrs_before) {
     allocDbcHandle();
@@ -54,7 +51,7 @@ SQLRETURN Connection::connectToDb() {
                                          (SQLWCHAR*)_conn_str.c_str(), SQL_NTS,
                                          nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
     if (!SQL_SUCCEEDED(ret)) {
-        throw std::runtime_error("Failed to connect to database");
+        ThrowStdException("Client unable to establish connection");
     }
     LOG("Connected to database successfully");
     return ret;
@@ -72,7 +69,7 @@ SQLRETURN Connection::close() {
     }
 
     SQLRETURN ret = SQLDisconnect_ptr(_dbc_handle->get());
-    _dbc_handle.reset();
+    _dbc_handle->free();
     return ret;
 }
 
@@ -119,7 +116,6 @@ bool Connection::getAutocommit() const {
     SQLINTEGER value;
     SQLINTEGER string_length;
     SQLGetConnectAttr_ptr(_dbc_handle->get(), SQL_ATTR_AUTOCOMMIT, &value, sizeof(value), &string_length);
-    
     return value == SQL_AUTOCOMMIT_ON;
 }
 

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -26,18 +26,18 @@ Connection::Connection(const std::wstring& conn_str, bool autocommit)
             DriverLoader::getInstance().loadDriver();
         }
         SQLRETURN ret = SQLAllocHandle_ptr(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
-        checkError(ret, "Failed to allocate environment handle");
+        checkError(ret);
         _envHandle = std::make_shared<SqlHandle>(SQL_HANDLE_ENV, env);
 
         LOG("Setting environment attributes");
         ret = SQLSetEnvAttr_ptr(_envHandle->get(), SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3_80, 0);
-        checkError(ret, "Failed to set environment attribute");
+        checkError(ret);
     }
     allocateDbcHandle();
 }
 
 Connection::~Connection() {
-    disconnect();   // fallback if app forgets to disconnect
+    disconnect();   // fallback if user forgets to disconnect
 }
 
 // Allocates connection handle
@@ -45,25 +45,32 @@ void Connection::allocateDbcHandle() {
     SQLHANDLE dbc = nullptr;
     LOG("Allocate SQL Connection Handle");
     SQLRETURN ret = SQLAllocHandle_ptr(SQL_HANDLE_DBC, _envHandle->get(), &dbc);
-    checkError(ret, "Failed to allocate connection handle");
+    checkError(ret);
     _dbcHandle = std::make_shared<SqlHandle>(SQL_HANDLE_DBC, dbc);
 }
 
-void Connection::connect() {
+SQLRETURN Connection::connect(const py::dict& attrs_before) {
     LOG("Connecting to database");
+    // Apply access token before connect
+    if (!attrs_before.is_none() && py::len(attrs_before) > 0) {
+        LOG("Apply attributes before connect");
+        applyAttrsBefore(attrs_before);
+        if (_autocommit) {
+            setAutocommit(_autocommit);
+        }
+    }
     SQLRETURN ret = SQLDriverConnect_ptr(
         _dbcHandle->get(), nullptr,
         (SQLWCHAR*)_connStr.c_str(), SQL_NTS,
         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
-    checkError(ret, "SQLDriverConnect failed");
-    setAutocommit(_autocommit);
+    checkError(ret);
 }
 
 void Connection::disconnect() {
     if (_dbcHandle) {
         LOG("Disconnecting from database");
         SQLRETURN ret = SQLDisconnect_ptr(_dbcHandle->get());
-        checkError(ret, "Failed to disconnect from database");
+        checkError(ret);
         _dbcHandle.reset(); // triggers SQLFreeHandle via destructor, if last owner
     }
     else {
@@ -71,9 +78,11 @@ void Connection::disconnect() {
     }
 }
 
-void Connection::checkError(SQLRETURN ret, const std::string& msg) const{
-    if (ret != SQL_SUCCESS && ret != SQL_SUCCESS_WITH_INFO) {
-        throw std::runtime_error("[ODBC Error] " + msg);
+void Connection::checkError(SQLRETURN ret) const{
+    if (!SQL_SUCCEEDED(ret)) {
+        ErrorInfo err = SQLCheckError_Wrap(SQL_HANDLE_DBC, _dbcHandle, ret);
+        std::string errorMsg = std::string(err.ddbcErrorMsg.begin(), err.ddbcErrorMsg.end());
+        ThrowStdException(errorMsg);
     }
 }
 
@@ -83,7 +92,7 @@ void Connection::commit() {
     }
     LOG("Committing transaction");
     SQLRETURN ret = SQLEndTran_ptr(SQL_HANDLE_DBC, _dbcHandle->get(), SQL_COMMIT);
-    checkError(ret, "Failed to commit transaction");
+    checkError(ret);
 }
 
 void Connection::rollback() {
@@ -92,7 +101,7 @@ void Connection::rollback() {
     }
     LOG("Rolling back transaction");
     SQLRETURN ret = SQLEndTran_ptr(SQL_HANDLE_DBC, _dbcHandle->get(), SQL_ROLLBACK);
-    checkError(ret, "Failed to rollback transaction");
+    checkError(ret);
 }
 
 void Connection::setAutocommit(bool enable) {
@@ -102,7 +111,7 @@ void Connection::setAutocommit(bool enable) {
     SQLINTEGER value = enable ? SQL_AUTOCOMMIT_ON : SQL_AUTOCOMMIT_OFF;
     LOG("Set SQL Connection Attribute");
     SQLRETURN ret = SQLSetConnectAttr_ptr(_dbcHandle->get(), SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)value, 0);
-    checkError(ret, "Failed to set autocommit attribute");
+    checkError(ret);
     _autocommit = enable;
 }
 
@@ -114,7 +123,7 @@ bool Connection::getAutocommit() const {
     SQLINTEGER value;
     SQLINTEGER string_length;
     SQLRETURN ret = SQLGetConnectAttr_ptr(_dbcHandle->get(), SQL_ATTR_AUTOCOMMIT, &value, sizeof(value), &string_length);
-    checkError(ret, "Failed to get autocommit attribute");
+    checkError(ret);
     return value == SQL_AUTOCOMMIT_ON;
 }
 
@@ -125,32 +134,54 @@ SqlHandlePtr Connection::allocStatementHandle() {
     LOG("Allocating statement handle");
     SQLHANDLE stmt = nullptr;
     SQLRETURN ret = SQLAllocHandle_ptr(SQL_HANDLE_STMT, _dbcHandle->get(), &stmt);
-    checkError(ret, "Failed to allocate statement handle");
+    checkError(ret);
     return std::make_shared<SqlHandle>(SQL_HANDLE_STMT, stmt);
 }
 
-SqlHandlePtr Connection::getSharedEnvHandle() {
-    static std::once_flag flag;
-    static SqlHandlePtr env_handle;
 
-    std::call_once(flag, []() {
-        LOG("Allocating environment handle");
-        SQLHANDLE env = nullptr;
-        if (!SQLAllocHandle_ptr) {
-            LOG("Function pointers not initialized, loading driver");
-            DriverLoader::getInstance().loadDriver();
-        }
-        SQLRETURN ret = SQLAllocHandle_ptr(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env);
-        if (!SQL_SUCCEEDED(ret)) {
-            throw std::runtime_error("Failed to allocate environment handle");
-        }
-        env_handle = std::make_shared<SqlHandle>(SQL_HANDLE_ENV, env);
+SQLRETURN Connection::setAttribute(SQLINTEGER attribute, py::object value) {
+    LOG("Setting SQL attribute");
+    SQLPOINTER ptr = nullptr;
+    SQLINTEGER length = 0;
 
-        LOG("Setting environment attributes");
-        ret = SQLSetEnvAttr_ptr(env_handle->get(), SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3_80, 0);
-        if (!SQL_SUCCEEDED(ret)) {
-            throw std::runtime_error("Failed to set environment attribute");
+    if (py::isinstance<py::int_>(value)) {
+        int intValue = value.cast<int>();
+        ptr = reinterpret_cast<SQLPOINTER>(static_cast<uintptr_t>(intValue));
+        length = SQL_IS_INTEGER;
+    } else if (py::isinstance<py::bytes>(value) || py::isinstance<py::bytearray>(value)) {
+        static std::vector<std::string> buffers;
+        buffers.emplace_back(value.cast<std::string>());
+        ptr = const_cast<char*>(buffers.back().c_str());
+        length = static_cast<SQLINTEGER>(buffers.back().size());
+    } else {
+        LOG("Unsupported attribute value type");
+        return SQL_ERROR;
+    }
+
+    SQLRETURN ret = SQLSetConnectAttr_ptr(_dbcHandle->get(), attribute, ptr, length);
+    if (!SQL_SUCCEEDED(ret)) {
+        LOG("Failed to set attribute");
+    }
+    else {
+        LOG("Set attribute successfully");
+    }
+    return ret;
+}
+
+void Connection::applyAttrsBefore(const py::dict& attrs) {
+    for (const auto& item : attrs) {
+        int key;
+        try {
+            key = py::cast<int>(item.first);
+        } catch (...) {
+            continue;
         }
-    });
-    return env_handle;
+
+        if (key == SQL_COPT_SS_ACCESS_TOKEN) {   
+            SQLRETURN ret = setAttribute(key, py::reinterpret_borrow<py::object>(item.second));
+            if (!SQL_SUCCEEDED(ret)) {
+                throw std::runtime_error("Failed to set access token before connect");
+            }
+        }
+    }
 }

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -116,46 +116,6 @@ bool Connection::getAutocommit() const {
     return value == SQL_AUTOCOMMIT_ON;
 }
 
-SQLRETURN set_attribute(SQLINTEGER Attribute, py::object ValuePtr) {
-    LOG("Set SQL Connection Attribute");
-    if (!SQLSetConnectAttr_ptr) {
-        LOG("Function pointer not initialized. Loading the driver.");
-        DriverLoader::getInstance().loadDriver();  // Load the driver
-    }
-
-    // Print the type of ValuePtr and attribute value - helpful for debugging
-    LOG("Type of ValuePtr: {}, Attribute: {}", py::type::of(ValuePtr).attr("__name__").cast<std::string>(), Attribute);
-
-    SQLPOINTER value = 0;
-    SQLINTEGER length = 0;
-
-    if (py::isinstance<py::int_>(ValuePtr)) {
-        // Handle integer values
-        int intValue = ValuePtr.cast<int>();
-        value = reinterpret_cast<SQLPOINTER>(intValue);
-        length = SQL_IS_INTEGER;  // Integer values don't require a length
-    } else if (py::isinstance<py::bytes>(ValuePtr) || py::isinstance<py::bytearray>(ValuePtr)) {
-        // Handle byte or bytearray values (like access tokens)
-        // Store in static buffer to ensure memory remains valid during connection
-        static std::vector<std::string> bytesBuffers;
-        bytesBuffers.push_back(ValuePtr.cast<std::string>());
-        value = const_cast<char*>(bytesBuffers.back().c_str());
-        length = SQL_IS_POINTER;  // Indicates we're passing a pointer (required for token)
-    } else {
-        LOG("Unsupported ValuePtr type");
-        return SQL_ERROR;
-    }
-
-    SQLRETURN ret = SQLSetConnectAttr_ptr(_dbc_handle->get(), Attribute, value, length);
-    if (!SQL_SUCCEEDED(ret)) {
-        LOG("Failed to set Connection attribute");
-    }
-    else {
-        LOG("Set Connection attribute successfully");
-    }
-    return ret;
-}
-
 SqlHandlePtr Connection::allocStatementHandle() {
     LOG("Allocating statement handle");
     SQLHANDLE stmt = nullptr;
@@ -205,8 +165,7 @@ void Connection::apply_attrs_before(const py::dict& attrs) {
             continue;
         }
 
-        //do not hard code the key values
-        if (key == 1256) {   
+        if (key == SQL_COPT_SS_ACCESS_TOKEN) {   
             SQLRETURN ret = set_attribute(key, py::reinterpret_borrow<py::object>(item.second));
             if (!SQL_SUCCEEDED(ret)) {
                 throw std::runtime_error("Failed to set access token before connect");

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -8,16 +8,23 @@
 #include <iostream>
 #include <vector>
 
+<<<<<<< HEAD
 #include <pybind11/pybind11.h>
-
 
 //-------------------------------------------------------------------------------------------------
 // Implements the Connection class declared in connection.h.
 // This class wraps low-level ODBC operations like connect/disconnect,
 // transaction control, and autocommit configuration.
 //-------------------------------------------------------------------------------------------------
+<<<<<<< HEAD
 Connection::Connection(const std::wstring& conn_str, bool autocommit)
     : _conn_str(conn_str) , _autocommit(autocommit) {}
+=======
+Connection::Connection(const std::wstring& conn_str, bool autocommit) : _conn_str(conn_str) , _autocommit(autocommit) {}
+=======
+Connection::Connection(const std::wstring& conn_str) : _conn_str(conn_str) {}
+>>>>>>> fcd64d4 (working flow with c++ connection class)
+>>>>>>> 29a7a65 (working flow with c++ connection class)
 
 Connection::~Connection() {
     close();    // Ensure the connection is closed when the object is destroyed.
@@ -118,13 +125,6 @@ bool Connection::getAutocommit() const {
     return value == SQL_AUTOCOMMIT_ON;
 }
 
-<<<<<<< HEAD
-SqlHandlePtr Connection::allocStatementHandle() {
-    if (!_dbc_handle) {
-        throw std::runtime_error("Connection handle not allocated");
-    }
-    LOG("Allocating statement handle");
-=======
 SQLRETURN set_attribute(SQLINTEGER Attribute, py::object ValuePtr) {
     LOG("Set SQL Connection Attribute");
     if (!SQLSetConnectAttr_ptr) {
@@ -165,8 +165,8 @@ SQLRETURN set_attribute(SQLINTEGER Attribute, py::object ValuePtr) {
     return ret;
 }
 
-SqlHandlePtr Connection::alloc_statement_handle() {
->>>>>>> 52a2dba (initial edit)
+SqlHandlePtr Connection::allocStatementHandle() {
+    LOG("Allocating statement handle");
     SQLHANDLE stmt = nullptr;
     SQLRETURN ret = SQLAllocHandle_ptr(SQL_HANDLE_STMT, _dbc_handle->get(), &stmt);
     if (!SQL_SUCCEEDED(ret)) {

--- a/mssql_python/pybind/connection/connection.h
+++ b/mssql_python/pybind/connection/connection.h
@@ -46,10 +46,10 @@ private:
     std::wstring _conn_str;
     SqlHandlePtr _dbc_handle;
     bool _autocommit = false;
-    std::shared_ptr<Connection> _conn; 
-
-    SQLRETURN set_attribute(SQLINTEGER attribute, pybind11::object value);
-    void apply_attrs_before(const pybind11::dict& attrs);
+    
+    static SqlHandlePtr getSharedEnvHandle();
+    SQLRETURN setAttribute(SQLINTEGER attribute, pybind11::object value);
+    void applyAttrsBefore(const pybind11::dict& attrs);
 };
 
 #endif // CONNECTION_H

--- a/mssql_python/pybind/connection/connection.h
+++ b/mssql_python/pybind/connection/connection.h
@@ -18,6 +18,7 @@ public:
     Connection(const std::wstring& conn_str, bool autocommit = false);
     ~Connection();
 
+    // Establish the connection using the stored connection string.
     SQLRETURN connect(const py::dict& attrs_before = py::dict());
 
     // Close the connection and free resources.

--- a/mssql_python/pybind/connection/connection.h
+++ b/mssql_python/pybind/connection/connection.h
@@ -17,7 +17,7 @@ public:
     ~Connection();
 
     // Establish the connection using the stored connection string.
-    void connect();
+    SQLRETURN connect(const py::dict& attrs_before = py::dict());
 
     // Disconnect and free the connection handle.
     void disconnect();
@@ -39,7 +39,9 @@ public:
 
 private:
     void allocateDbcHandle();
-    void checkError(SQLRETURN ret, const std::string& msg) const;
+    void checkError(SQLRETURN ret) const;
+    SQLRETURN setAttribute(SQLINTEGER attribute, py::object value);
+    void applyAttrsBefore(const py::dict& attrs_before);
 
     std::wstring _connStr;
     bool _usePool = false;

--- a/mssql_python/pybind/connection/connection.h
+++ b/mssql_python/pybind/connection/connection.h
@@ -18,8 +18,7 @@ public:
     Connection(const std::wstring& conn_str, bool autocommit = false);
     ~Connection();
 
-    // Establish the connection using the stored connection string.
-    SQLRETURN connect();
+    SQLRETURN connect(const py::dict& attrs_before = py::dict());
 
     // Close the connection and free resources.
     SQLRETURN close();
@@ -46,8 +45,10 @@ private:
     std::wstring _conn_str;
     SqlHandlePtr _dbc_handle;
     bool _autocommit = false;
+    std::shared_ptr<Connection> _conn; 
 
-    static SqlHandlePtr getSharedEnvHandle();
+    SQLRETURN set_attribute(SQLINTEGER attribute, pybind11::object value);
+    void apply_attrs_before(const pybind11::dict& attrs);
 };
 
 #endif // CONNECTION_H

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -1922,14 +1922,11 @@ PYBIND11_MODULE(ddbc_bindings, m) {
         .def(py::init<const std::wstring&, bool>(), py::arg("conn_str"), py::arg("autocommit") = false)
         .def("connect", &Connection::connect, py::arg("attrs_before") = py::dict(), "Establish a connection to the database")
         .def("close", &Connection::close, "Close the connection")
-        .def("commit", [](Connection& self) {
-            self.end_transaction(SQL_COMMIT);
-        })
-        .def("rollback", [](Connection& self) {
-            self.end_transaction(SQL_ROLLBACK);})
-        .def("set_autocommit", &Connection::set_autocommit)
-        .def("get_autocommit", &Connection::get_autocommit)
-        .def("alloc_statement_handle", &Connection::alloc_statement_handle);
+        .def("commit", &Connection::commit, "Commit the current transaction")
+        .def("rollback", &Connection::rollback, "Rollback the current transaction")
+        .def("set_autocommit", &Connection::setAutocommit)
+        .def("get_autocommit", &Connection::getAutocommit)
+        .def("alloc_statement_handle", &Connection::allocStatementHandle);
     m.def("DDBCSQLExecDirect", &SQLExecDirect_wrap, "Execute a SQL query directly");
     m.def("DDBCSQLExecute", &SQLExecute_wrap, "Prepare and execute T-SQL statements");
     m.def("DDBCSQLRowCount", &SQLRowCount_wrap,

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -95,12 +95,6 @@ struct ColumnBuffers {
           indicators(numCols, std::vector<SQLLEN>(fetchSize)) {}
 };
 
-// This struct is used to relay error info obtained from SQLDiagRec API to the Python module
-struct ErrorInfo {
-    std::wstring sqlState;
-    std::wstring ddbcErrorMsg;
-};
-
 //-------------------------------------------------------------------------------------------------
 // Function pointer initialization
 //-------------------------------------------------------------------------------------------------
@@ -1927,8 +1921,8 @@ PYBIND11_MODULE(ddbc_bindings, m) {
         .def("free", &SqlHandle::free, "Free the handle");
     py::class_<Connection>(m, "Connection")
         .def(py::init<const std::wstring&, bool>(), py::arg("conn_str"), py::arg("autocommit") = false)
-        .def("connect", &Connection::connect, py::arg("attrs_before") = py::dict(), "Establish a connection to the database")
-        .def("close", &Connection::close, "Close the connection")
+        .def("connect", &Connection::connect)
+        .def("close", &Connection::disconnect, "Close the connection")
         .def("commit", &Connection::commit, "Commit the current transaction")
         .def("rollback", &Connection::rollback, "Rollback the current transaction")
         .def("set_autocommit", &Connection::setAutocommit)

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -633,17 +633,7 @@ SqlHandle::SqlHandle(SQLSMALLINT type, SQLHANDLE rawHandle)
 // Native ODBC handles must be explicitly released by calling `free()` directly from Python.
 // This avoids nondeterministic crashes during GC or shutdown during pytest.
 // Read the documentation for more details (https://aka.ms/CPPvsPythonGC)
-SqlHandle::~SqlHandle() {}
-
-SQLHANDLE SqlHandle::get() const {
-    return _handle;
-}
-
-SQLSMALLINT SqlHandle::type() const {
-    return _type;
-}
-
-void SqlHandle::free() {
+SqlHandle::~SqlHandle() {
     if (_handle && SQLFreeHandle_ptr) {
         const char* type_str = nullptr;
         switch (_type) {
@@ -659,6 +649,14 @@ void SqlHandle::free() {
         ss << "Freed SQL Handle of type: " << type_str;
         LOG(ss.str());
     }
+}
+
+SQLHANDLE SqlHandle::get() const {
+    return _handle;
+}
+
+SQLSMALLINT SqlHandle::type() const {
+    return _type;
 }
 
 // Wrap SQLSetConnectAttr
@@ -1963,8 +1961,7 @@ PYBIND11_MODULE(ddbc_bindings, m) {
         .def_readwrite("sqlState", &ErrorInfo::sqlState)
         .def_readwrite("ddbcErrorMsg", &ErrorInfo::ddbcErrorMsg);
         
-    py::class_<SqlHandle, SqlHandlePtr>(m, "SqlHandle")
-        .def("free", &SqlHandle::free);
+    py::class_<SqlHandle, SqlHandlePtr>(m, "SqlHandle");
     py::class_<Connection>(m, "Connection")
         .def(py::init<const std::wstring&, bool>(), py::arg("conn_str"), py::arg("autocommit") = false)
         .def("connect", &Connection::connect, py::arg("attrs_before") = py::dict(), "Establish a connection to the database")

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -3,8 +3,8 @@
 
 // INFO|TODO - Note that is file is Windows specific right now. Making it arch agnostic will be
 //             taken up in beta release
-
-#include <pybind11/pybind11.h> // pybind11.h must be the first include - https://pybind11.readthedocs.io/en/latest/basics.html#header-and-namespace-conventions
+#include "ddbc_bindings.h"
+#include "connection/connection.h"
 
 #include <cstdint>
 #include <iomanip>  // std::setw, std::setfill
@@ -14,17 +14,6 @@
 // Replace std::filesystem usage with Windows-specific headers
 #include <shlwapi.h>
 #pragma comment(lib, "shlwapi.lib")
-
-#include "ddbc_bindings.h"
-#include <pybind11/chrono.h>
-#include <pybind11/complex.h>
-#include <pybind11/functional.h>
-#include <pybind11/pytypes.h>  // Add this line for datetime support
-#include <pybind11/stl.h>
-#include "connection/connection.h"
-
-namespace py = pybind11;
-using namespace pybind11::literals;
 
 //-------------------------------------------------------------------------------------------------
 // Macro definitions
@@ -673,44 +662,44 @@ void SqlHandle::free() {
 }
 
 // Wrap SQLSetConnectAttr
-SQLRETURN SQLSetConnectAttr_wrap(SqlHandlePtr ConnectionHandle, SQLINTEGER Attribute, 
-                                 py::object ValuePtr) {
-    LOG("Set SQL Connection Attribute");
-    if (!SQLSetConnectAttr_ptr) {
-        LOG("Function pointer not initialized. Loading the driver.");
-        DriverLoader::getInstance().loadDriver();  // Load the driver
-    }
+// SQLRETURN SQLSetConnectAttr_wrap(SqlHandlePtr ConnectionHandle, SQLINTEGER Attribute, 
+//                                  py::object ValuePtr) {
+//     LOG("Set SQL Connection Attribute");
+//     if (!SQLSetConnectAttr_ptr) {
+//         LOG("Function pointer not initialized. Loading the driver.");
+//         DriverLoader::getInstance().loadDriver();  // Load the driver
+//     }
 
-    // Print the type of ValuePtr and attribute value - helpful for debugging
-    LOG("Type of ValuePtr: {}, Attribute: {}", py::type::of(ValuePtr).attr("__name__").cast<std::string>(), Attribute);
+//     // Print the type of ValuePtr and attribute value - helpful for debugging
+//     LOG("Type of ValuePtr: {}, Attribute: {}", py::type::of(ValuePtr).attr("__name__").cast<std::string>(), Attribute);
 
-    SQLPOINTER value = 0;
-    SQLINTEGER length = 0;
+//     SQLPOINTER value = 0;
+//     SQLINTEGER length = 0;
 
-    if (py::isinstance<py::int_>(ValuePtr)) {
-        // Handle integer values
-        int intValue = ValuePtr.cast<int>();
-        value = reinterpret_cast<SQLPOINTER>(intValue);
-        length = SQL_IS_INTEGER;  // Integer values don't require a length
-    } else if (py::isinstance<py::bytes>(ValuePtr) || py::isinstance<py::bytearray>(ValuePtr)) {
-        // Handle byte or bytearray values (like access tokens)
-        // Store in static buffer to ensure memory remains valid during connection
-        static std::vector<std::string> bytesBuffers;
-        bytesBuffers.push_back(ValuePtr.cast<std::string>());
-        value = const_cast<char*>(bytesBuffers.back().c_str());
-        length = SQL_IS_POINTER;  // Indicates we're passing a pointer (required for token)
-    } else {
-        LOG("Unsupported ValuePtr type");
-        return SQL_ERROR;
-    }
+//     if (py::isinstance<py::int_>(ValuePtr)) {
+//         // Handle integer values
+//         int intValue = ValuePtr.cast<int>();
+//         value = reinterpret_cast<SQLPOINTER>(intValue);
+//         length = SQL_IS_INTEGER;  // Integer values don't require a length
+//     } else if (py::isinstance<py::bytes>(ValuePtr) || py::isinstance<py::bytearray>(ValuePtr)) {
+//         // Handle byte or bytearray values (like access tokens)
+//         // Store in static buffer to ensure memory remains valid during connection
+//         static std::vector<std::string> bytesBuffers;
+//         bytesBuffers.push_back(ValuePtr.cast<std::string>());
+//         value = const_cast<char*>(bytesBuffers.back().c_str());
+//         length = SQL_IS_POINTER;  // Indicates we're passing a pointer (required for token)
+//     } else {
+//         LOG("Unsupported ValuePtr type");
+//         return SQL_ERROR;
+//     }
 
-    SQLRETURN ret = SQLSetConnectAttr_ptr(ConnectionHandle->get(), Attribute, value, length);
-    if (!SQL_SUCCEEDED(ret)) {
-        LOG("Failed to set Connection attribute");
-    }
-    LOG("Set Connection attribute successfully");
-    return ret;
-}
+//     SQLRETURN ret = SQLSetConnectAttr_ptr(ConnectionHandle->get(), Attribute, value, length);
+//     if (!SQL_SUCCEEDED(ret)) {
+//         LOG("Failed to set Connection attribute");
+//     }
+//     LOG("Set Connection attribute successfully");
+//     return ret;
+// }
 
 // Helper function to check for driver errors
 ErrorInfo SQLCheckError_Wrap(SQLSMALLINT handleType, SqlHandlePtr handle, SQLRETURN retcode) {
@@ -1977,8 +1966,8 @@ PYBIND11_MODULE(ddbc_bindings, m) {
     py::class_<SqlHandle, SqlHandlePtr>(m, "SqlHandle")
         .def("free", &SqlHandle::free);
     py::class_<Connection>(m, "Connection")
-        .def(py::init<const std::wstring&>(), py::arg("conn_str"))
-        .def("connect", &Connection::connect, "Establish a connection to the database")
+        .def(py::init<const std::wstring&, bool>(), py::arg("conn_str"), py::arg("autocommit") = false)
+        .def("connect", &Connection::connect, py::arg("attrs_before") = py::dict(), "Establish a connection to the database")
         .def("close", &Connection::close, "Close the connection")
         .def("commit", [](Connection& self) {
             self.end_transaction(SQL_COMMIT);
@@ -1988,9 +1977,6 @@ PYBIND11_MODULE(ddbc_bindings, m) {
         .def("set_autocommit", &Connection::set_autocommit)
         .def("get_autocommit", &Connection::get_autocommit)
         .def("alloc_statement_handle", &Connection::alloc_statement_handle);
-    m.def("DDBCSQLSetConnectAttr", &SQLSetConnectAttr_wrap,
-          "Set an attribute that governs aspects of connections");
-
     m.def("DDBCSQLExecDirect", &SQLExecDirect_wrap, "Execute a SQL query directly");
     m.def("DDBCSQLExecute", &SQLExecute_wrap, "Prepare and execute T-SQL statements");
     m.def("DDBCSQLRowCount", &SQLRowCount_wrap,

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -671,134 +671,6 @@ void SqlHandle::free() {
     }
 }
 
-// Wrap SQLAllocHandle
-SQLRETURN SQLAllocHandle_wrap(SQLSMALLINT HandleType, SqlHandlePtr InputHandle, SqlHandlePtr& OutputHandle) {
-    LOG("Allocate SQL Handle");
-    if (!SQLAllocHandle_ptr) {
-        LOG("Function pointer not initialized. Loading the driver.");
-        DriverLoader::getInstance().loadDriver();  // Load the driver
-    }
-
-    SQLHANDLE rawOutputHandle = nullptr;
-    SQLRETURN ret = SQLAllocHandle_ptr(HandleType, InputHandle ? InputHandle->get() : nullptr, &rawOutputHandle);
-    if (!SQL_SUCCEEDED(ret)) {
-        LOG("Failed to allocate handle");
-        return ret;
-    }
-    OutputHandle = std::make_shared<SqlHandle>(HandleType, rawOutputHandle);
-    return ret;
-}
-
-// Wrap SQLSetEnvAttr
-SQLRETURN SQLSetEnvAttr_wrap(SqlHandlePtr EnvHandle, SQLINTEGER Attribute, intptr_t ValuePtr,
-                             SQLINTEGER StringLength) {
-    LOG("Set SQL environment Attribute");
-    if (!SQLSetEnvAttr_ptr) {
-        LOG("Function pointer not initialized. Loading the driver.");
-        DriverLoader::getInstance().loadDriver();  // Load the driver
-    }
-
-    // TODO: Does ValuePtr need to be converted from Python to C++ object?
-    SQLRETURN ret =  SQLSetEnvAttr_ptr(EnvHandle->get(), Attribute, reinterpret_cast<SQLPOINTER>(ValuePtr), StringLength);
-    if (!SQL_SUCCEEDED(ret)) {
-        LOG("Failed to set environment attribute");
-    }
-    return ret;
-}
-
-// Wrap SQLSetConnectAttr
-SQLRETURN SQLSetConnectAttr_wrap(SqlHandlePtr ConnectionHandle, SQLINTEGER Attribute, 
-                                 py::object ValuePtr) {
-    LOG("Set SQL Connection Attribute");
-    if (!SQLSetConnectAttr_ptr) {
-        LOG("Function pointer not initialized. Loading the driver.");
-        DriverLoader::getInstance().loadDriver();  // Load the driver
-    }
-
-    // Print the type of ValuePtr and attribute value - helpful for debugging
-    LOG("Type of ValuePtr: {}, Attribute: {}", py::type::of(ValuePtr).attr("__name__").cast<std::string>(), Attribute);
-
-    SQLPOINTER value = 0;
-    SQLINTEGER length = 0;
-
-    if (py::isinstance<py::int_>(ValuePtr)) {
-        // Handle integer values
-        int intValue = ValuePtr.cast<int>();
-        value = reinterpret_cast<SQLPOINTER>(intValue);
-        length = SQL_IS_INTEGER;  // Integer values don't require a length
-    // } else if (py::isinstance<py::str>(ValuePtr)) {
-    //     // Handle Unicode string values
-    //     static std::wstring unicodeValueBuffer;
-    //     unicodeValueBuffer = ValuePtr.cast<std::wstring>();
-    //     value = const_cast<SQLWCHAR*>(unicodeValueBuffer.c_str());
-    //     length = SQL_NTS;  // Indicates null-terminated string
-    } else if (py::isinstance<py::bytes>(ValuePtr) || py::isinstance<py::bytearray>(ValuePtr)) {
-        // Handle byte or bytearray values (like access tokens)
-        // Store in static buffer to ensure memory remains valid during connection
-        static std::vector<std::string> bytesBuffers;
-        bytesBuffers.push_back(ValuePtr.cast<std::string>());
-        value = const_cast<char*>(bytesBuffers.back().c_str());
-        length = SQL_IS_POINTER;  // Indicates we're passing a pointer (required for token)
-    // } else if (py::isinstance<py::list>(ValuePtr) || py::isinstance<py::tuple>(ValuePtr)) {
-    //     // Handle list or tuple values
-    //     LOG("ValuePtr is a sequence (list or tuple)");
-    //     for (py::handle item : ValuePtr) {
-    //         LOG("Processing item in sequence");
-    //         SQLRETURN ret = SQLSetConnectAttr_wrap(ConnectionHandle, Attribute, py::reinterpret_borrow<py::object>(item));
-    //         if (!SQL_SUCCEEDED(ret)) {
-    //             LOG("Failed to set attribute for item in sequence");
-    //             return ret;
-    //         }
-    //     }    
-    } else {
-        LOG("Unsupported ValuePtr type");
-        return SQL_ERROR;
-    }
-
-    SQLRETURN ret = SQLSetConnectAttr_ptr(ConnectionHandle->get(), Attribute, value, length);
-    if (!SQL_SUCCEEDED(ret)) {
-        LOG("Failed to set Connection attribute");
-    }
-    LOG("Set Connection attribute successfully");
-    return ret;
-}
-
-// Wrap SQLSetStmtAttr
-SQLRETURN SQLSetStmtAttr_wrap(SqlHandlePtr StatementHandle, SQLINTEGER Attribute, intptr_t ValuePtr,
-                              SQLINTEGER StringLength) {
-    LOG("Set SQL Statement Attribute");
-    if (!SQLSetConnectAttr_ptr) {
-        LOG("Function pointer not initialized. Loading the driver.");
-        DriverLoader::getInstance().loadDriver();  // Load the driver
-    }
-
-    // TODO: Does ValuePtr need to be converted from Python to C++ object?
-    SQLRETURN ret = SQLSetStmtAttr_ptr(StatementHandle->get(), Attribute, reinterpret_cast<SQLPOINTER>(ValuePtr), StringLength);
-    if (!SQL_SUCCEEDED(ret)) {
-        LOG("Failed to set Statement attribute");
-    }
-    return ret;
-}
-
-// Wrap SQLGetConnectionAttrA
-// Currently only supports retrieval of int-valued attributes
-// TODO: add support to retrieve all types of attributes
-SQLINTEGER SQLGetConnectionAttr_wrap(SqlHandlePtr ConnectionHandle, SQLINTEGER attribute) {
-    LOG("Get SQL COnnection Attribute");
-    if (!SQLGetConnectAttr_ptr) {
-        LOG("Function pointer not initialized. Loading the driver.");
-        DriverLoader::getInstance().loadDriver();  // Load the driver
-    }
-
-    SQLINTEGER stringLength;
-    SQLINTEGER intValue;
-
-    // Try to get the attribute as an integer
-    SQLGetConnectAttr_ptr(ConnectionHandle->get(), attribute, &intValue,
-                          sizeof(SQLINTEGER), &stringLength);
-    return intValue;
-}
-
 // Helper function to check for driver errors
 ErrorInfo SQLCheckError_Wrap(SQLSMALLINT handleType, SqlHandlePtr handle, SQLRETURN retcode) {
     LOG("Checking errors for retcode - {}" , retcode);
@@ -830,23 +702,6 @@ ErrorInfo SQLCheckError_Wrap(SQLSMALLINT handleType, SqlHandlePtr handle, SQLRET
         }
     }
     return errorInfo;
-}
-
-// Wrap SQLDriverConnect
-SQLRETURN SQLDriverConnect_wrap(SqlHandlePtr ConnectionHandle, intptr_t WindowHandle, const std::wstring& ConnectionString) {
-    LOG("Driver Connect to MSSQL");
-    if (!SQLDriverConnect_ptr) {
-        LOG("Function pointer not initialized. Loading the driver.");
-        DriverLoader::getInstance().loadDriver();  // Load the driver
-    }
-    SQLRETURN ret = SQLDriverConnect_ptr(ConnectionHandle->get(),
-                                reinterpret_cast<SQLHWND>(WindowHandle),
-                                const_cast<SQLWCHAR*>(ConnectionString.c_str()), SQL_NTS, nullptr,
-                                0, nullptr, SQL_DRIVER_NOPROMPT);
-    if (!SQL_SUCCEEDED(ret)) {
-        LOG("Failed to connect to DB");
-    }
-    return ret;
 }
 
 // Wrap SQLExecDirect
@@ -2004,17 +1859,6 @@ SQLRETURN SQLMoreResults_wrap(SqlHandlePtr StatementHandle) {
     return SQLMoreResults_ptr(StatementHandle->get());
 }
 
-// Wrap SQLEndTran
-SQLRETURN SQLEndTran_wrap(SQLSMALLINT HandleType, SqlHandlePtr Handle, SQLSMALLINT CompletionType) {
-    LOG("End SQL Transaction");
-    if (!SQLEndTran_ptr) {
-        LOG("Function pointer not initialized. Loading the driver.");
-        DriverLoader::getInstance().loadDriver();  // Load the driver
-    }
-
-    return SQLEndTran_ptr(HandleType, Handle->get(), CompletionType);
-}
-
 // Wrap SQLFreeHandle
 SQLRETURN SQLFreeHandle_wrap(SQLSMALLINT HandleType, SqlHandlePtr Handle) {
     LOG("Free SQL handle");
@@ -2028,17 +1872,6 @@ SQLRETURN SQLFreeHandle_wrap(SQLSMALLINT HandleType, SqlHandlePtr Handle) {
         LOG("SQLFreeHandle failed with error code - {}", ret);
     }
     return ret;
-}
-
-// Wrap SQLDisconnect
-SQLRETURN SQLDisconnect_wrap(SqlHandlePtr ConnectionHandle) {
-    LOG("Disconnect from MSSQL");
-    if (!SQLDisconnect_ptr) {
-        LOG("Function pointer not initialized. Loading the driver.");
-        DriverLoader::getInstance().loadDriver();  // Load the driver
-    }
-
-    return SQLDisconnect_ptr(ConnectionHandle->get());
 }
 
 // Wrap SQLRowCount
@@ -2102,22 +1935,21 @@ PYBIND11_MODULE(ddbc_bindings, m) {
         
     py::class_<SqlHandle, SqlHandlePtr>(m, "SqlHandle")
         .def("free", &SqlHandle::free);
-        
-    m.def("DDBCSQLAllocHandle", [](SQLSMALLINT HandleType, SqlHandlePtr InputHandle = nullptr) {
-            SqlHandlePtr OutputHandle;
-            SQLRETURN rc = SQLAllocHandle_wrap(HandleType, InputHandle, OutputHandle);
-            return py::make_tuple(rc, OutputHandle);
-        }, "Allocate an environment, connection, statement, or descriptor handle");
-    m.def("DDBCSQLSetEnvAttr", &SQLSetEnvAttr_wrap,
-          "Set an attribute that governs aspects of environments");
+    py::class_<Connection>(m, "Connection")
+        .def(py::init<const std::wstring&, bool>(), py::arg("conn_str"))
+        .def("connect", &Connection::connect, "Establish a connection to the database")
+        .def("close", &Connection::close, "Close the connection")
+        .def("commit", [](Connection& self) {
+            self.end_transaction(SQL_COMMIT);
+        })
+        .def("rollback", [](Connection& self) {
+            self.end_transaction(SQL_ROLLBACK)})
+        .def("set_autocommit", &Connection::set_autocommit)
+        .def("get_autocommit", &Connection::get_autocommit)
+        .def("set_attribute", &Connection::set_attribute);
+        .def("alloc_statement_handle", &Connection::alloc_statement_handle);
     m.def("DDBCSQLSetConnectAttr", &SQLSetConnectAttr_wrap,
           "Set an attribute that governs aspects of connections");
-    m.def("DDBCSQLSetStmtAttr", &SQLSetStmtAttr_wrap,
-          "Set an attribute that governs aspects of statements");
-    m.def("DDBCSQLGetConnectionAttr", &SQLGetConnectionAttr_wrap,
-          "Get an attribute that governs aspects of connections");
-    m.def("DDBCSQLDriverConnect", &SQLDriverConnect_wrap,
-          "Connect to a data source with a connection string");
     m.def("DDBCSQLExecDirect", &SQLExecDirect_wrap, "Execute a SQL query directly");
     m.def("DDBCSQLExecute", &SQLExecute_wrap, "Prepare and execute T-SQL statements");
     m.def("DDBCSQLRowCount", &SQLRowCount_wrap,
@@ -2135,7 +1967,6 @@ PYBIND11_MODULE(ddbc_bindings, m) {
     m.def("DDBCSQLFetchAll", &FetchAll_wrap, "Fetch all rows from the result set");
     m.def("DDBCSQLEndTran", &SQLEndTran_wrap, "End a transaction");
     m.def("DDBCSQLFreeHandle", &SQLFreeHandle_wrap, "Free a handle");
-    m.def("DDBCSQLDisconnect", &SQLDisconnect_wrap, "Disconnect from a data source");
     m.def("DDBCSQLCheckError", &SQLCheckError_Wrap, "Check for driver errors");
 
     // Add a version attribute

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -160,6 +160,7 @@ class SqlHandle {
         ~SqlHandle();
         SQLHANDLE get() const;
         SQLSMALLINT type() const;
+        void free();
     private:
         SQLSMALLINT _type;
         SQLHANDLE _handle;

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -4,7 +4,6 @@
 // INFO|TODO - Note that is file is Windows specific right now. Making it arch agnostic will be
 //             taken up in future.
 
->>>>>>> 1182190 (resolve review comments)
 #pragma once
 
 #include <Windows.h>

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-<<<<<<< HEAD
 // INFO|TODO - Note that is file is Windows specific right now. Making it arch agnostic will be
 //             taken up in future.
 
-=======
->>>>>>> 25d6ef0 (refactor native layer and create reusable components)
+>>>>>>> 1182190 (resolve review comments)
 #pragma once
 
 #include <Windows.h>

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -121,6 +121,7 @@ extern SQLGetDiagRecFunc SQLGetDiagRec_ptr;
 template <typename... Args>
 void LOG(const std::string& formatString, Args&&... args);
 
+
 // Throws a std::runtime_error with the given message
 void ThrowStdException(const std::string& message);
 
@@ -169,3 +170,10 @@ class SqlHandle {
         SQLHANDLE _handle;
     };
     using SqlHandlePtr = std::shared_ptr<SqlHandle>;
+
+// This struct is used to relay error info obtained from SQLDiagRec API to the Python module
+struct ErrorInfo {
+    std::wstring sqlState;
+    std::wstring ddbcErrorMsg;
+};
+ErrorInfo SQLCheckError_Wrap(SQLSMALLINT handleType, SqlHandlePtr handle, SQLRETURN retcode);

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -160,7 +160,6 @@ class SqlHandle {
         ~SqlHandle();
         SQLHANDLE get() const;
         SQLSMALLINT type() const;
-        void free();
     private:
         SQLSMALLINT _type;
         SQLHANDLE _handle;

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -106,11 +106,11 @@ extern SQLFreeStmtFunc SQLFreeStmt_ptr;
 extern SQLGetDiagRecFunc SQLGetDiagRec_ptr;
 
 
-// -- Logging utility --
+// Logging utility
 template <typename... Args>
 void LOG(const std::string& formatString, Args&&... args);
 
-// -- Exception helper --
+// Throws a std::runtime_error with the given message
 void ThrowStdException(const std::string& message);
 
 //-------------------------------------------------------------------------------------------------

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -159,3 +159,4 @@ class SqlHandle {
         SQLHANDLE _handle;
     };
     using SqlHandlePtr = std::shared_ptr<SqlHandle>;
+    

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+<<<<<<< HEAD
 // INFO|TODO - Note that is file is Windows specific right now. Making it arch agnostic will be
 //             taken up in future.
 
+=======
+>>>>>>> 25d6ef0 (refactor native layer and create reusable components)
 #pragma once
 
 #include <Windows.h>

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -159,4 +159,3 @@ class SqlHandle {
         SQLHANDLE _handle;
     };
     using SqlHandlePtr = std::shared_ptr<SqlHandle>;
-    

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -6,11 +6,21 @@
 
 #pragma once
 
+#include <pybind11/pybind11.h> // pybind11.h must be the first include - https://pybind11.readthedocs.io/en/latest/basics.html#header-and-namespace-conventions
+
 #include <Windows.h>
 #include <string>
 #include <sql.h>
 #include <sqlext.h>
 #include <memory>
+
+#include <pybind11/chrono.h>
+#include <pybind11/complex.h>
+#include <pybind11/functional.h>
+#include <pybind11/pytypes.h>  // Add this line for datetime support
+#include <pybind11/stl.h>
+namespace py = pybind11;
+using namespace pybind11::literals;
 
 //-------------------------------------------------------------------------------------------------
 // Function pointer typedefs

--- a/tests/test_005_exceptions.py
+++ b/tests/test_005_exceptions.py
@@ -124,7 +124,7 @@ def test_foreign_key_constraint_error(cursor, db_connection):
         drop_table_if_exists(cursor, "pytest_parent_table")
         db_connection.commit()
 
-def test_connection_error(db_connection):
-    with pytest.raises(OperationalError) as excinfo:
-        Connection("InvalidConnectionString")
-    assert "Client unable to establish connection" in str(excinfo.value)
+# def test_connection_error(db_connection):
+#     with pytest.raises(OperationalError) as excinfo:
+#         Connection("InvalidConnectionString")
+#     assert "Client unable to establish connection" in str(excinfo.value)

--- a/tests/test_005_exceptions.py
+++ b/tests/test_005_exceptions.py
@@ -124,7 +124,7 @@ def test_foreign_key_constraint_error(cursor, db_connection):
         drop_table_if_exists(cursor, "pytest_parent_table")
         db_connection.commit()
 
-# def test_connection_error(db_connection):
-#     with pytest.raises(OperationalError) as excinfo:
-#         Connection("InvalidConnectionString")
-#     assert "Client unable to establish connection" in str(excinfo.value)
+def test_connection_error(db_connection):
+    with pytest.raises(RuntimeError) as excinfo:
+        Connection("InvalidConnectionString")
+    assert "Neither DSN nor SERVER keyword supplied" in str(excinfo.value)


### PR DESCRIPTION
This pull request makes the database connection and cursor handling in the `mssql_python` module via new C++ `Connection` class and simplifying the Python-side implementation. The changes include replacing low-level connection management with a higher-level abstraction, removing redundant methods, and delegating key operations to the new C++ backend. Below are the most important changes grouped by theme:

### Refactoring Python Connection Management
* Replaced manual handle allocation (`henv`, `hdbc`) and initialization in `mssql_python/connection.py` with a new `Connection` class from the C++ backend. The `_initializer`, `_allocate_environment_handle`, `_allocate_connection_handle`, and related methods were removed. 
* Simplified transaction methods (`commit`, `rollback`) and connection lifecycle methods (`close`) by delegating their logic to the C++ `Connection` class.
* Updated autocommit handling to use the `set_autocommit` and `get_autocommit` methods from the C++ `Connection` class. 
### Refactoring Python Cursor Management
* Removed checks for closed connections in `mssql_python/cursor.py` and delegated statement handle allocation to the C++ `Connection` class. 
* Simplified cursor cleanup by removing explicit handle freeing logic. 

### Integration with Python Bindings
* Updated `ddbc_bindings.cpp` to include the new `Connection` class, enabling its use in the Python layer. 

-------------------------------------------------------------------
### Checklist  
- [ ] **Tests Passed** (if applicable) : Pytests need to be fixed with connection logic in C++.