### PR TITLE
FIX: Fixing Level 3 and level 4 compiler warnings.

### DIFF
--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -27,7 +27,7 @@ static SqlHandlePtr getEnvHandle() {
         if (!SQL_SUCCEEDED(ret)) {
             ThrowStdException("Failed to set environment attributes");
         }
-        return std::make_shared<SqlHandle>(SQL_HANDLE_ENV, env);
+        return std::make_shared<SqlHandle>(static_cast<SQLSMALLINT>(SQL_HANDLE_ENV), env);
     }();
 
     return envHandle;
@@ -54,7 +54,7 @@ void Connection::allocateDbcHandle() {
     LOG("Allocate SQL Connection Handle");
     SQLRETURN ret = SQLAllocHandle_ptr(SQL_HANDLE_DBC, _envHandle->get(), &dbc);
     checkError(ret);
-    _dbcHandle = std::make_shared<SqlHandle>(SQL_HANDLE_DBC, dbc);
+    _dbcHandle = std::make_shared<SqlHandle>(static_cast<SQLSMALLINT>(SQL_HANDLE_DBC), dbc);
 }
 
 void Connection::connect(const py::dict& attrs_before) {
@@ -148,7 +148,7 @@ SqlHandlePtr Connection::allocStatementHandle() {
     SQLHANDLE stmt = nullptr;
     SQLRETURN ret = SQLAllocHandle_ptr(SQL_HANDLE_STMT, _dbcHandle->get(), &stmt);
     checkError(ret);
-    return std::make_shared<SqlHandle>(SQL_HANDLE_STMT, stmt);
+    return std::make_shared<SqlHandle>(static_cast<SQLSMALLINT>(SQL_HANDLE_STMT), stmt);
 }
 
 
@@ -214,7 +214,6 @@ bool Connection::reset() {
         ThrowStdException("Connection handle not allocated");
     }
     LOG("Resetting connection via SQL_ATTR_RESET_CONNECTION");
-    SQLULEN reset = SQL_TRUE;
     SQLRETURN ret = SQLSetConnectAttr_ptr(
         _dbcHandle->get(),
         SQL_ATTR_RESET_CONNECTION,

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -91,7 +91,7 @@ void Connection::disconnect() {
 void Connection::checkError(SQLRETURN ret) const{
     if (!SQL_SUCCEEDED(ret)) {
         ErrorInfo err = SQLCheckError_Wrap(SQL_HANDLE_DBC, _dbcHandle, ret);
-        std::string errorMsg = std::string(err.ddbcErrorMsg.begin(), err.ddbcErrorMsg.end());
+        std::string errorMsg = WideToUTF8(err.ddbcErrorMsg);
         ThrowStdException(errorMsg);
     }
 }
@@ -122,7 +122,7 @@ void Connection::setAutocommit(bool enable) {
     }
     SQLINTEGER value = enable ? SQL_AUTOCOMMIT_ON : SQL_AUTOCOMMIT_OFF;
     LOG("Set SQL Connection Attribute");
-    SQLRETURN ret = SQLSetConnectAttr_ptr(_dbcHandle->get(), SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)value, 0);
+    SQLRETURN ret = SQLSetConnectAttr_ptr(_dbcHandle->get(), SQL_ATTR_AUTOCOMMIT, reinterpret_cast<SQLPOINTER>(static_cast<SQLULEN>(value)), 0);
     checkError(ret);
     _autocommit = enable;
 }

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -177,3 +177,5 @@ struct ErrorInfo {
     std::wstring ddbcErrorMsg;
 };
 ErrorInfo SQLCheckError_Wrap(SQLSMALLINT handleType, SqlHandlePtr handle, SQLRETURN retcode);
+
+std::string WideToUTF8(const std::wstring& wstr);


### PR DESCRIPTION
[AB#37476](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/37476)
This pull request focuses on improving type safety, enhancing error handling, and adding utility functions in the `mssql_python/pybind` module. The changes primarily involve the use of explicit type casting, the introduction of a `WideToUTF8` utility function for string conversion, and minor fixes to improve code clarity and correctness.

### Type Safety Improvements:
* Updated `std::make_shared<SqlHandle>` calls across multiple functions in `connection.cpp` to use `static_cast<SQLSMALLINT>` for handle types (`SQL_HANDLE_ENV`, `SQL_HANDLE_DBC`, `SQL_HANDLE_STMT`) to ensure explicit type casting. [[1]](diffhunk://#diff-eca696c13d997f510e5f9b16288ed1deb0ad132768c283eda1518f78edf9b6ecL30-R30) [[2]](diffhunk://#diff-eca696c13d997f510e5f9b16288ed1deb0ad132768c283eda1518f78edf9b6ecL57-R57) [[3]](diffhunk://#diff-eca696c13d997f510e5f9b16288ed1deb0ad132768c283eda1518f78edf9b6ecL151-R151)
* Added explicit type casting for SQL date, time, and timestamp fields in `BindParameters` to use `SQLSMALLINT` or `SQLUSMALLINT` instead of `int`. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L323-R325) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L336-R338) [[3]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L349-R354)
* Updated various `SQLSetStmtAttr_ptr` and `SQLSetConnectAttr_ptr` calls to use `reinterpret_cast` or `static_cast` for pointer conversions, ensuring type correctness. [[1]](diffhunk://#diff-eca696c13d997f510e5f9b16288ed1deb0ad132768c283eda1518f78edf9b6ecL125-R125) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L1705-R1714) [[3]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L1793-R1802)

### Error Handling Enhancements:
* Replaced manual wide-to-narrow string conversion in `LoadDriverOrThrowException` with the new `WideToUTF8` utility function for better readability and consistency.
* Introduced the `WideToUTF8` function in `ddbc_bindings.cpp` and declared it in `ddbc_bindings.h` to handle `std::wstring` to `std::string` conversions. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R475-R482) [[2]](diffhunk://#diff-85167a2d59779df18704284ab7ce46220c3619408fbf22c631ffdf29f794d635R180-R181)
* Enhanced error message handling in `Connection::checkError` by using `WideToUTF8` for converting wide error messages to UTF-8.

### Code Fixes and Cleanup:
* Fixed a typo in `std::memset` in `BindParameters` to correct the namespace usage.
* Corrected redundant semicolon in `SQLGetData_wrap` initialization.
* Improved comparison logic in `SQLGetData_wrap` and `FetchBatchData` to use `static_cast<size_t>` for comparing `dataLen` with `columnSize`. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L1140-R1149) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L1554-R1563)

These changes collectively enhance the robustness, maintainability, and readability of the code.

### Checklist  
- [ ] **Tests Passed** (if applicable)  : All pytests passed.