### PR TITLE
FEAT: BCP Python APIs

### DIFF
--- a/mssql_python/bcp_main.py
+++ b/mssql_python/bcp_main.py
@@ -1,0 +1,177 @@
+import logging # Add this import
+from mssql_python.bcp_options import (
+    BCPOptions,
+)  # BCPOptions now handles more validation
+from ddbc_bindings import BCPWrapper
+from mssql_python.constants import BCPControlOptions
+
+logger = logging.getLogger(__name__) # Add a logger instance
+
+class BCPClient:
+    """
+    A client for performing bulk copy operations using the BCP (Bulk Copy Program) utility.
+    This class provides methods to initialize and execute BCP operations.
+    """
+
+    def __init__(self, connection):
+        """
+        Initializes the BCPClient with a database connection.
+        Args:
+            connection: A database connection object that will be used by BCPWrapper.
+        """
+        logger.info("Initializing BCPClient.")
+        if connection is None:
+            logger.error("Connection object is None during BCPClient initialization.")
+            raise ValueError(
+                "A valid connection object is required to initialize BCPClient."
+            )
+        self.wrapper = BCPWrapper(connection)
+        logger.info("BCPClient initialized successfully.")
+
+    def run_bcp(self, table: str, options: BCPOptions):  # options is no longer Optional
+        """
+        Executes a bulk copy operation to or from a specified table or using a query.
+
+        Args:
+            table (str): The name of the table (for 'in', 'out', 'format') or the query string (for 'queryout').
+            options (BCPOptions): Configuration for the bulk copy operation. Must be provided.
+                                  The options.direction field dictates the BCP operation.
+        Raises:
+            ValueError: If 'table' is not provided, or if 'options' are invalid
+                        or use a direction not supported by this client.
+            TypeError: If 'options' is not an instance of BCPOptions.
+            RuntimeError: If the BCPWrapper was not initialized.
+        """
+        logger.info(f"Starting run_bcp for table/query: '{table}', direction: '{options.direction}'.")
+        if not table:
+            logger.error("Validation failed: 'table' (or query) not provided for run_bcp.")
+            raise ValueError(
+                "The 'table' name (or query for queryout) must be provided."
+            )
+
+        if not isinstance(options, BCPOptions):
+            logger.error(f"Validation failed: 'options' is not an instance of BCPOptions. Got type: {type(options)}.")
+            # This check is good practice, though type hints help statically.
+            raise TypeError("The 'options' argument must be an instance of BCPOptions.")
+
+        # BCPOptions.__post_init__ has already performed its internal validation.
+        # BCPClient can add its own operational constraints:
+        if options.direction not in BCPControlOptions.SUPPORTED_DIRECTIONS.values():
+            logger.error(f"Validation failed: Unsupported BCP direction '{options.direction}'. Supported: {BCPControlOptions.SUPPORTED_DIRECTIONS.values()}")
+            raise ValueError(
+                f"BCPClient currently only supports directions: {', '.join(BCPControlOptions.SUPPORTED_DIRECTIONS.values())}. "
+                f"Got '{options.direction}'."
+            )
+
+        current_options = options  # Use the validated options directly
+        logger.debug(f"Using BCPOptions: {current_options}")
+
+        if not self.wrapper:  # Should be caught by __init__ ideally
+            logger.error("BCPWrapper was not initialized before calling run_bcp.")
+            raise RuntimeError("BCPWrapper was not initialized.")
+
+        try:
+            logger.info(
+                f"Initializing BCP operation: table='{table}', data_file='{current_options.data_file}', "
+                f"error_file='{current_options.error_file}', direction='{current_options.direction}'"
+            )
+            # 'table' here is used as szTable for bcp_init, which can be a table name or view.
+            # For 'queryout', the C++ wrapper would need to handle 'table' as the query string
+            # if bcp_init is used, or use bcp_queryout directly if that's the chosen C++ API.
+            # Assuming bcp_initialize_operation is flexible or maps to bcp_init.
+            self.wrapper.bcp_initialize_operation(
+                table,
+                current_options.data_file,
+                current_options.error_file,
+                current_options.direction,
+            )
+            logger.debug("BCP operation initialized with BCPWrapper.")
+
+            # Set BCP control options
+            if current_options.batch_size is not None:
+                logger.debug(f"Setting BCPControlOptions.BATCH_SIZE to {current_options.batch_size}")
+                self.wrapper.bcp_control(
+                    BCPControlOptions.BATCH_SIZE.value, current_options.batch_size
+                )
+            if current_options.max_errors is not None:
+                logger.debug(f"Setting BCPControlOptions.MAX_ERRORS to {current_options.max_errors}")
+                self.wrapper.bcp_control(
+                    BCPControlOptions.MAX_ERRORS.value, current_options.max_errors
+                )
+            if current_options.first_row is not None:
+                logger.debug(f"Setting BCPControlOptions.FIRST_ROW to {current_options.first_row}")
+                self.wrapper.bcp_control(
+                    BCPControlOptions.FIRST_ROW.value, current_options.first_row
+                )
+            if current_options.last_row is not None:
+                logger.debug(f"Setting BCPControlOptions.LAST_ROW to {current_options.last_row}")
+                self.wrapper.bcp_control(
+                    BCPControlOptions.LAST_ROW.value, current_options.last_row
+                )
+            if current_options.code_page is not None:
+                logger.debug(f"Setting BCPControlOptions.FILE_CODE_PAGE to {current_options.code_page}")
+                self.wrapper.bcp_control(
+                    BCPControlOptions.FILE_CODE_PAGE.value, current_options.code_page
+                )
+            if current_options.keep_identity:
+                logger.debug("Setting BCPControlOptions.KEEP_IDENTITY to 1")
+                self.wrapper.bcp_control(BCPControlOptions.KEEP_IDENTITY.value, 1)
+            if current_options.keep_nulls:
+                logger.debug("Setting BCPControlOptions.KEEP_NULLS to 1")
+                self.wrapper.bcp_control(BCPControlOptions.KEEP_NULLS.value, 1)
+            if current_options.hints:
+                logger.debug(f"Setting BCPControlOptions.HINTS to '{current_options.hints}'")
+                self.wrapper.bcp_control(
+                    BCPControlOptions.HINTS.value, current_options.hints
+                )
+            if (
+                current_options.columns
+                and current_options.columns[0].row_terminator is not None
+            ):  # Check if columns list is not empty
+                logger.debug(f"Setting BCPControlOptions.SET_ROW_TERMINATOR to '{current_options.columns[0].row_terminator}'")
+                self.wrapper.bcp_control(
+                    BCPControlOptions.SET_ROW_TERMINATOR.value,
+                    current_options.columns[0].row_terminator,
+                )
+
+            if current_options.bulk_mode:
+                logger.debug(f"Setting bulk mode to '{current_options.bulk_mode}'")
+                self.wrapper.set_bulk_mode(current_options.bulk_mode)
+
+            # Handle format file or column definitions
+            if current_options.format_file:
+                logger.info(f"Reading format file: '{current_options.format_file}'")
+                # This implies direction is "format" or "in"/"out" with a format file
+                self.wrapper.read_format_file(current_options.format_file)
+            elif current_options.columns:  # Check if columns list is not empty
+                logger.info(f"Defining {len(current_options.columns)} columns programmatically.")
+                self.wrapper.define_columns(len(current_options.columns))
+                for i, col_format_obj in enumerate(current_options.columns):
+                    logger.debug(f"Defining column {i+1}: {col_format_obj}")
+                    self.wrapper.define_column_format(
+                        col_num_ordinal=i + 1,
+                        prefix_len=col_format_obj.prefix_len,
+                        data_len=col_format_obj.data_len,
+                        terminator_wstr=col_format_obj.field_terminator,
+                        col_name=col_format_obj.col_name,
+                        server_col=col_format_obj.server_col,
+                        file_col=col_format_obj.file_col,
+                    )
+            else:
+                logger.info("No format file or explicit column definitions provided. Relying on BCP defaults or server types.")
+
+
+            logger.info("Executing BCP operation via wrapper.exec_bcp().")
+            self.wrapper.exec_bcp()
+            logger.info("BCP operation executed successfully.")
+
+        except Exception as e:
+            logger.exception(f"An error occurred during BCP operation for table '{table}': {e}")
+            raise # Re-raise the exception after logging
+        finally:
+            if self.wrapper:
+                logger.info("Finishing and closing BCPWrapper.")
+                self.wrapper.finish()
+                self.wrapper.close()
+                logger.debug("BCPWrapper finished and closed.")
+            logger.info(f"run_bcp for table/query: '{table}' completed.")

