### PR TITLE
FEAT: Enforce Level 3 and 4 warnings as errors to adhere to compliance standards.

### DIFF
--- a/mssql_python/pybind/CMakeLists.txt
+++ b/mssql_python/pybind/CMakeLists.txt
@@ -286,6 +286,11 @@ target_compile_definitions(ddbc_bindings PRIVATE
     NOMINMAX
 )
 
+# Add warning level flags for MSVC
+if(MSVC)
+    target_compile_options(ddbc_bindings PRIVATE /W4 /WX)
+endif()
+
 # Add macOS-specific string conversion fix
 if(APPLE)
     message(STATUS "Enabling macOS string conversion fix")


### PR DESCRIPTION
This pull request introduces a platform-specific enhancement to the build configuration for `ddbc_bindings` in the `CMakeLists.txt` file. It adds stricter warning level flags for MSVC to improve code quality.

Build configuration improvement:

* [`mssql_python/pybind/CMakeLists.txt`](diffhunk://#diff-dbb5892fbbb28149d1639664797cf3adb48ced28ec11aba95f2e2b338ca46badR289-R294): Added a conditional block to apply `/W4` (warning level 4) and `/WX` (treat warnings as errors) compiler flags when building with MSVC. This ensures stricter code quality checks for Windows builds.