### PR TITLE
FEAT: MacOS in PR Validation Pipeline

### DIFF
--- a/eng/pipelines/pr-validation-pipeline.yml
+++ b/eng/pipelines/pr-validation-pipeline.yml
@@ -80,3 +80,90 @@ jobs:
       codeCoverageTool: 'Cobertura'
       summaryFileLocation: 'coverage.xml'
     displayName: 'Publish code coverage results'
+
+- job: PytestOnMacOS
+  pool:
+    vmImage: 'macos-latest'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.13.5'
+      addToPath: true
+    displayName: 'Use Python 3.13 on macOS'
+
+  - script: |
+      brew update
+      brew install cmake
+    displayName: 'Install CMake'
+
+  # - script: |
+  #     brew update
+  #     brew install docker colima
+
+  #     # Start Colima with extra resources
+  #     colima start --cpu 4 --memory 8 --disk 50
+
+  #     # Optional: set Docker context (usually automatic)
+  #     docker context use colima >/dev/null || true
+
+  #     # Confirm Docker is operational
+  #     docker version
+  #     docker ps
+  #   displayName: 'Install and start Colima-based Docker'
+
+  # - script: |
+  #     # Pull and run SQL Server container
+  #     docker pull mcr.microsoft.com/mssql/server:2022-latest
+  #     docker run \
+  #       --name sqlserver \
+  #       -e ACCEPT_EULA=Y \
+  #       -e MSSQL_SA_PASSWORD="${DB_PASSWORD}" \
+  #       -p 1433:1433 \
+  #       -d mcr.microsoft.com/mssql/server:2022-latest
+
+  #     # Starting SQL Server container…
+  #     for i in {1..30}; do
+  #       docker exec sqlserver \
+  #         /opt/mssql-tools18/bin/sqlcmd \
+  #         -S localhost \
+  #         -U SA \
+  #         -P "$DB_PASSWORD" \
+  #         -C -Q "SELECT 1" && break
+  #       sleep 2
+  #     done
+  #   displayName: 'Pull & start SQL Server (Docker)'
+  #   env:
+  #     DB_PASSWORD: $(DB_PASSWORD)
+
+  - script: |
+      python -m pip install --upgrade pip
+      pip install -r requirements.txt
+    displayName: 'Install Python dependencies'
+
+  - script: |
+      cd mssql_python/pybind
+      ./build.sh
+    displayName: 'Build pybind bindings (.so)'
+
+  - script: |
+      echo "Build successful, running tests now"
+      python -m pytest -v --junitxml=test-results.xml --cov=. --cov-report=xml --capture=tee-sys --cache-clear
+    displayName: 'Run pytest with coverage'
+    env:
+      # Temporarily Use Azure SQL Database connection string for testing purposes since Docker takes too long to install & start in MacOS
+      DB_CONNECTION_STRING: $(AZURE_CONNECTION_STRING)
+      # DB_CONNECTION_STRING: 'Driver=ODBC Driver 18 for SQL Server;Server=localhost;Database=master;Uid=SA;Pwd=$(DB_PASSWORD);TrustServerCertificate=yes'
+      DB_PASSWORD: $(DB_PASSWORD)
+
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: '**/test-results.xml'
+      testRunTitle: 'Publish pytest results on macOS'
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: 'coverage.xml'
+    displayName: 'Publish code coverage results'


### PR DESCRIPTION
### Summary  
This pull request adds a new job to the `pr-validation-pipeline.yml` file to enable running Python tests on macOS. The job includes steps for setting up the environment, installing dependencies, building bindings, running tests with coverage, and publishing results. Some Docker-related steps are commented out for now.

### Additions to the pipeline:
* **New job for macOS testing**: Added a `PytestOnMacOS` job to the pipeline, which uses the `macos-latest` image to run Python tests.
* **Python environment setup**: Configured the job to use Python 3.13.5 and installed dependencies from `requirements.txt`.
* **Build and test execution**:
  - Built pybind bindings via `build.sh`.
  - Ran `pytest` with coverage and published the results.

### Commented-out Docker-related steps:
* Steps for installing and configuring Docker on macOS, including setting up Colima and running an SQL Server container, are included but commented out for now.

### Issue Reference  
Fixes [AB#37749](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/37749)  

### Checklist  
- [x] **Tests Passed** (if applicable)  
- [x] **Code is formatted**   
- [x] **Docs Updated** (if necessary) 

### Testing Performed  
<!-- How was this fix tested? -->
- [x] Unit Tests