### PR TITLE
FIX: Python library linking - not using 3.13.4

### DIFF
--- a/eng/pipelines/build-whl-pipeline.yml
+++ b/eng/pipelines/build-whl-pipeline.yml
@@ -50,12 +50,12 @@ jobs:
 
       # Python 3.13
       py313_x64:
-        pythonVersion: '3.13.3'
+        pythonVersion: '3.13.5'
         shortPyVer: '313'
         architecture: 'x64'
         targetArch: 'x64'
       py313_arm64:
-        pythonVersion: '3.13.3'
+        pythonVersion: '3.13.5'
         shortPyVer: '313'
         architecture: 'x64'
         targetArch: 'arm64'

--- a/eng/pipelines/build-whl-pipeline.yml
+++ b/eng/pipelines/build-whl-pipeline.yml
@@ -50,12 +50,12 @@ jobs:
 
       # Python 3.13
       py313_x64:
-        pythonVersion: '3.13'
+        pythonVersion: '3.13.3'
         shortPyVer: '313'
         architecture: 'x64'
         targetArch: 'x64'
       py313_arm64:
-        pythonVersion: '3.13'
+        pythonVersion: '3.13.3'
         shortPyVer: '313'
         architecture: 'x64'
         targetArch: 'arm64'

--- a/eng/pipelines/pr-validation-pipeline.yml
+++ b/eng/pipelines/pr-validation-pipeline.yml
@@ -14,10 +14,11 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      # TODO: Update to latest Python version.
-      # For now, we use Python 3.13.3 since 3.13.4 has issues with compilation.
+      # TODO: Remove this once Python 3.13 is available in ADO
+      # ADO indexing will take some time to reflect 3.13 as 3.13.5, right now it is pointing to 3.13.4.
+      # We're specifying to use Python 3.13.5 since 3.13.4 has issues with compilation
       # See https://github.com/python/cpython/issues/135151, next release should fix it.
-      versionSpec: '3.13.3'
+      versionSpec: '3.13.5'
       addToPath: true
       githubToken: $(GITHUB_TOKEN)
     displayName: 'Use Python 3.13'

--- a/eng/pipelines/pr-validation-pipeline.yml
+++ b/eng/pipelines/pr-validation-pipeline.yml
@@ -14,7 +14,10 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.13'
+      # TODO: Update to latest Python version.
+      # For now, we use Python 3.13.3 since 3.13.4 has issues with compilation.
+      # See https://github.com/python/cpython/issues/135151, next release should fix it.
+      versionSpec: '3.13.3'
       addToPath: true
       githubToken: $(GITHUB_TOKEN)
     displayName: 'Use Python 3.13'


### PR DESCRIPTION
### Summary  
This pull request updates the Python version used in the build and validation pipelines to address a known issue with Python 3.13.4 and ensure compatibility with Python 3.13.5. The changes include adjustments to the version specifications and relevant comments for clarity.

Pipeline updates:

* [`eng/pipelines/build-whl-pipeline.yml`](diffhunk://#diff-a871d64acfb78366b4b077045db53551c2df7d622854569f5f6780ad2ec6f911L53-R58): Updated the `pythonVersion` for `py313_x64` and `py313_arm64` jobs from `3.13` to `3.13.5` to ensure the use of the latest compatible version.
* [`eng/pipelines/pr-validation-pipeline.yml`](diffhunk://#diff-296c8f902bbd70f34ee1c8c32383c8c99165fe4c8e5b0f234f8f22246e56a621L17-R21): Updated the `versionSpec` in the `UsePythonVersion` task to `3.13.5` and added a comment explaining the temporary workaround due to ADO indexing delays and known issues with Python 3.13.4.

### Issue Reference  
Fixes [AB#37710](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/37710) 

### Checklist  
- [x] **Tests Passed** (if applicable)  
- [x] **Code is formatted**   
- [x] **Docs Updated** (if necessary) 

### Testing Performed  
<!-- How was this fix tested? -->
- [x] Unit Tests
- [x] Manual Testing  
  - [x] Python Version: `3.13.3`
  - [x] OS: `Windows`   
