### PR TITLE
REFACTOR: Change pytests to use temp tables (starting with #)

### DIFF
--- a/tests/test_003_connection.py
+++ b/tests/test_003_connection.py
@@ -77,41 +77,41 @@ def test_autocommit_setter(db_connection):
     db_connection.autocommit = True
     cursor = db_connection.cursor()
     # Make a transaction and check if it is autocommited
-    drop_table_if_exists(cursor, "pytest_test_autocommit")
+    drop_table_if_exists(cursor, "#pytest_test_autocommit")
     try:
-        cursor.execute("CREATE TABLE pytest_test_autocommit (id INT PRIMARY KEY, value VARCHAR(50));")
-        cursor.execute("INSERT INTO pytest_test_autocommit (id, value) VALUES (1, 'test');")
-        cursor.execute("SELECT * FROM pytest_test_autocommit WHERE id = 1;")
+        cursor.execute("CREATE TABLE #pytest_test_autocommit (id INT PRIMARY KEY, value VARCHAR(50));")
+        cursor.execute("INSERT INTO #pytest_test_autocommit (id, value) VALUES (1, 'test');")
+        cursor.execute("SELECT * FROM #pytest_test_autocommit WHERE id = 1;")
         result = cursor.fetchone()
         assert result is not None, "Autocommit failed: No data found"
         assert result[1] == 'test', "Autocommit failed: Incorrect data"
     except Exception as e:
         pytest.fail(f"Autocommit failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_test_autocommit;")
+        cursor.execute("DROP TABLE #pytest_test_autocommit;")
         db_connection.commit()
     assert db_connection.autocommit is True, "Autocommit should be True"
     
     db_connection.autocommit = False
     cursor = db_connection.cursor()
     # Make a transaction and check if it is not autocommited
-    drop_table_if_exists(cursor, "pytest_test_autocommit")
+    drop_table_if_exists(cursor, "#pytest_test_autocommit")
     try:
-        cursor.execute("CREATE TABLE pytest_test_autocommit (id INT PRIMARY KEY, value VARCHAR(50));")
-        cursor.execute("INSERT INTO pytest_test_autocommit (id, value) VALUES (1, 'test');")
-        cursor.execute("SELECT * FROM pytest_test_autocommit WHERE id = 1;")
+        cursor.execute("CREATE TABLE #pytest_test_autocommit (id INT PRIMARY KEY, value VARCHAR(50));")
+        cursor.execute("INSERT INTO #pytest_test_autocommit (id, value) VALUES (1, 'test');")
+        cursor.execute("SELECT * FROM #pytest_test_autocommit WHERE id = 1;")
         result = cursor.fetchone()
         assert result is not None, "Autocommit failed: No data found"
         assert result[1] == 'test', "Autocommit failed: Incorrect data"
         db_connection.commit()
-        cursor.execute("SELECT * FROM pytest_test_autocommit WHERE id = 1;")
+        cursor.execute("SELECT * FROM #pytest_test_autocommit WHERE id = 1;")
         result = cursor.fetchone()
         assert result is not None, "Autocommit failed: No data found after commit"
         assert result[1] == 'test', "Autocommit failed: Incorrect data after commit"
     except Exception as e:
         pytest.fail(f"Autocommit failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_test_autocommit;")
+        cursor.execute("DROP TABLE #pytest_test_autocommit;")
         db_connection.commit()
     
 def test_set_autocommit(db_connection):
@@ -123,49 +123,49 @@ def test_set_autocommit(db_connection):
 def test_commit(db_connection):
     # Make a transaction and commit
     cursor = db_connection.cursor()
-    drop_table_if_exists(cursor, "pytest_test_commit")
+    drop_table_if_exists(cursor, "#pytest_test_commit")
     try:
-        cursor.execute("CREATE TABLE pytest_test_commit (id INT PRIMARY KEY, value VARCHAR(50));")
-        cursor.execute("INSERT INTO pytest_test_commit (id, value) VALUES (1, 'test');")
+        cursor.execute("CREATE TABLE #pytest_test_commit (id INT PRIMARY KEY, value VARCHAR(50));")
+        cursor.execute("INSERT INTO #pytest_test_commit (id, value) VALUES (1, 'test');")
         db_connection.commit()
-        cursor.execute("SELECT * FROM pytest_test_commit WHERE id = 1;")
+        cursor.execute("SELECT * FROM #pytest_test_commit WHERE id = 1;")
         result = cursor.fetchone()
         assert result is not None, "Commit failed: No data found"
         assert result[1] == 'test', "Commit failed: Incorrect data"
     except Exception as e:
         pytest.fail(f"Commit failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_test_commit;")
+        cursor.execute("DROP TABLE #pytest_test_commit;")
         db_connection.commit()
 
 def test_rollback(db_connection):
     # Make a transaction and rollback
     cursor = db_connection.cursor()
-    drop_table_if_exists(cursor, "pytest_test_rollback")
+    drop_table_if_exists(cursor, "#pytest_test_rollback")
     try:
         # Create a table and insert data
-        cursor.execute("CREATE TABLE pytest_test_rollback (id INT PRIMARY KEY, value VARCHAR(50));")
-        cursor.execute("INSERT INTO pytest_test_rollback (id, value) VALUES (1, 'test');")
+        cursor.execute("CREATE TABLE #pytest_test_rollback (id INT PRIMARY KEY, value VARCHAR(50));")
+        cursor.execute("INSERT INTO #pytest_test_rollback (id, value) VALUES (1, 'test');")
         db_connection.commit()
         
         # Check if the data is present before rollback
-        cursor.execute("SELECT * FROM pytest_test_rollback WHERE id = 1;")
+        cursor.execute("SELECT * FROM #pytest_test_rollback WHERE id = 1;")
         result = cursor.fetchone()
         assert result is not None, "Rollback failed: No data found before rollback"
         assert result[1] == 'test', "Rollback failed: Incorrect data"
 
         # Insert data and rollback
-        cursor.execute("INSERT INTO pytest_test_rollback (id, value) VALUES (2, 'test');")
+        cursor.execute("INSERT INTO #pytest_test_rollback (id, value) VALUES (2, 'test');")
         db_connection.rollback()
         
         # Check if the data is not present after rollback
-        cursor.execute("SELECT * FROM pytest_test_rollback WHERE id = 2;")
+        cursor.execute("SELECT * FROM #pytest_test_rollback WHERE id = 2;")
         result = cursor.fetchone()
         assert result is None, "Rollback failed: Data found after rollback"
     except Exception as e:
         pytest.fail(f"Rollback failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_test_rollback;")
+        cursor.execute("DROP TABLE #pytest_test_rollback;")
         db_connection.commit()
 
 def test_invalid_connection_string():

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -118,75 +118,75 @@ def test_insert_nvarchar_column(cursor, db_connection):
 def test_insert_time_column(cursor, db_connection):
     """Test inserting data into the time_column"""
     try:
-        drop_table_if_exists(cursor, "single_column")
-        cursor.execute("CREATE TABLE single_column (time_column TIME)")
+        drop_table_if_exists(cursor, "#pytest_single_column")
+        cursor.execute("CREATE TABLE #pytest_single_column (time_column TIME)")
         db_connection.commit()
-        cursor.execute("INSERT INTO single_column (time_column) VALUES (?)", [time(12, 34, 56)])
+        cursor.execute("INSERT INTO #pytest_single_column (time_column) VALUES (?)", [time(12, 34, 56)])
         db_connection.commit()
-        cursor.execute("SELECT time_column FROM single_column")
+        cursor.execute("SELECT time_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == time(12, 34, 56), "Time column insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"Time column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 def test_insert_datetime_column(cursor, db_connection):
     """Test inserting data into the datetime_column"""
     try:
-        drop_table_if_exists(cursor, "single_column")
-        cursor.execute("CREATE TABLE single_column (datetime_column DATETIME)")
+        drop_table_if_exists(cursor, "#pytest_single_column")
+        cursor.execute("CREATE TABLE #pytest_single_column (datetime_column DATETIME)")
         db_connection.commit()
-        cursor.execute("INSERT INTO single_column (datetime_column) VALUES (?)", [datetime(2024, 5, 20, 12, 34, 56, 123000)])
+        cursor.execute("INSERT INTO #pytest_single_column (datetime_column) VALUES (?)", [datetime(2024, 5, 20, 12, 34, 56, 123000)])
         db_connection.commit()
-        cursor.execute("SELECT datetime_column FROM single_column")
+        cursor.execute("SELECT datetime_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == datetime(2024, 5, 20, 12, 34, 56, 123000), "Datetime column insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"Datetime column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 def test_insert_datetime2_column(cursor, db_connection):
-    """Test inserting data into the datetime_column"""
+    """Test inserting data into the datetime2_column"""
     try:
-        drop_table_if_exists(cursor, "single_column")
-        cursor.execute("CREATE TABLE single_column (datetime2_column DATETIME2)")
+        drop_table_if_exists(cursor, "#pytest_single_column")
+        cursor.execute("CREATE TABLE #pytest_single_column (datetime2_column DATETIME2)")
         db_connection.commit()
-        cursor.execute("INSERT INTO single_column (datetime2_column) VALUES (?)", [datetime(2024, 5, 20, 12, 34, 56, 123456)])
+        cursor.execute("INSERT INTO #pytest_single_column (datetime2_column) VALUES (?)", [datetime(2024, 5, 20, 12, 34, 56, 123456)])
         db_connection.commit()
-        cursor.execute("SELECT datetime2_column FROM single_column")
+        cursor.execute("SELECT datetime2_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == datetime(2024, 5, 20, 12, 34, 56, 123456), "Datetime2 column insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"Datetime2 column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 def test_insert_smalldatetime_column(cursor, db_connection):
-    """Test inserting data into the datetime_column"""
+    """Test inserting data into the smalldatetime_column"""
     try:
-        drop_table_if_exists(cursor, "single_column")
-        cursor.execute("CREATE TABLE single_column (smalldatetime_column SMALLDATETIME)")
+        drop_table_if_exists(cursor, "#pytest_single_column")
+        cursor.execute("CREATE TABLE #pytest_single_column (smalldatetime_column SMALLDATETIME)")
         db_connection.commit()
-        cursor.execute("INSERT INTO single_column (smalldatetime_column) VALUES (?)", [datetime(2024, 5, 20, 12, 34)])
+        cursor.execute("INSERT INTO #pytest_single_column (smalldatetime_column) VALUES (?)", [datetime(2024, 5, 20, 12, 34)])
         db_connection.commit()
-        cursor.execute("SELECT smalldatetime_column FROM single_column")
+        cursor.execute("SELECT smalldatetime_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == datetime(2024, 5, 20, 12, 34), "Smalldatetime column insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"Smalldatetime column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 def test_insert_date_column(cursor, db_connection):
     """Test inserting data into the date_column"""
     try:
-        drop_table_if_exists(cursor, "single_column")
+        drop_table_if_exists(cursor, "#pytest_single_column")
         cursor.execute("CREATE TABLE #pytest_single_column (date_column DATE)")
         db_connection.commit()
         cursor.execute("INSERT INTO #pytest_single_column (date_column) VALUES (?)", [date(2024, 5, 20)])
@@ -203,7 +203,7 @@ def test_insert_date_column(cursor, db_connection):
 def test_insert_real_column(cursor, db_connection):
     """Test inserting data into the real_column"""
     try:
-        drop_table_if_exists(cursor, "single_column")
+        drop_table_if_exists(cursor, "#pytest_single_column")
         cursor.execute("CREATE TABLE #pytest_single_column (real_column REAL)")
         db_connection.commit()
         cursor.execute("INSERT INTO #pytest_single_column (real_column) VALUES (?)", [1.23456789])
@@ -220,23 +220,23 @@ def test_insert_real_column(cursor, db_connection):
 def test_insert_decimal_column(cursor, db_connection):
     """Test inserting data into the decimal_column"""
     try:
-        cursor.execute("CREATE TABLE single_column (decimal_column DECIMAL(10, 2))")
+        cursor.execute("CREATE TABLE #pytest_single_column (decimal_column DECIMAL(10, 2))")
         db_connection.commit()
-        cursor.execute("INSERT INTO single_column (decimal_column) VALUES (?)", [decimal.Decimal(123.45).quantize(decimal.Decimal('0.00'))])
+        cursor.execute("INSERT INTO #pytest_single_column (decimal_column) VALUES (?)", [decimal.Decimal(123.45).quantize(decimal.Decimal('0.00'))])
         db_connection.commit()
-        cursor.execute("SELECT decimal_column FROM single_column")
+        cursor.execute("SELECT decimal_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == decimal.Decimal(123.45).quantize(decimal.Decimal('0.00')), "Decimal column insertion/fetch failed"
-        cursor.execute("TRUNCATE TABLE single_column")
-        cursor.execute("INSERT INTO single_column (decimal_column) VALUES (?)", [decimal.Decimal(-123.45).quantize(decimal.Decimal('0.00'))])
+        cursor.execute("TRUNCATE TABLE #pytest_single_column")
+        cursor.execute("INSERT INTO #pytest_single_column (decimal_column) VALUES (?)", [decimal.Decimal(-123.45).quantize(decimal.Decimal('0.00'))])
         db_connection.commit()
-        cursor.execute("SELECT decimal_column FROM single_column")
+        cursor.execute("SELECT decimal_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == decimal.Decimal(-123.45).quantize(decimal.Decimal('0.00')), "Negative Decimal insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"Decimal column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 def test_insert_tinyint_column(cursor, db_connection):

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -15,7 +15,7 @@ from mssql_python import Connection
 
 # Setup test table
 TEST_TABLE = """
-CREATE TABLE pytest_all_data_types (
+CREATE TABLE #pytest_all_data_types (
     id INTEGER PRIMARY KEY,
     bit_column BIT,
     tinyint_column TINYINT,
@@ -69,50 +69,50 @@ def test_cursor(cursor):
 def test_insert_id_column(cursor, db_connection):
     """Test inserting data into the id column"""
     try:
-        drop_table_if_exists(cursor, "pytest_single_column")
-        cursor.execute("CREATE TABLE pytest_single_column (id INTEGER PRIMARY KEY)")
+        drop_table_if_exists(cursor, "#pytest_single_column")
+        cursor.execute("CREATE TABLE #pytest_single_column (id INTEGER PRIMARY KEY)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_single_column (id) VALUES (?)", [1])
+        cursor.execute("INSERT INTO #pytest_single_column (id) VALUES (?)", [1])
         db_connection.commit()
-        cursor.execute("SELECT id FROM pytest_single_column")
+        cursor.execute("SELECT id FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == 1, "ID column insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"ID column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 def test_insert_bit_column(cursor, db_connection):
     """Test inserting data into the bit_column"""
     try:
-        cursor.execute("CREATE TABLE pytest_single_column (bit_column BIT)")
+        cursor.execute("CREATE TABLE #pytest_single_column (bit_column BIT)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_single_column (bit_column) VALUES (?)", [1])
+        cursor.execute("INSERT INTO #pytest_single_column (bit_column) VALUES (?)", [1])
         db_connection.commit()
-        cursor.execute("SELECT bit_column FROM pytest_single_column")
+        cursor.execute("SELECT bit_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == 1, "Bit column insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"Bit column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 def test_insert_nvarchar_column(cursor, db_connection):
     """Test inserting data into the nvarchar_column"""
     try:
-        cursor.execute("CREATE TABLE pytest_single_column (nvarchar_column NVARCHAR(255))")
+        cursor.execute("CREATE TABLE #pytest_single_column (nvarchar_column NVARCHAR(255))")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_single_column (nvarchar_column) VALUES (?)", ["test"])
+        cursor.execute("INSERT INTO #pytest_single_column (nvarchar_column) VALUES (?)", ["test"])
         db_connection.commit()
-        cursor.execute("SELECT nvarchar_column FROM pytest_single_column")
+        cursor.execute("SELECT nvarchar_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == "test", "Nvarchar column insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"Nvarchar column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 def test_insert_time_column(cursor, db_connection):
@@ -187,34 +187,34 @@ def test_insert_date_column(cursor, db_connection):
     """Test inserting data into the date_column"""
     try:
         drop_table_if_exists(cursor, "single_column")
-        cursor.execute("CREATE TABLE pytest_single_column (date_column DATE)")
+        cursor.execute("CREATE TABLE #pytest_single_column (date_column DATE)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_single_column (date_column) VALUES (?)", [date(2024, 5, 20)])
+        cursor.execute("INSERT INTO #pytest_single_column (date_column) VALUES (?)", [date(2024, 5, 20)])
         db_connection.commit()
-        cursor.execute("SELECT date_column FROM pytest_single_column")
+        cursor.execute("SELECT date_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == date(2024, 5, 20), "Date column insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"Date column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 def test_insert_real_column(cursor, db_connection):
     """Test inserting data into the real_column"""
     try:
         drop_table_if_exists(cursor, "single_column")
-        cursor.execute("CREATE TABLE pytest_single_column (real_column REAL)")
+        cursor.execute("CREATE TABLE #pytest_single_column (real_column REAL)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_single_column (real_column) VALUES (?)", [1.23456789])
+        cursor.execute("INSERT INTO #pytest_single_column (real_column) VALUES (?)", [1.23456789])
         db_connection.commit()
-        cursor.execute("SELECT real_column FROM pytest_single_column")
+        cursor.execute("SELECT real_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert abs(row[0] - 1.23456789) < 1e-8, "Real column insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"Real column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 def test_insert_decimal_column(cursor, db_connection):
@@ -242,140 +242,140 @@ def test_insert_decimal_column(cursor, db_connection):
 def test_insert_tinyint_column(cursor, db_connection):
     """Test inserting data into the tinyint_column"""
     try:
-        cursor.execute("CREATE TABLE pytest_single_column (tinyint_column TINYINT)")
+        cursor.execute("CREATE TABLE #pytest_single_column (tinyint_column TINYINT)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_single_column (tinyint_column) VALUES (?)", [127])
+        cursor.execute("INSERT INTO #pytest_single_column (tinyint_column) VALUES (?)", [127])
         db_connection.commit()
-        cursor.execute("SELECT tinyint_column FROM pytest_single_column")
+        cursor.execute("SELECT tinyint_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == 127, "Tinyint column insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"Tinyint column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 def test_insert_smallint_column(cursor, db_connection):
     """Test inserting data into the smallint_column"""
     try:
-        cursor.execute("CREATE TABLE pytest_single_column (smallint_column SMALLINT)")
+        cursor.execute("CREATE TABLE #pytest_single_column (smallint_column SMALLINT)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_single_column (smallint_column) VALUES (?)", [32767])
+        cursor.execute("INSERT INTO #pytest_single_column (smallint_column) VALUES (?)", [32767])
         db_connection.commit()
-        cursor.execute("SELECT smallint_column FROM pytest_single_column")
+        cursor.execute("SELECT smallint_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == 32767, "Smallint column insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"Smallint column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 def test_insert_bigint_column(cursor, db_connection):
     """Test inserting data into the bigint_column"""
     try:
-        cursor.execute("CREATE TABLE pytest_single_column (bigint_column BIGINT)")
+        cursor.execute("CREATE TABLE #pytest_single_column (bigint_column BIGINT)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_single_column (bigint_column) VALUES (?)", [9223372036854775807])
+        cursor.execute("INSERT INTO #pytest_single_column (bigint_column) VALUES (?)", [9223372036854775807])
         db_connection.commit()
-        cursor.execute("SELECT bigint_column FROM pytest_single_column")
+        cursor.execute("SELECT bigint_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == 9223372036854775807, "Bigint column insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"Bigint column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 def test_insert_integer_column(cursor, db_connection):
     """Test inserting data into the integer_column"""
     try:
-        cursor.execute("CREATE TABLE pytest_single_column (integer_column INTEGER)")
+        cursor.execute("CREATE TABLE #pytest_single_column (integer_column INTEGER)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_single_column (integer_column) VALUES (?)", [2147483647])
+        cursor.execute("INSERT INTO #pytest_single_column (integer_column) VALUES (?)", [2147483647])
         db_connection.commit()
-        cursor.execute("SELECT integer_column FROM pytest_single_column")
+        cursor.execute("SELECT integer_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == 2147483647, "Integer column insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"Integer column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 def test_insert_float_column(cursor, db_connection):
     """Test inserting data into the float_column"""
     try:
-        cursor.execute("CREATE TABLE pytest_single_column (float_column FLOAT)")
+        cursor.execute("CREATE TABLE #pytest_single_column (float_column FLOAT)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_single_column (float_column) VALUES (?)", [1.23456789])
+        cursor.execute("INSERT INTO #pytest_single_column (float_column) VALUES (?)", [1.23456789])
         db_connection.commit()
-        cursor.execute("SELECT float_column FROM pytest_single_column")
+        cursor.execute("SELECT float_column FROM #pytest_single_column")
         row = cursor.fetchone()
         assert row[0] == 1.23456789, "Float column insertion/fetch failed"
     except Exception as e:
         pytest.fail(f"Float column insertion/fetch failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_single_column")
+        cursor.execute("DROP TABLE #pytest_single_column")
         db_connection.commit()
 
 # Test that VARCHAR(n) can accomodate values of size n
 def test_varchar_full_capacity(cursor, db_connection):
     """Test SQL_VARCHAR"""
     try:
-        cursor.execute("CREATE TABLE pytest_varchar_test (varchar_column VARCHAR(9))")
+        cursor.execute("CREATE TABLE #pytest_varchar_test (varchar_column VARCHAR(9))")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_varchar_test (varchar_column) VALUES (?)", ['123456789'])
+        cursor.execute("INSERT INTO #pytest_varchar_test (varchar_column) VALUES (?)", ['123456789'])
         db_connection.commit()
         # fetchone test
-        cursor.execute("SELECT varchar_column FROM pytest_varchar_test")
+        cursor.execute("SELECT varchar_column FROM #pytest_varchar_test")
         row = cursor.fetchone()
         assert row[0] == '123456789', "SQL_VARCHAR parsing failed for fetchone"
         # fetchall test
-        cursor.execute("SELECT varchar_column FROM pytest_varchar_test")
+        cursor.execute("SELECT varchar_column FROM #pytest_varchar_test")
         rows = cursor.fetchall()
         assert rows[0] == ['123456789'], "SQL_VARCHAR parsing failed for fetchall"
     except Exception as e:
         pytest.fail(f"SQL_VARCHAR parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_varchar_test")
+        cursor.execute("DROP TABLE #pytest_varchar_test")
         db_connection.commit()
 
 # Test that NVARCHAR(n) can accomodate values of size n
 def test_wvarchar_full_capacity(cursor, db_connection):
     """Test SQL_WVARCHAR"""
     try:
-        cursor.execute("CREATE TABLE pytest_wvarchar_test (wvarchar_column NVARCHAR(6))")
+        cursor.execute("CREATE TABLE #pytest_wvarchar_test (wvarchar_column NVARCHAR(6))")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_wvarchar_test (wvarchar_column) VALUES (?)", ['123456'])
+        cursor.execute("INSERT INTO #pytest_wvarchar_test (wvarchar_column) VALUES (?)", ['123456'])
         db_connection.commit()
         # fetchone test
-        cursor.execute("SELECT wvarchar_column FROM pytest_wvarchar_test")
+        cursor.execute("SELECT wvarchar_column FROM #pytest_wvarchar_test")
         row = cursor.fetchone()
         assert row[0] == '123456', "SQL_WVARCHAR parsing failed for fetchone"
         # fetchall test
-        cursor.execute("SELECT wvarchar_column FROM pytest_wvarchar_test")
+        cursor.execute("SELECT wvarchar_column FROM #pytest_wvarchar_test")
         rows = cursor.fetchall()
         assert rows[0] == ['123456'], "SQL_WVARCHAR parsing failed for fetchall"
     except Exception as e:
         pytest.fail(f"SQL_WVARCHAR parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_wvarchar_test")
+        cursor.execute("DROP TABLE #pytest_wvarchar_test")
         db_connection.commit()
 
 # Test that VARBINARY(n) can accomodate values of size n
 def test_varbinary_full_capacity(cursor, db_connection):
     """Test SQL_VARBINARY"""
     try:
-        cursor.execute("CREATE TABLE pytest_varbinary_test (varbinary_column VARBINARY(8))")
+        cursor.execute("CREATE TABLE #pytest_varbinary_test (varbinary_column VARBINARY(8))")
         db_connection.commit()
         # Try inserting binary using both bytes & bytearray
-        cursor.execute("INSERT INTO pytest_varbinary_test (varbinary_column) VALUES (?)", bytearray("12345", 'utf-8'))
-        cursor.execute("INSERT INTO pytest_varbinary_test (varbinary_column) VALUES (?)", bytes("12345678", 'utf-8')) # Full capacity
+        cursor.execute("INSERT INTO #pytest_varbinary_test (varbinary_column) VALUES (?)", bytearray("12345", 'utf-8'))
+        cursor.execute("INSERT INTO #pytest_varbinary_test (varbinary_column) VALUES (?)", bytes("12345678", 'utf-8')) # Full capacity
         db_connection.commit()
         expectedRows = 2
         # fetchone test
-        cursor.execute("SELECT varbinary_column FROM pytest_varbinary_test")
+        cursor.execute("SELECT varbinary_column FROM #pytest_varbinary_test")
         rows = []
         for i in range(0, expectedRows):
             rows.append(cursor.fetchone())
@@ -383,26 +383,26 @@ def test_varbinary_full_capacity(cursor, db_connection):
         assert rows[0] == [bytes("12345", 'utf-8')], "SQL_VARBINARY parsing failed for fetchone - row 0"
         assert rows[1] == [bytes("12345678", 'utf-8')], "SQL_VARBINARY parsing failed for fetchone - row 1"
         # fetchall test
-        cursor.execute("SELECT varbinary_column FROM pytest_varbinary_test")
+        cursor.execute("SELECT varbinary_column FROM #pytest_varbinary_test")
         rows = cursor.fetchall()
         assert rows[0] == [bytes("12345", 'utf-8')], "SQL_VARBINARY parsing failed for fetchall - row 0"
         assert rows[1] == [bytes("12345678", 'utf-8')], "SQL_VARBINARY parsing failed for fetchall - row 1"
     except Exception as e:
         pytest.fail(f"SQL_VARBINARY parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_varbinary_test")
+        cursor.execute("DROP TABLE #pytest_varbinary_test")
         db_connection.commit()
 
 def test_varchar_max(cursor, db_connection):
     """Test SQL_VARCHAR with MAX length"""
     try:
-        cursor.execute("CREATE TABLE pytest_varchar_test (varchar_column VARCHAR(MAX))")
+        cursor.execute("CREATE TABLE #pytest_varchar_test (varchar_column VARCHAR(MAX))")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_varchar_test (varchar_column) VALUES (?), (?)", ["ABCDEFGHI", None])
+        cursor.execute("INSERT INTO #pytest_varchar_test (varchar_column) VALUES (?), (?)", ["ABCDEFGHI", None])
         db_connection.commit()
         expectedRows = 2
         # fetchone test
-        cursor.execute("SELECT varchar_column FROM pytest_varchar_test")
+        cursor.execute("SELECT varchar_column FROM #pytest_varchar_test")
         rows = []
         for i in range(0, expectedRows):
             rows.append(cursor.fetchone())
@@ -410,26 +410,26 @@ def test_varchar_max(cursor, db_connection):
         assert rows[0] == ["ABCDEFGHI"], "SQL_VARCHAR parsing failed for fetchone - row 0"
         assert rows[1] == [None], "SQL_VARCHAR parsing failed for fetchone - row 1"
         # fetchall test
-        cursor.execute("SELECT varchar_column FROM pytest_varchar_test")
+        cursor.execute("SELECT varchar_column FROM #pytest_varchar_test")
         rows = cursor.fetchall()
         assert rows[0] == ["ABCDEFGHI"], "SQL_VARCHAR parsing failed for fetchall - row 0"
         assert rows[1] == [None], "SQL_VARCHAR parsing failed for fetchall - row 1"
     except Exception as e:
         pytest.fail(f"SQL_VARCHAR parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_varchar_test")
+        cursor.execute("DROP TABLE #pytest_varchar_test")
         db_connection.commit()
 
 def test_wvarchar_max(cursor, db_connection):
     """Test SQL_WVARCHAR with MAX length"""
     try:
-        cursor.execute("CREATE TABLE pytest_wvarchar_test (wvarchar_column NVARCHAR(MAX))")
+        cursor.execute("CREATE TABLE #pytest_wvarchar_test (wvarchar_column NVARCHAR(MAX))")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_wvarchar_test (wvarchar_column) VALUES (?), (?)", ["!@#$%^&*()_+", None])
+        cursor.execute("INSERT INTO #pytest_wvarchar_test (wvarchar_column) VALUES (?), (?)", ["!@#$%^&*()_+", None])
         db_connection.commit()
         expectedRows = 2
         # fetchone test
-        cursor.execute("SELECT wvarchar_column FROM pytest_wvarchar_test")
+        cursor.execute("SELECT wvarchar_column FROM #pytest_wvarchar_test")
         rows = []
         for i in range(0, expectedRows):
             rows.append(cursor.fetchone())
@@ -437,28 +437,28 @@ def test_wvarchar_max(cursor, db_connection):
         assert rows[0] == ["!@#$%^&*()_+"], "SQL_WVARCHAR parsing failed for fetchone - row 0"
         assert rows[1] == [None], "SQL_WVARCHAR parsing failed for fetchone - row 1"
         # fetchall test
-        cursor.execute("SELECT wvarchar_column FROM pytest_wvarchar_test")
+        cursor.execute("SELECT wvarchar_column FROM #pytest_wvarchar_test")
         rows = cursor.fetchall()
         assert rows[0] == ["!@#$%^&*()_+"], "SQL_WVARCHAR parsing failed for fetchall - row 0"
         assert rows[1] == [None], "SQL_WVARCHAR parsing failed for fetchall - row 1"
     except Exception as e:
         pytest.fail(f"SQL_WVARCHAR parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_wvarchar_test")
+        cursor.execute("DROP TABLE #pytest_wvarchar_test")
         db_connection.commit()
 
 def test_varbinary_max(cursor, db_connection):
     """Test SQL_VARBINARY with MAX length"""
     try:
-        cursor.execute("CREATE TABLE pytest_varbinary_test (varbinary_column VARBINARY(MAX))")
+        cursor.execute("CREATE TABLE #pytest_varbinary_test (varbinary_column VARBINARY(MAX))")
         db_connection.commit()
         # TODO: Uncomment this execute after adding null binary support
-        # cursor.execute("INSERT INTO pytest_varbinary_test (varbinary_column) VALUES (?)", [None])
-        cursor.execute("INSERT INTO pytest_varbinary_test (varbinary_column) VALUES (?), (?)", [bytearray("ABCDEF", 'utf-8'), bytes("123!@#", 'utf-8')])
+        # cursor.execute("INSERT INTO #pytest_varbinary_test (varbinary_column) VALUES (?)", [None])
+        cursor.execute("INSERT INTO #pytest_varbinary_test (varbinary_column) VALUES (?), (?)", [bytearray("ABCDEF", 'utf-8'), bytes("123!@#", 'utf-8')])
         db_connection.commit()
         expectedRows = 2
         # fetchone test
-        cursor.execute("SELECT varbinary_column FROM pytest_varbinary_test")
+        cursor.execute("SELECT varbinary_column FROM #pytest_varbinary_test")
         rows = []
         for i in range(0, expectedRows):
             rows.append(cursor.fetchone())
@@ -466,26 +466,26 @@ def test_varbinary_max(cursor, db_connection):
         assert rows[0] == [bytearray("ABCDEF", 'utf-8')], "SQL_VARBINARY parsing failed for fetchone - row 0"
         assert rows[1] == [bytes("123!@#", 'utf-8')], "SQL_VARBINARY parsing failed for fetchone - row 1"
         # fetchall test
-        cursor.execute("SELECT varbinary_column FROM pytest_varbinary_test")
+        cursor.execute("SELECT varbinary_column FROM #pytest_varbinary_test")
         rows = cursor.fetchall()
         assert rows[0] == [bytearray("ABCDEF", 'utf-8')], "SQL_VARBINARY parsing failed for fetchall - row 0"
         assert rows[1] == [bytes("123!@#", 'utf-8')], "SQL_VARBINARY parsing failed for fetchall - row 1"
     except Exception as e:
         pytest.fail(f"SQL_VARBINARY parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_varbinary_test")
+        cursor.execute("DROP TABLE #pytest_varbinary_test")
         db_connection.commit()
 
 def test_longvarchar(cursor, db_connection):
     """Test SQL_LONGVARCHAR"""
     try:
-        cursor.execute("CREATE TABLE pytest_longvarchar_test (longvarchar_column TEXT)")
+        cursor.execute("CREATE TABLE #pytest_longvarchar_test (longvarchar_column TEXT)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_longvarchar_test (longvarchar_column) VALUES (?), (?)", ["ABCDEFGHI", None])
+        cursor.execute("INSERT INTO #pytest_longvarchar_test (longvarchar_column) VALUES (?), (?)", ["ABCDEFGHI", None])
         db_connection.commit()
         expectedRows = 2
         # fetchone test
-        cursor.execute("SELECT longvarchar_column FROM pytest_longvarchar_test")
+        cursor.execute("SELECT longvarchar_column FROM #pytest_longvarchar_test")
         rows = []
         for i in range(0, expectedRows):
             rows.append(cursor.fetchone())
@@ -493,26 +493,26 @@ def test_longvarchar(cursor, db_connection):
         assert rows[0] == ["ABCDEFGHI"], "SQL_LONGVARCHAR parsing failed for fetchone - row 0"
         assert rows[1] == [None], "SQL_LONGVARCHAR parsing failed for fetchone - row 1"
         # fetchall test
-        cursor.execute("SELECT longvarchar_column FROM pytest_longvarchar_test")
+        cursor.execute("SELECT longvarchar_column FROM #pytest_longvarchar_test")
         rows = cursor.fetchall()
         assert rows[0] == ["ABCDEFGHI"], "SQL_LONGVARCHAR parsing failed for fetchall - row 0"
         assert rows[1] == [None], "SQL_LONGVARCHAR parsing failed for fetchall - row 1"
     except Exception as e:
         pytest.fail(f"SQL_LONGVARCHAR parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_longvarchar_test")
+        cursor.execute("DROP TABLE #pytest_longvarchar_test")
         db_connection.commit()
 
 def test_longwvarchar(cursor, db_connection):
     """Test SQL_LONGWVARCHAR"""
     try:
-        cursor.execute("CREATE TABLE pytest_longwvarchar_test (longwvarchar_column NTEXT)")
+        cursor.execute("CREATE TABLE #pytest_longwvarchar_test (longwvarchar_column NTEXT)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_longwvarchar_test (longwvarchar_column) VALUES (?), (?)", ["ABCDEFGHI", None])
+        cursor.execute("INSERT INTO #pytest_longwvarchar_test (longwvarchar_column) VALUES (?), (?)", ["ABCDEFGHI", None])
         db_connection.commit()
         expectedRows = 2
         # fetchone test
-        cursor.execute("SELECT longwvarchar_column FROM pytest_longwvarchar_test")
+        cursor.execute("SELECT longwvarchar_column FROM #pytest_longwvarchar_test")
         rows = []
         for i in range(0, expectedRows):
             rows.append(cursor.fetchone())
@@ -520,26 +520,26 @@ def test_longwvarchar(cursor, db_connection):
         assert rows[0] == ["ABCDEFGHI"], "SQL_LONGWVARCHAR parsing failed for fetchone - row 0"
         assert rows[1] == [None], "SQL_LONGWVARCHAR parsing failed for fetchone - row 1"
         # fetchall test
-        cursor.execute("SELECT longwvarchar_column FROM pytest_longwvarchar_test")
+        cursor.execute("SELECT longwvarchar_column FROM #pytest_longwvarchar_test")
         rows = cursor.fetchall()
         assert rows[0] == ["ABCDEFGHI"], "SQL_LONGWVARCHAR parsing failed for fetchall - row 0"
         assert rows[1] == [None], "SQL_LONGWVARCHAR parsing failed for fetchall - row 1"
     except Exception as e:
         pytest.fail(f"SQL_LONGWVARCHAR parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_longwvarchar_test")
+        cursor.execute("DROP TABLE #pytest_longwvarchar_test")
         db_connection.commit()
 
 def test_longvarbinary(cursor, db_connection):
     """Test SQL_LONGVARBINARY"""
     try:
-        cursor.execute("CREATE TABLE pytest_longvarbinary_test (longvarbinary_column IMAGE)")
+        cursor.execute("CREATE TABLE #pytest_longvarbinary_test (longvarbinary_column IMAGE)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_longvarbinary_test (longvarbinary_column) VALUES (?), (?)", [bytearray("ABCDEFGHI", 'utf-8'), bytes("123!@#", 'utf-8')])
+        cursor.execute("INSERT INTO #pytest_longvarbinary_test (longvarbinary_column) VALUES (?), (?)", [bytearray("ABCDEFGHI", 'utf-8'), bytes("123!@#", 'utf-8')])
         db_connection.commit()
         expectedRows = 3
         # fetchone test
-        cursor.execute("SELECT longvarbinary_column FROM pytest_longvarbinary_test")
+        cursor.execute("SELECT longvarbinary_column FROM #pytest_longvarbinary_test")
         rows = []
         for i in range(0, expectedRows):
             rows.append(cursor.fetchone())
@@ -547,19 +547,19 @@ def test_longvarbinary(cursor, db_connection):
         assert rows[0] == [bytearray("ABCDEFGHI", 'utf-8')], "SQL_LONGVARBINARY parsing failed for fetchone - row 0"
         assert rows[1] == [bytes("123!@#\0\0\0", 'utf-8')], "SQL_LONGVARBINARY parsing failed for fetchone - row 1"
         # fetchall test
-        cursor.execute("SELECT longvarbinary_column FROM pytest_longvarbinary_test")
+        cursor.execute("SELECT longvarbinary_column FROM #pytest_longvarbinary_test")
         rows = cursor.fetchall()
         assert rows[0] == [bytearray("ABCDEFGHI", 'utf-8')], "SQL_LONGVARBINARY parsing failed for fetchall - row 0"
         assert rows[1] == [bytes("123!@#\0\0\0", 'utf-8')], "SQL_LONGVARBINARY parsing failed for fetchall - row 1"
     except Exception as e:
         pytest.fail(f"SQL_LONGVARBINARY parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_longvarbinary_test")
+        cursor.execute("DROP TABLE #pytest_longvarbinary_test")
         db_connection.commit()
 
 def test_create_table(cursor, db_connection):
     # Drop the table if it exists
-    drop_table_if_exists(cursor, "pytest_all_data_types")
+    drop_table_if_exists(cursor, "#pytest_all_data_types")
     
     # Create test table
     try:
@@ -572,7 +572,7 @@ def test_insert_args(cursor, db_connection):
     """Test parameterized insert using qmark parameters"""
     try:
         cursor.execute("""
-            INSERT INTO pytest_all_data_types VALUES (
+            INSERT INTO #pytest_all_data_types VALUES (
                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
             )
         """, 
@@ -590,13 +590,13 @@ def test_insert_args(cursor, db_connection):
             TEST_DATA[11]
         )
         db_connection.commit()
-        cursor.execute("SELECT * FROM pytest_all_data_types WHERE id = 1")
+        cursor.execute("SELECT * FROM #pytest_all_data_types WHERE id = 1")
         row = cursor.fetchone()
         assert row[0] == TEST_DATA[0], "Insertion using args failed"
     except Exception as e:
         pytest.fail(f"Parameterized data insertion/fetch failed: {e}")    
     finally:
-        cursor.execute("DELETE FROM pytest_all_data_types")
+        cursor.execute("DELETE FROM #pytest_all_data_types")
         db_connection.commit()                   
 
 @pytest.mark.parametrize("data", PARAM_TEST_DATA)
@@ -604,7 +604,7 @@ def test_parametrized_insert(cursor, db_connection, data):
     """Test parameterized insert using qmark parameters"""
     try:
         cursor.execute("""
-            INSERT INTO pytest_all_data_types VALUES (
+            INSERT INTO #pytest_all_data_types VALUES (
                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
             )
         """, [None if v is None else v for v in data])
@@ -615,20 +615,20 @@ def test_parametrized_insert(cursor, db_connection, data):
 def test_rowcount(cursor, db_connection):
     """Test rowcount after insert operations"""
     try:
-        cursor.execute("CREATE TABLE pytest_test_rowcount (id INT IDENTITY(1,1) PRIMARY KEY, name NVARCHAR(100))")
+        cursor.execute("CREATE TABLE #pytest_test_rowcount (id INT IDENTITY(1,1) PRIMARY KEY, name NVARCHAR(100))")
         db_connection.commit()
 
-        cursor.execute("INSERT INTO pytest_test_rowcount (name) VALUES ('JohnDoe1');")
+        cursor.execute("INSERT INTO #pytest_test_rowcount (name) VALUES ('JohnDoe1');")
         assert cursor.rowcount == 1, "Rowcount should be 1 after first insert"
 
-        cursor.execute("INSERT INTO pytest_test_rowcount (name) VALUES ('JohnDoe2');")
+        cursor.execute("INSERT INTO #pytest_test_rowcount (name) VALUES ('JohnDoe2');")
         assert cursor.rowcount == 1, "Rowcount should be 1 after second insert"
 
-        cursor.execute("INSERT INTO pytest_test_rowcount (name) VALUES ('JohnDoe3');")
+        cursor.execute("INSERT INTO #pytest_test_rowcount (name) VALUES ('JohnDoe3');")
         assert cursor.rowcount == 1, "Rowcount should be 1 after third insert"
 
         cursor.execute("""
-            INSERT INTO pytest_test_rowcount (name) 
+            INSERT INTO #pytest_test_rowcount (name) 
             VALUES 
             ('JohnDoe4'), 
             ('JohnDoe5'), 
@@ -636,20 +636,20 @@ def test_rowcount(cursor, db_connection):
         """)
         assert cursor.rowcount == 3, "Rowcount should be 3 after inserting multiple rows"
 
-        cursor.execute("SELECT * FROM pytest_test_rowcount;")
+        cursor.execute("SELECT * FROM #pytest_test_rowcount;")
         assert cursor.rowcount == -1, "Rowcount should be -1 after a SELECT statement"
 
         db_connection.commit()
     except Exception as e:
         pytest.fail(f"Rowcount test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_test_rowcount")
+        cursor.execute("DROP TABLE #pytest_test_rowcount")
         db_connection.commit()
 
 def test_rowcount_executemany(cursor, db_connection):
     """Test rowcount after executemany operations"""
     try:
-        cursor.execute("CREATE TABLE pytest_test_rowcount (id INT IDENTITY(1,1) PRIMARY KEY, name NVARCHAR(100))")
+        cursor.execute("CREATE TABLE #pytest_test_rowcount (id INT IDENTITY(1,1) PRIMARY KEY, name NVARCHAR(100))")
         db_connection.commit()
 
         data = [
@@ -658,29 +658,29 @@ def test_rowcount_executemany(cursor, db_connection):
             ('JohnDoe3',)
         ]
 
-        cursor.executemany("INSERT INTO pytest_test_rowcount (name) VALUES (?)", data)
+        cursor.executemany("INSERT INTO #pytest_test_rowcount (name) VALUES (?)", data)
         assert cursor.rowcount == 3, "Rowcount should be 3 after executemany insert"
 
-        cursor.execute("SELECT * FROM pytest_test_rowcount;")
+        cursor.execute("SELECT * FROM #pytest_test_rowcount;")
         assert cursor.rowcount == -1, "Rowcount should be -1 after a SELECT statement"
 
         db_connection.commit()
     except Exception as e:
         pytest.fail(f"Rowcount executemany test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_test_rowcount")
+        cursor.execute("DROP TABLE #pytest_test_rowcount")
         db_connection.commit()
 
 def test_fetchone(cursor):
     """Test fetching a single row"""
-    cursor.execute("SELECT * FROM pytest_all_data_types WHERE id = 1")
+    cursor.execute("SELECT * FROM #pytest_all_data_types WHERE id = 1")
     row = cursor.fetchone()
     assert row is not None, "No row returned"
     assert len(row) == 12, "Incorrect number of columns"
 
 def test_fetchmany(cursor):
     """Test fetching multiple rows"""
-    cursor.execute("SELECT * FROM pytest_all_data_types")
+    cursor.execute("SELECT * FROM #pytest_all_data_types")
     rows = cursor.fetchmany(2)
     assert isinstance(rows, list), "fetchmany should return a list"
     assert len(rows) == 2, "Incorrect number of rows returned"
@@ -688,13 +688,13 @@ def test_fetchmany(cursor):
 def test_fetchmany_with_arraysize(cursor, db_connection):
     """Test fetchmany with arraysize"""
     cursor.arraysize = 3
-    cursor.execute("SELECT * FROM pytest_all_data_types")
+    cursor.execute("SELECT * FROM #pytest_all_data_types")
     rows = cursor.fetchmany()
     assert len(rows) == 3, "fetchmany with arraysize returned incorrect number of rows"
 
 def test_fetchall(cursor):
     """Test fetching all rows"""
-    cursor.execute("SELECT * FROM pytest_all_data_types")
+    cursor.execute("SELECT * FROM #pytest_all_data_types")
     rows = cursor.fetchall()
     assert isinstance(rows, list), "fetchall should return a list"
     assert len(rows) == len(PARAM_TEST_DATA), "Incorrect number of rows returned"
@@ -732,7 +732,7 @@ def test_arraysize(cursor):
 
 def test_description(cursor):
     """Test description"""
-    cursor.execute("SELECT * FROM pytest_all_data_types WHERE id = 1")
+    cursor.execute("SELECT * FROM #pytest_all_data_types WHERE id = 1")
     desc = cursor.description
     assert len(desc) == 12, "Description length mismatch"
     assert desc[0][0] == "id", "Description column name mismatch"
@@ -749,43 +749,43 @@ def test_description(cursor):
 def test_execute_many(cursor, db_connection):
     """Test executemany"""
     # Start fresh
-    cursor.execute("DELETE FROM pytest_all_data_types")
+    cursor.execute("DELETE FROM #pytest_all_data_types")
     db_connection.commit()
     data = [(i,) for i in range(1, 12)]
-    cursor.executemany("INSERT INTO pytest_all_data_types (id) VALUES (?)", data)
-    cursor.execute("SELECT COUNT(*) FROM pytest_all_data_types")
+    cursor.executemany("INSERT INTO #pytest_all_data_types (id) VALUES (?)", data)
+    cursor.execute("SELECT COUNT(*) FROM #pytest_all_data_types")
     count = cursor.fetchone()[0]
     assert count == 11, "Executemany failed"
 
 def test_nextset(cursor):
     """Test nextset"""
-    cursor.execute("SELECT * FROM pytest_all_data_types WHERE id = 1;")
+    cursor.execute("SELECT * FROM #pytest_all_data_types WHERE id = 1;")
     assert cursor.nextset() is False, "Nextset should return False"
-    cursor.execute("SELECT * FROM pytest_all_data_types WHERE id = 2; SELECT * FROM pytest_all_data_types WHERE id = 3;")
+    cursor.execute("SELECT * FROM #pytest_all_data_types WHERE id = 2; SELECT * FROM #pytest_all_data_types WHERE id = 3;")
     assert cursor.nextset() is True, "Nextset should return True"
 
 def test_delete_table(cursor, db_connection):
     """Test deleting the table"""
-    drop_table_if_exists(cursor, "pytest_all_data_types")
+    drop_table_if_exists(cursor, "#pytest_all_data_types")
     db_connection.commit()
 
 # Setup tables for join operations
 CREATE_TABLES_FOR_JOIN = [
     """
-    CREATE TABLE pytest_employees (
+    CREATE TABLE #pytest_employees (
         employee_id INTEGER PRIMARY KEY,
         name NVARCHAR(255),
         department_id INTEGER
     );
     """,
     """
-    CREATE TABLE pytest_departments (
+    CREATE TABLE #pytest_departments (
         department_id INTEGER PRIMARY KEY,
         department_name NVARCHAR(255)
     );
     """,
     """
-    CREATE TABLE pytest_projects (
+    CREATE TABLE #pytest_projects (
         project_id INTEGER PRIMARY KEY,
         project_name NVARCHAR(255),
         employee_id INTEGER
@@ -796,18 +796,18 @@ CREATE_TABLES_FOR_JOIN = [
 # Insert data for join operations
 INSERT_DATA_FOR_JOIN = [
     """
-    INSERT INTO pytest_employees (employee_id, name, department_id) VALUES
+    INSERT INTO #pytest_employees (employee_id, name, department_id) VALUES
     (1, 'Alice', 1),
     (2, 'Bob', 2),
     (3, 'Charlie', 1);
     """,
     """
-    INSERT INTO pytest_departments (department_id, department_name) VALUES
+    INSERT INTO #pytest_departments (department_id, department_name) VALUES
     (1, 'HR'),
     (2, 'Engineering');
     """,
     """
-    INSERT INTO pytest_projects (project_id, project_name, employee_id) VALUES
+    INSERT INTO #pytest_projects (project_id, project_name, employee_id) VALUES
     (1, 'Project A', 1),
     (2, 'Project B', 2),
     (3, 'Project C', 3);
@@ -837,9 +837,9 @@ def test_join_operations(cursor):
     try:
         cursor.execute("""
             SELECT e.name, d.department_name, p.project_name
-            FROM pytest_employees e
-            JOIN pytest_departments d ON e.department_id = d.department_id
-            JOIN pytest_projects p ON e.employee_id = p.employee_id
+            FROM #pytest_employees e
+            JOIN #pytest_departments d ON e.department_id = d.department_id
+            JOIN #pytest_projects p ON e.employee_id = p.employee_id
         """)
         rows = cursor.fetchall()
         assert len(rows) == 3, "Join operation returned incorrect number of rows"
@@ -855,9 +855,9 @@ def test_join_operations_with_parameters(cursor):
         employee_ids = [1, 2]
         query = """
             SELECT e.name, d.department_name, p.project_name
-            FROM pytest_employees e
-            JOIN pytest_departments d ON e.department_id = d.department_id
-            JOIN pytest_projects p ON e.employee_id = p.employee_id
+            FROM #pytest_employees e
+            JOIN #pytest_departments d ON e.department_id = d.department_id
+            JOIN #pytest_projects p ON e.employee_id = p.employee_id
             WHERE e.employee_id IN (?, ?)
         """
         cursor.execute(query, employee_ids)
@@ -875,8 +875,8 @@ CREATE PROCEDURE GetEmployeeProjects
 AS
 BEGIN
     SELECT e.name, p.project_name
-    FROM pytest_employees e
-    JOIN pytest_projects p ON e.employee_id = p.employee_id
+    FROM #pytest_employees e
+    JOIN #pytest_projects p ON e.employee_id = p.employee_id
     WHERE e.employee_id = @EmployeeID
 END
 """
@@ -923,9 +923,9 @@ def test_drop_stored_procedure(cursor, db_connection):
 def test_drop_tables_for_join(cursor, db_connection):
     """Drop tables for join operations"""
     try:
-        cursor.execute("DROP TABLE IF EXISTS pytest_employees")
-        cursor.execute("DROP TABLE IF EXISTS pytest_departments")
-        cursor.execute("DROP TABLE IF EXISTS pytest_projects")
+        cursor.execute("DROP TABLE IF EXISTS #pytest_employees")
+        cursor.execute("DROP TABLE IF EXISTS #pytest_departments")
+        cursor.execute("DROP TABLE IF EXISTS #pytest_projects")
         db_connection.commit()
     except Exception as e:
         pytest.fail(f"Failed to drop tables for join operations: {e}")
@@ -945,172 +945,172 @@ def test_cursor_description(cursor):
 def test_parse_datetime(cursor, db_connection):
     """Test _parse_datetime"""
     try:
-        cursor.execute("CREATE TABLE pytest_datetime_test (datetime_column DATETIME)")
+        cursor.execute("CREATE TABLE #pytest_datetime_test (datetime_column DATETIME)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_datetime_test (datetime_column) VALUES (?)", ['2024-05-20T12:34:56.123'])
+        cursor.execute("INSERT INTO #pytest_datetime_test (datetime_column) VALUES (?)", ['2024-05-20T12:34:56.123'])
         db_connection.commit()
-        cursor.execute("SELECT datetime_column FROM pytest_datetime_test")
+        cursor.execute("SELECT datetime_column FROM #pytest_datetime_test")
         row = cursor.fetchone()
         assert row[0] == datetime(2024, 5, 20, 12, 34, 56, 123000), "Datetime parsing failed"
     except Exception as e:
         pytest.fail(f"Datetime parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_datetime_test")
+        cursor.execute("DROP TABLE #pytest_datetime_test")
         db_connection.commit()
 
 def test_parse_date(cursor, db_connection):
     """Test _parse_date"""
     try:
-        cursor.execute("CREATE TABLE pytest_date_test (date_column DATE)")
+        cursor.execute("CREATE TABLE #pytest_date_test (date_column DATE)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_date_test (date_column) VALUES (?)", ['2024-05-20'])
+        cursor.execute("INSERT INTO #pytest_date_test (date_column) VALUES (?)", ['2024-05-20'])
         db_connection.commit()
-        cursor.execute("SELECT date_column FROM pytest_date_test")
+        cursor.execute("SELECT date_column FROM #pytest_date_test")
         row = cursor.fetchone()
         assert row[0] == date(2024, 5, 20), "Date parsing failed"
     except Exception as e:
         pytest.fail(f"Date parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_date_test")
+        cursor.execute("DROP TABLE #pytest_date_test")
         db_connection.commit()
 
 def test_parse_time(cursor, db_connection):
     """Test _parse_time"""
     try:
-        cursor.execute("CREATE TABLE pytest_time_test (time_column TIME)")
+        cursor.execute("CREATE TABLE #pytest_time_test (time_column TIME)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_time_test (time_column) VALUES (?)", ['12:34:56'])
+        cursor.execute("INSERT INTO #pytest_time_test (time_column) VALUES (?)", ['12:34:56'])
         db_connection.commit()
-        cursor.execute("SELECT time_column FROM pytest_time_test")
+        cursor.execute("SELECT time_column FROM #pytest_time_test")
         row = cursor.fetchone()
         assert row[0] == time(12, 34, 56), "Time parsing failed"
     except Exception as e:
         pytest.fail(f"Time parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_time_test")
+        cursor.execute("DROP TABLE #pytest_time_test")
         db_connection.commit()
 
 def test_parse_smalldatetime(cursor, db_connection):
     """Test _parse_smalldatetime"""
     try:
-        cursor.execute("CREATE TABLE pytest_smalldatetime_test (smalldatetime_column SMALLDATETIME)")
+        cursor.execute("CREATE TABLE #pytest_smalldatetime_test (smalldatetime_column SMALLDATETIME)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_smalldatetime_test (smalldatetime_column) VALUES (?)", ['2024-05-20 12:34'])
+        cursor.execute("INSERT INTO #pytest_smalldatetime_test (smalldatetime_column) VALUES (?)", ['2024-05-20 12:34'])
         db_connection.commit()
-        cursor.execute("SELECT smalldatetime_column FROM pytest_smalldatetime_test")
+        cursor.execute("SELECT smalldatetime_column FROM #pytest_smalldatetime_test")
         row = cursor.fetchone()
         assert row[0] == datetime(2024, 5, 20, 12, 34), "Smalldatetime parsing failed"
     except Exception as e:
         pytest.fail(f"Smalldatetime parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_smalldatetime_test")
+        cursor.execute("DROP TABLE #pytest_smalldatetime_test")
         db_connection.commit()
 
 def test_parse_datetime2(cursor, db_connection):
     """Test _parse_datetime2"""
     try:
-        cursor.execute("CREATE TABLE pytest_datetime2_test (datetime2_column DATETIME2)")
+        cursor.execute("CREATE TABLE #pytest_datetime2_test (datetime2_column DATETIME2)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_datetime2_test (datetime2_column) VALUES (?)", ['2024-05-20 12:34:56.123456'])
+        cursor.execute("INSERT INTO #pytest_datetime2_test (datetime2_column) VALUES (?)", ['2024-05-20 12:34:56.123456'])
         db_connection.commit()
-        cursor.execute("SELECT datetime2_column FROM pytest_datetime2_test")
+        cursor.execute("SELECT datetime2_column FROM #pytest_datetime2_test")
         row = cursor.fetchone()
         assert row[0] == datetime(2024, 5, 20, 12, 34, 56, 123456), "Datetime2 parsing failed"
     except Exception as e:
         pytest.fail(f"Datetime2 parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_datetime2_test")
+        cursor.execute("DROP TABLE #pytest_datetime2_test")
         db_connection.commit()
 
 def test_get_numeric_data(cursor, db_connection):
     """Test _get_numeric_data"""
     try:
-        cursor.execute("CREATE TABLE pytest_numeric_test (numeric_column DECIMAL(10, 2))")
+        cursor.execute("CREATE TABLE #pytest_numeric_test (numeric_column DECIMAL(10, 2))")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_numeric_test (numeric_column) VALUES (?)", [decimal.Decimal('123.45')])
+        cursor.execute("INSERT INTO #pytest_numeric_test (numeric_column) VALUES (?)", [decimal.Decimal('123.45')])
         db_connection.commit()
-        cursor.execute("SELECT numeric_column FROM pytest_numeric_test")
+        cursor.execute("SELECT numeric_column FROM #pytest_numeric_test")
         row = cursor.fetchone()
         assert row[0] == decimal.Decimal('123.45'), "Numeric data parsing failed"
     except Exception as e:
         pytest.fail(f"Numeric data parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_numeric_test")
+        cursor.execute("DROP TABLE #pytest_numeric_test")
         db_connection.commit()
 
 def test_none(cursor, db_connection):
     """Test None"""
     try:
-        cursor.execute("CREATE TABLE pytest_none_test (none_column NVARCHAR(255))")
+        cursor.execute("CREATE TABLE #pytest_none_test (none_column NVARCHAR(255))")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_none_test (none_column) VALUES (?)", [None])
+        cursor.execute("INSERT INTO #pytest_none_test (none_column) VALUES (?)", [None])
         db_connection.commit()
-        cursor.execute("SELECT none_column FROM pytest_none_test")
+        cursor.execute("SELECT none_column FROM #pytest_none_test")
         row = cursor.fetchone()
         assert row[0] is None, "None parsing failed"
     except Exception as e:
         pytest.fail(f"None parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_none_test")
+        cursor.execute("DROP TABLE #pytest_none_test")
         db_connection.commit()
 
 def test_boolean(cursor, db_connection):
     """Test boolean"""
     try:
-        cursor.execute("CREATE TABLE pytest_boolean_test (boolean_column BIT)")
+        cursor.execute("CREATE TABLE #pytest_boolean_test (boolean_column BIT)")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_boolean_test (boolean_column) VALUES (?)", [True])
+        cursor.execute("INSERT INTO #pytest_boolean_test (boolean_column) VALUES (?)", [True])
         db_connection.commit()
-        cursor.execute("SELECT boolean_column FROM pytest_boolean_test")
+        cursor.execute("SELECT boolean_column FROM #pytest_boolean_test")
         row = cursor.fetchone()
         assert row[0] is True, "Boolean parsing failed"
     except Exception as e:
         pytest.fail(f"Boolean parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_boolean_test")
+        cursor.execute("DROP TABLE #pytest_boolean_test")
         db_connection.commit()
 
 
 def test_sql_wvarchar(cursor, db_connection):
     """Test SQL_WVARCHAR"""
     try:
-        cursor.execute("CREATE TABLE pytest_wvarchar_test (wvarchar_column NVARCHAR(255))")
+        cursor.execute("CREATE TABLE #pytest_wvarchar_test (wvarchar_column NVARCHAR(255))")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_wvarchar_test (wvarchar_column) VALUES (?)", ['nvarchar data'])
+        cursor.execute("INSERT INTO #pytest_wvarchar_test (wvarchar_column) VALUES (?)", ['nvarchar data'])
         db_connection.commit()
-        cursor.execute("SELECT wvarchar_column FROM pytest_wvarchar_test")
+        cursor.execute("SELECT wvarchar_column FROM #pytest_wvarchar_test")
         row = cursor.fetchone()
         assert row[0] == 'nvarchar data', "SQL_WVARCHAR parsing failed"
     except Exception as e:
         pytest.fail(f"SQL_WVARCHAR parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_wvarchar_test")
+        cursor.execute("DROP TABLE #pytest_wvarchar_test")
         db_connection.commit()
 
 def test_sql_varchar(cursor, db_connection):
     """Test SQL_VARCHAR"""
     try:
-        cursor.execute("CREATE TABLE pytest_varchar_test (varchar_column VARCHAR(255))")
+        cursor.execute("CREATE TABLE #pytest_varchar_test (varchar_column VARCHAR(255))")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_varchar_test (varchar_column) VALUES (?)", ['varchar data'])
+        cursor.execute("INSERT INTO #pytest_varchar_test (varchar_column) VALUES (?)", ['varchar data'])
         db_connection.commit()
-        cursor.execute("SELECT varchar_column FROM pytest_varchar_test")
+        cursor.execute("SELECT varchar_column FROM #pytest_varchar_test")
         row = cursor.fetchone()
         assert row[0] == 'varchar data', "SQL_VARCHAR parsing failed"
     except Exception as e:
         pytest.fail(f"SQL_VARCHAR parsing test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_varchar_test")
+        cursor.execute("DROP TABLE #pytest_varchar_test")
         db_connection.commit()
 
 def test_numeric_precision_scale_positive_exponent(cursor, db_connection):
     """Test precision and scale for numeric values with positive exponent"""
     try:
-        cursor.execute("CREATE TABLE pytest_numeric_test (numeric_column DECIMAL(10, 2))")
+        cursor.execute("CREATE TABLE #pytest_numeric_test (numeric_column DECIMAL(10, 2))")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_numeric_test (numeric_column) VALUES (?)", [decimal.Decimal('31400')])
+        cursor.execute("INSERT INTO #pytest_numeric_test (numeric_column) VALUES (?)", [decimal.Decimal('31400')])
         db_connection.commit()
-        cursor.execute("SELECT numeric_column FROM pytest_numeric_test")
+        cursor.execute("SELECT numeric_column FROM #pytest_numeric_test")
         row = cursor.fetchone()
         assert row[0] == decimal.Decimal('31400'), "Numeric data parsing failed"
         # Check precision and scale
@@ -1121,17 +1121,17 @@ def test_numeric_precision_scale_positive_exponent(cursor, db_connection):
     except Exception as e:
         pytest.fail(f"Numeric precision and scale test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_numeric_test")
+        cursor.execute("DROP TABLE #pytest_numeric_test")
         db_connection.commit()
 
 def test_numeric_precision_scale_negative_exponent(cursor, db_connection):
     """Test precision and scale for numeric values with negative exponent"""
     try:
-        cursor.execute("CREATE TABLE pytest_numeric_test (numeric_column DECIMAL(10, 5))")
+        cursor.execute("CREATE TABLE #pytest_numeric_test (numeric_column DECIMAL(10, 5))")
         db_connection.commit()
-        cursor.execute("INSERT INTO pytest_numeric_test (numeric_column) VALUES (?)", [decimal.Decimal('0.03140')])
+        cursor.execute("INSERT INTO #pytest_numeric_test (numeric_column) VALUES (?)", [decimal.Decimal('0.03140')])
         db_connection.commit()
-        cursor.execute("SELECT numeric_column FROM pytest_numeric_test")
+        cursor.execute("SELECT numeric_column FROM #pytest_numeric_test")
         row = cursor.fetchone()
         assert row[0] == decimal.Decimal('0.03140'), "Numeric data parsing failed"
         # Check precision and scale
@@ -1142,7 +1142,7 @@ def test_numeric_precision_scale_negative_exponent(cursor, db_connection):
     except Exception as e:
         pytest.fail(f"Numeric precision and scale test failed: {e}")
     finally:
-        cursor.execute("DROP TABLE pytest_numeric_test")
+        cursor.execute("DROP TABLE #pytest_numeric_test")
         db_connection.commit()
 
 def test_close(db_connection):


### PR DESCRIPTION
### Summary  
This pull request updates the test cases to use temporary tables (prefixed with `#`) instead of permanent tables for improved isolation and to prevent unintended side effects during test execution. The changes span across multiple test functions in the `tests/test_003_connection.py` and `tests/test_004_cursor.py` files.

### Transition to Temporary Tables

* Updated all test cases in `tests/test_003_connection.py` to use temporary tables (e.g., `#pytest_test_autocommit`, `#pytest_test_commit`, `#pytest_test_rollback`) instead of permanent tables. This includes changes in table creation, data insertion, selection, and cleanup steps. [[1]](diffhunk://#diff-ca315ffd463e0f93f3d45ace0869a4a3b1e572941da6723d7e9ce028cf9d2278L80-R114) [[2]](diffhunk://#diff-ca315ffd463e0f93f3d45ace0869a4a3b1e572941da6723d7e9ce028cf9d2278L126-R168)

* Modified the `TEST_TABLE` definition in `tests/test_004_cursor.py` to create a temporary table `#pytest_all_data_types` instead of a permanent one.

* Updated various test cases in `tests/test_004_cursor.py` (e.g., `test_insert_id_column`, `test_insert_bit_column`, `test_insert_nvarchar_column`, `test_insert_date_column`, `test_insert_real_column`) to use temporary tables (`#pytest_single_column`) for creating, inserting, and querying data. This ensures better test isolation and cleanup. [[1]](diffhunk://#diff-82594712308ff34afa8b067af67db231e9a1372ef474da3db121e14e4d418f69L72-R115) [[2]](diffhunk://#diff-82594712308ff34afa8b067af67db231e9a1372ef474da3db121e14e4d418f69L190-R217)

### Issue Reference  
Fixes [AB#34163](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/34163)

### Checklist  
- [x] **Tests Passed** (if applicable)  
- [x] **Code is formatted**   
- [x] **Docs Updated** (if necessary) 

### Testing Performed  
<!-- How was this fix tested? -->
- [x] Unit Tests