--- a/mssql_python/constants.py
+++ b/mssql_python/constants.py
@@ -118,3 +118,21 @@ class ConstantsDDBC(Enum):
     SQL_MAX_NUMERIC_LEN = 16
     SQL_IS_POINTER = -4
     SQL_COPT_SS_ACCESS_TOKEN = 1256
+
+class BCPControlOptions(Enum):
+    """
+    Constants for BCP control options.
+    The values are the string representations expected by the BCP API.
+    """
+    BATCH_SIZE = "BCPBATCH"
+    MAX_ERRORS = "BCPMAXERRS"
+    FIRST_ROW = "BCPFIRST"
+    LAST_ROW = "BCPLAST"
+    FILE_CODE_PAGE = "BCPFILECP"
+    KEEP_IDENTITY = "BCPKEEPIDENTITY"
+    KEEP_NULLS = "BCPKEEPNULLS"
+    HINTS = "BCPHINTS"
+    SET_ROW_TERMINATOR = "BCPSETROWTERM"
+    ALLOWED_DIRECTIONS = ("in", "out", "format", "query")
+    ALLOWED_FILE_MODES = ("native", "char", "unicode")
+    SUPPORTED_DIRECTIONS = ("in", "out")


### PR DESCRIPTION
This pull request introduces significant enhancements to the bulk copy functionality in the `mssql_python` package, including the addition of a new `BCPClient` class, improved validation logic in `BCPOptions`, and the introduction of `BCPControlOptions` for managing BCP control settings. These changes aim to provide better error handling, flexibility, and usability for bulk copy operations.

### New Features and Enhancements:

#### Bulk Copy Client:
* Added `BCPClient` class in `mssql_python/bcp_main.py` to encapsulate bulk copy operations. It includes robust logging, validation, and integration with `BCPWrapper` for executing BCP operations.

#### Validation Improvements:
* Enhanced validation logic in `BCPOptions` to ensure correctness of parameters, including stricter checks for `direction`, `data_file`, `error_file`, and other attributes. Added support for new options such as `bulk_mode`, `hints`, and `code_page`.

#### Constants for BCP Control:
* Introduced `BCPControlOptions` in `mssql_python/constants.py`, providing a centralized enum for BCP control settings like batch size, max errors, and row terminators. This improves clarity and reduces hardcoding of control options.

### Code Refinements:

#### Default Values:
* Updated `ColumnFormat` attributes (`prefix_len` and `data_len`) to have default values of `0`, and added a new optional `col_name` attribute for column definitions.

#### Type Adjustments:
* Replaced `Literal` types with `str` and `Union` in `BCPOptions` to improve flexibility and compatibility with dynamically validated values. 