### PR TITLE
FIX: minor cleanup, adding LOG statement instead of print

### DIFF
--- a/mssql_python/pybind/connection/connection_pool.cpp
+++ b/mssql_python/pybind/connection/connection_pool.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<Connection> ConnectionPool::acquire(const std::wstring& connStr,
         try {
             conn->disconnect();
         } catch (const std::exception& ex) {
-            std::cout << "disconnect() failed: " << ex.what() << std::endl;
+            LOG("Disconnect bad/expired connections failed: {}", ex.what());
         }
     }
     return valid_conn;


### PR DESCRIPTION
This pull request updates the logging mechanism in the `ConnectionPool::acquire` method to improve error reporting when disconnecting bad or expired connections.

* [`mssql_python/pybind/connection/connection_pool.cpp`](diffhunk://#diff-35a698bc3405cc30c1bf656066bd0575302239b5e39083a8160a6202026ca360L69-R69): Replaced `std::cout` logging with a `LOG` function for better consistency and integration with the logging system.