### PR TITLE
FEAT: support for macOS

### DIFF
--- a/eng/pipelines/pr-validation-pipeline.yml
+++ b/eng/pipelines/pr-validation-pipeline.yml
@@ -7,163 +7,38 @@ trigger:
       - main
 
 jobs:
-- job: PytestOnWindows
-  pool:
-    vmImage: 'windows-latest'
-  
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      # TODO: Remove this once Python 3.13 is available in ADO
-      # ADO indexing will take some time to reflect 3.13 as 3.13.5, right now it is pointing to 3.13.4.
-      # We're specifying to use Python 3.13.5 since 3.13.4 has issues with compilation
-      # See https://github.com/python/cpython/issues/135151, next release should fix it.
-      versionSpec: '3.13.5'
-      addToPath: true
-      githubToken: $(GITHUB_TOKEN)
-    displayName: 'Use Python 3.13'
+  - job: TestMacOS
+    pool:
+      vmImage: 'macos-latest'
 
-  - script: |
-      python -m pip install --upgrade pip
-      pip install -r requirements.txt
-    displayName: 'Install dependencies'
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.13.5'
+        addToPath: true
+      displayName: 'Use Python 3.13 on macOS'
 
-  # Start LocalDB instance
-  - powershell: |
-      sqllocaldb create MSSQLLocalDB
-      sqllocaldb start MSSQLLocalDB
-    displayName: 'Start LocalDB instance'
+    - script: |
+        brew update
+        brew install cmake
+      displayName: 'Install CMake'
 
-  # Create database and user
-  - powershell: |
-      sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "CREATE DATABASE TestDB"
-      sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "CREATE LOGIN testuser WITH PASSWORD = '$(DB_PASSWORD)'"
-      sqlcmd -S "(localdb)\MSSQLLocalDB" -d TestDB -Q "CREATE USER testuser FOR LOGIN testuser"
-      sqlcmd -S "(localdb)\MSSQLLocalDB" -d TestDB -Q "ALTER ROLE db_owner ADD MEMBER testuser"
-    displayName: 'Setup database and user'
-    env:
-      DB_PASSWORD: $(DB_PASSWORD)
+    - script: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+      displayName: 'Install Python dependencies'
 
-  - script: |
-      cd mssql_python\pybind
-      build.bat x64
-    displayName: 'Build .pyd file'
+    - script: |
+        cd mssql_python/pybind
+        ./build.sh
+      displayName: 'Build pybind bindings (.so)'
 
-  - script: |
-      python -m pytest -v --junitxml=test-results.xml --cov=. --cov-report=xml --capture=tee-sys --cache-clear
-    displayName: 'Run tests with coverage'
-    env:
-      DB_CONNECTION_STRING: 'Server=(localdb)\MSSQLLocalDB;Database=TestDB;Uid=testuser;Pwd=$(DB_PASSWORD);TrustServerCertificate=yes'
-
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: 'mssql_python/ddbc_bindings.cp313-amd64.pyd'
-      ArtifactName: 'ddbc_bindings'
-      publishLocation: 'Container'
-    displayName: 'Publish pyd file as artifact'
-
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: 'mssql_python/ddbc_bindings.cp313-amd64.pdb'
-      ArtifactName: 'ddbc_bindings'
-      publishLocation: 'Container'
-    displayName: 'Publish pdb file as artifact'
-
-  - task: PublishTestResults@2
-    condition: succeededOrFailed()
-    inputs:
-      testResultsFiles: '**/test-results.xml'
-      testRunTitle: 'Publish test results'
-
-  - task: PublishCodeCoverageResults@1
-    inputs:
-      codeCoverageTool: 'Cobertura'
-      summaryFileLocation: 'coverage.xml'
-    displayName: 'Publish code coverage results'
-
-- job: PytestOnMacOS
-  pool:
-    vmImage: 'macos-latest'
-
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.13.5'
-      addToPath: true
-    displayName: 'Use Python 3.13 on macOS'
-
-  - script: |
-      brew update
-      brew install cmake
-    displayName: 'Install CMake'
-
-  # - script: |
-  #     brew update
-  #     brew install docker colima
-
-  #     # Start Colima with extra resources
-  #     colima start --cpu 4 --memory 8 --disk 50
-
-  #     # Optional: set Docker context (usually automatic)
-  #     docker context use colima >/dev/null || true
-
-  #     # Confirm Docker is operational
-  #     docker version
-  #     docker ps
-  #   displayName: 'Install and start Colima-based Docker'
-
-  # - script: |
-  #     # Pull and run SQL Server container
-  #     docker pull mcr.microsoft.com/mssql/server:2022-latest
-  #     docker run \
-  #       --name sqlserver \
-  #       -e ACCEPT_EULA=Y \
-  #       -e MSSQL_SA_PASSWORD="${DB_PASSWORD}" \
-  #       -p 1433:1433 \
-  #       -d mcr.microsoft.com/mssql/server:2022-latest
-
-  #     # Starting SQL Server container…
-  #     for i in {1..30}; do
-  #       docker exec sqlserver \
-  #         /opt/mssql-tools18/bin/sqlcmd \
-  #         -S localhost \
-  #         -U SA \
-  #         -P "$DB_PASSWORD" \
-  #         -C -Q "SELECT 1" && break
-  #       sleep 2
-  #     done
-  #   displayName: 'Pull & start SQL Server (Docker)'
-  #   env:
-  #     DB_PASSWORD: $(DB_PASSWORD)
-
-  - script: |
-      python -m pip install --upgrade pip
-      pip install -r requirements.txt
-    displayName: 'Install Python dependencies'
-
-  - script: |
-      cd mssql_python/pybind
-      ./build.sh
-    displayName: 'Build pybind bindings (.so)'
-
-  - script: |
-      echo "Build successful, running tests now"
-      python -m pytest -v --junitxml=test-results.xml --cov=. --cov-report=xml --capture=tee-sys --cache-clear
-    displayName: 'Run pytest with coverage'
-    env:
-      # Temporarily Use Azure SQL Database connection string for testing purposes since Docker takes too long to install & start in MacOS
-      DB_CONNECTION_STRING: $(AZURE_CONNECTION_STRING)
-      # DB_CONNECTION_STRING: 'Driver=ODBC Driver 18 for SQL Server;Server=localhost;Database=master;Uid=SA;Pwd=$(DB_PASSWORD);TrustServerCertificate=yes'
-      DB_PASSWORD: $(DB_PASSWORD)
-
-  - task: PublishTestResults@2
-    condition: succeededOrFailed()
-    inputs:
-      testResultsFiles: '**/test-results.xml'
-      testRunTitle: 'Publish pytest results on macOS'
-
-  - task: PublishCodeCoverageResults@1
-    inputs:
-      codeCoverageTool: 'Cobertura'
-      summaryFileLocation: 'coverage.xml'
-    displayName: 'Publish code coverage results'
+    - script: |
+        echo "Build successful, running tests now"
+        python -m pytest -v --junitxml=test-results.xml --cov=. --cov-report=xml --capture=tee-sys --cache-clear
+      displayName: 'Run pytest with coverage'
+      env:
+        # Temporarily Use Azure SQL Database connection string for testing purposes since Docker takes too long to install & start in MacOS
+        DB_CONNECTION_STRING: $(AZURE_CONNECTION_STRING)
+        # DB_CONNECTION_STRING: 'Driver=ODBC Driver 18 for SQL Server;Server=localhost;Database=master;Uid=SA;Pwd=$(DB_PASSWORD);TrustServerCertificate=yes'
+        DB_PASSWORD: $(DB_PASSWORD)

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -67,9 +67,20 @@ void Connection::connect(const py::dict& attrs_before) {
             setAutocommit(_autocommit);
         }
     }
+    SQLWCHAR* connStrPtr;
+#if defined(__APPLE__) // macOS specific code
+    LOG("Creating connection string buffer for macOS");
+    std::vector<SQLWCHAR> connStrBuffer = WStringToSQLWCHAR(_connStr);
+    // Ensure the buffer is null-terminated
+    LOG("Connection string buffer size - {}", connStrBuffer.size());
+    connStrPtr = connStrBuffer.data();
+    LOG("Connection string buffer created");
+#else
+    connStrPtr = const_cast<SQLWCHAR*>(_connStr.c_str());
+#endif
     SQLRETURN ret = SQLDriverConnect_ptr(
         _dbcHandle->get(), nullptr,
-        (SQLWCHAR*)_connStr.c_str(), SQL_NTS,
+        connStrPtr, SQL_NTS,
         nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
     checkError(ret);
     updateLastUsed();

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -12,10 +12,6 @@
 #include <iostream>
 #include <utility>  // std::forward
 
-// Replace std::filesystem usage with Windows-specific headers
-#include <shlwapi.h>
-#pragma comment(lib, "shlwapi.lib")
-
 //-------------------------------------------------------------------------------------------------
 // Macro definitions
 //-------------------------------------------------------------------------------------------------
@@ -193,9 +189,11 @@ ParamType* AllocateParamBuffer(std::vector<std::shared_ptr<void>>& paramBuffers,
 SQLRETURN BindParameters(SQLHANDLE hStmt, const py::list& params,
                          const std::vector<ParamInfo>& paramInfos,
                          std::vector<std::shared_ptr<void>>& paramBuffers) {
+    LOG("Starting parameter binding. Number of parameters: {}", params.size());
     for (int paramIndex = 0; paramIndex < params.size(); paramIndex++) {
         const auto& param = params[paramIndex];
         const ParamInfo& paramInfo = paramInfos[paramIndex];
+        LOG("Binding parameter {} - C Type: {}, SQL Type: {}", paramIndex, paramInfo.paramCType, paramInfo.paramSQLType);
         void* dataPtr = nullptr;
         SQLLEN bufferLength = 0;
         SQLLEN* strLenOrIndPtr = nullptr;
@@ -233,8 +231,44 @@ SQLRETURN BindParameters(SQLHANDLE hStmt, const py::list& params,
                         "Streaming parameters is not yet supported. Parameter size"
                         " must be less than 8192 bytes");
                 }
+                
+                // Log detailed parameter information
+                LOG("SQL_C_WCHAR Parameter[{}]: Length={}, Content='{}'", 
+                    paramIndex, strParam->size(), 
+                    strParam->size() <= 100 ? std::string(strParam->begin(), strParam->end()) : 
+                                             std::string(strParam->begin(), strParam->begin() + 100) + "...");
+                
+                // Log each character's code point for debugging
+                if (strParam->size() <= 20) {
+                    for (size_t i = 0; i < strParam->size(); i++) {
+                        LOG("  char[{}] = {} ({})", i, static_cast<int>((*strParam)[i]), 
+                            ((*strParam)[i] >= 32 && (*strParam)[i] <= 126) ? 
+                            static_cast<char>((*strParam)[i]) : '?');
+                    }
+                }
+#if defined(__APPLE__)
+                // On macOS, we need special handling for wide characters
+                // Create a properly encoded SQLWCHAR buffer for the parameter
+                std::vector<SQLWCHAR>* sqlwcharBuffer = 
+                    AllocateParamBuffer<std::vector<SQLWCHAR>>(paramBuffers);
+                
+                // Reserve space and convert from wstring to SQLWCHAR array
+                sqlwcharBuffer->resize(strParam->size() + 1, 0); // +1 for null terminator
+                
+                // Convert each wchar_t (4 bytes on macOS) to SQLWCHAR (2 bytes)
+                for (size_t i = 0; i < strParam->size(); i++) {
+                    (*sqlwcharBuffer)[i] = static_cast<SQLWCHAR>((*strParam)[i]);
+                }
+                
+                // Use the SQLWCHAR buffer instead of the wstring directly
+                dataPtr = sqlwcharBuffer->data();
+                bufferLength = (strParam->size() + 1) * sizeof(SQLWCHAR);
+                LOG("macOS: Created SQLWCHAR buffer for parameter with size: {} bytes", bufferLength);
+#else
+                // On Windows, wchar_t and SQLWCHAR are the same size, so direct cast works
                 dataPtr = const_cast<void*>(static_cast<const void*>(strParam->c_str()));
                 bufferLength = (strParam->size() + 1 /* null terminator */) * sizeof(wchar_t);
+#endif
                 strLenOrIndPtr = AllocateParamBuffer<SQLLEN>(paramBuffers);
                 *strLenOrIndPtr = SQL_NTS;
                 break;
@@ -464,6 +498,7 @@ SQLRETURN BindParameters(SQLHANDLE hStmt, const py::list& params,
             }
         }
     }
+    LOG("Finished parameter binding. Number of parameters: {}", params.size());
     return SQL_SUCCESS;
 }
 
@@ -511,130 +546,288 @@ std::string GetModuleDirectory() {
     py::object module_path = module.attr("__file__");
     std::string module_file = module_path.cast<std::string>();
     
+#ifdef _WIN32
+    // Windows-specific path handling
     char path[MAX_PATH];
     strncpy_s(path, MAX_PATH, module_file.c_str(), module_file.length());
     PathRemoveFileSpecA(path);
     return std::string(path);
+#else
+    // macOS/Unix path handling without using std::filesystem
+    std::string::size_type pos = module_file.find_last_of('/');
+    if (pos != std::string::npos) {
+        std::string dir = module_file.substr(0, pos);
+        return dir;
+    }
+    std::cerr << "DEBUG: Could not extract directory from path: " << module_file << std::endl;
+    return module_file;
+#endif
 }
 
 // Helper to load the driver
 // TODO: We don't need to do explicit linking using LoadLibrary. We can just use implicit
 //       linking to load this DLL. It will simplify the code a lot.
-std::wstring LoadDriverOrThrowException() {
-    const std::wstring& modulePath = L"";
-    std::wstring ddbcModulePath = modulePath;
-    if (ddbcModulePath.empty()) {
-        // Get the module path if not provided
-        std::string path = GetModuleDirectory();
-        ddbcModulePath = std::wstring(path.begin(), path.end());
-    }
+// std::wstring LoadDriverOrThrowException() {
+//     const std::wstring& modulePath = L"";
+//     std::wstring ddbcModulePath = modulePath;
+//     if (ddbcModulePath.empty()) {
+//         // Get the module path if not provided
+//         std::string path = GetModuleDirectory();
+//         ddbcModulePath = std::wstring(path.begin(), path.end());
+//     }
 
-    std::wstring dllDir = ddbcModulePath;
-    dllDir += L"\\libs\\";
+//     std::wstring dllDir = ddbcModulePath;
+//     dllDir += L"\\libs\\";
     
-    // Convert ARCHITECTURE macro to wstring
-    std::wstring archStr(ARCHITECTURE, ARCHITECTURE + strlen(ARCHITECTURE));
+//     // Convert ARCHITECTURE macro to wstring
+//     std::wstring archStr(ARCHITECTURE, ARCHITECTURE + strlen(ARCHITECTURE));
     
-    // Map architecture identifiers to correct subdirectory names
-    std::wstring archDir;
-    if (archStr == L"win64" || archStr == L"amd64" || archStr == L"x64") {
-        archDir = L"x64";
-    } else if (archStr == L"arm64") {
-        archDir = L"arm64";
+//     // Map architecture identifiers to correct subdirectory names
+//     std::wstring archDir;
+//     if (archStr == L"win64" || archStr == L"amd64" || archStr == L"x64") {
+//         archDir = L"x64";
+//     } else if (archStr == L"arm64") {
+//         archDir = L"arm64";
+//     } else {
+//         archDir = L"x86";
+//     }
+//     dllDir += archDir;
+//     std::wstring mssqlauthDllPath = dllDir + L"\\mssql-auth.dll";
+//     dllDir += L"\\msodbcsql18.dll";
+
+//     // Preload mssql-auth.dll from the same path if available
+//     HMODULE hAuthModule = LoadLibraryW(mssqlauthDllPath.c_str());
+//     if (hAuthModule) {
+//         LOG("Authentication library loaded successfully from - {}", mssqlauthDllPath.c_str());
+//     } else {
+//         LOG("Note: Authentication library not found at - {}. This is OK if you're not using Entra ID Authentication.", mssqlauthDllPath.c_str());
+//     }
+
+//     // Convert wstring to string for logging
+//     LOG("Attempting to load driver from - {}", WideToUTF8(dllDir));
+    
+//     HMODULE hModule = LoadLibraryW(dllDir.c_str());
+//     if (!hModule) {
+//         // Failed to load the DLL, get the error message
+//         DWORD error = GetLastError();
+//         char* messageBuffer = nullptr;
+//         size_t size = FormatMessageA(
+//             FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+//             NULL,
+//             error,
+//             MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+//             (LPSTR)&messageBuffer,
+//             0,
+//             NULL
+//         );
+//         std::string errorMessage = messageBuffer ? std::string(messageBuffer, size) : "Unknown error";
+//         LocalFree(messageBuffer);
+
+//         // Log the error message        
+//         LOG("Failed to load the driver with error code: {} - {}", error, errorMessage);
+//         ThrowStdException("Failed to load the ODBC driver. Please check that it is installed correctly.");
+//     }
+
+//     // If we got here, we've successfully loaded the DLL. Now get the function pointers.
+//     // Environment and handle function loading
+//     SQLAllocHandle_ptr = (SQLAllocHandleFunc)GetProcAddress(hModule, "SQLAllocHandle");
+//     SQLSetEnvAttr_ptr = (SQLSetEnvAttrFunc)GetProcAddress(hModule, "SQLSetEnvAttr");
+//     SQLSetConnectAttr_ptr = (SQLSetConnectAttrFunc)GetProcAddress(hModule, "SQLSetConnectAttrW");
+//     SQLSetStmtAttr_ptr = (SQLSetStmtAttrFunc)GetProcAddress(hModule, "SQLSetStmtAttrW");
+//     SQLGetConnectAttr_ptr = (SQLGetConnectAttrFunc)GetProcAddress(hModule, "SQLGetConnectAttrW");
+
+//     // Connection and statement function loading
+//     SQLDriverConnect_ptr = (SQLDriverConnectFunc)GetProcAddress(hModule, "SQLDriverConnectW");
+//     SQLExecDirect_ptr = (SQLExecDirectFunc)GetProcAddress(hModule, "SQLExecDirectW");
+//     SQLPrepare_ptr = (SQLPrepareFunc)GetProcAddress(hModule, "SQLPrepareW");
+//     SQLBindParameter_ptr = (SQLBindParameterFunc)GetProcAddress(hModule, "SQLBindParameter");
+//     SQLExecute_ptr = (SQLExecuteFunc)GetProcAddress(hModule, "SQLExecute");
+//     SQLRowCount_ptr = (SQLRowCountFunc)GetProcAddress(hModule, "SQLRowCount");
+//     SQLGetStmtAttr_ptr = (SQLGetStmtAttrFunc)GetProcAddress(hModule, "SQLGetStmtAttrW");
+//     SQLSetDescField_ptr = (SQLSetDescFieldFunc)GetProcAddress(hModule, "SQLSetDescFieldW");
+
+//     // Fetch and data retrieval function loading
+//     SQLFetch_ptr = (SQLFetchFunc)GetProcAddress(hModule, "SQLFetch");
+//     SQLFetchScroll_ptr = (SQLFetchScrollFunc)GetProcAddress(hModule, "SQLFetchScroll");
+//     SQLGetData_ptr = (SQLGetDataFunc)GetProcAddress(hModule, "SQLGetData");
+//     SQLNumResultCols_ptr = (SQLNumResultColsFunc)GetProcAddress(hModule, "SQLNumResultCols");
+//     SQLBindCol_ptr = (SQLBindColFunc)GetProcAddress(hModule, "SQLBindCol");
+//     SQLDescribeCol_ptr = (SQLDescribeColFunc)GetProcAddress(hModule, "SQLDescribeColW");
+//     SQLMoreResults_ptr = (SQLMoreResultsFunc)GetProcAddress(hModule, "SQLMoreResults");
+//     SQLColAttribute_ptr = (SQLColAttributeFunc)GetProcAddress(hModule, "SQLColAttributeW");
+
+//     // Transaction functions loading
+//     SQLEndTran_ptr = (SQLEndTranFunc)GetProcAddress(hModule, "SQLEndTran");
+
+//     // Disconnect and free functions loading
+//     SQLFreeHandle_ptr = (SQLFreeHandleFunc)GetProcAddress(hModule, "SQLFreeHandle");
+//     SQLDisconnect_ptr = (SQLDisconnectFunc)GetProcAddress(hModule, "SQLDisconnect");
+//     SQLFreeStmt_ptr = (SQLFreeStmtFunc)GetProcAddress(hModule, "SQLFreeStmt");
+
+//     // Diagnostic record function Loading
+//     SQLGetDiagRec_ptr = (SQLGetDiagRecFunc)GetProcAddress(hModule, "SQLGetDiagRecW");
+
+//     bool success = SQLAllocHandle_ptr && SQLSetEnvAttr_ptr && SQLSetConnectAttr_ptr &&
+//                    SQLSetStmtAttr_ptr && SQLGetConnectAttr_ptr && SQLDriverConnect_ptr &&
+//                    SQLExecDirect_ptr && SQLPrepare_ptr && SQLBindParameter_ptr && SQLExecute_ptr &&
+//                    SQLRowCount_ptr && SQLGetStmtAttr_ptr && SQLSetDescField_ptr && SQLFetch_ptr &&
+//                    SQLFetchScroll_ptr && SQLGetData_ptr && SQLNumResultCols_ptr &&
+//                    SQLBindCol_ptr && SQLDescribeCol_ptr && SQLMoreResults_ptr &&
+//                    SQLColAttribute_ptr && SQLEndTran_ptr && SQLFreeHandle_ptr &&
+//                    SQLDisconnect_ptr && SQLFreeStmt_ptr && SQLGetDiagRec_ptr;
+
+//     if (!success) {
+//         ThrowStdException("Failed to load required function pointers from driver");
+//     }
+//     LOG("Successfully loaded function pointers from driver");
+    
+//     return dllDir;
+// }
+
+// Platform-agnostic function to load the driver dynamic library
+DriverHandle LoadDriverLibrary(const std::string& driverPath) {
+    LOG("Loading driver from path: {}", driverPath);
+    
+#ifdef _WIN32
+    // Windows: Convert string to wide string for LoadLibraryW
+    std::wstring widePath(driverPath.begin(), driverPath.end());
+    return LoadLibraryW(widePath.c_str());
+#else
+    // macOS/Unix: Use dlopen
+    return dlopen(driverPath.c_str(), RTLD_LAZY);
+#endif
+}
+
+// Platform-agnostic function to get last error message
+std::string GetLastErrorMessage() {
+#ifdef _WIN32
+    // Windows: Use FormatMessageA
+    DWORD error = GetLastError();
+    char* messageBuffer = nullptr;
+    size_t size = FormatMessageA(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL,
+        error,
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        (LPSTR)&messageBuffer,
+        0,
+        NULL
+    );
+    std::string errorMessage = messageBuffer ? std::string(messageBuffer, size) : "Unknown error";
+    LocalFree(messageBuffer);
+    return "Error code: " + std::to_string(error) + " - " + errorMessage;
+#else
+    // macOS/Unix: Use dlerror
+    const char* error = dlerror();
+    return error ? std::string(error) : "Unknown error";
+#endif
+}
+
+
+DriverHandle LoadDriverOrThrowException() {
+    std::string moduleDir = GetModuleDirectory();
+    LOG("Module directory: {}", moduleDir);
+
+    std::string archStr = ARCHITECTURE;
+    std::string archDir;
+    if (archStr == "win64" || archStr == "amd64" || archStr == "x64") archDir = "x64";
+    else if (archStr == "arm64") archDir = "arm64";
+    else archDir = "x86";
+
+    std::string driverPath;
+
+#ifdef _WIN32
+    std::string dllDir = moduleDir + "\\libs\\" + archDir + "\\";
+
+    // Optionally load mssql-auth.dll if it exists
+    std::string authDllPath = dllDir + "mssql-auth.dll";
+    HMODULE hAuth = LoadLibraryW(std::wstring(authDllPath.begin(), authDllPath.end()).c_str());
+    if (hAuth) {
+        LOG("Authentication DLL loaded: {}", authDllPath);
     } else {
-        archDir = L"x86";
+        LOG("Note: mssql-auth.dll not found. This is OK if Entra ID is not in use.");
     }
-    dllDir += archDir;
-    std::wstring mssqlauthDllPath = dllDir + L"\\mssql-auth.dll";
-    dllDir += L"\\msodbcsql18.dll";
 
-    // Preload mssql-auth.dll from the same path if available
-    HMODULE hAuthModule = LoadLibraryW(mssqlauthDllPath.c_str());
-    if (hAuthModule) {
-        LOG("Authentication library loaded successfully from - {}", mssqlauthDllPath.c_str());
+    driverPath = dllDir + "msodbcsql18.dll";
+
+#else // macOS only
+    // Determine actual runtime architecture
+    std::string runtimeArch =
+    #if defined(__arm64__) || defined(__aarch64__)
+        "arm64";
+    #else
+        "x86_64";
+    #endif
+
+    std::string primaryPath = moduleDir + "/libs/macos/" + runtimeArch + "/lib/libmsodbcsql.18.dylib";
+    FILE* file = fopen(primaryPath.c_str(), "r");
+    if (file) {
+        fclose(file);
+        driverPath = primaryPath;
+        LOG("macOS driver found at: {}", driverPath);
     } else {
-        LOG("Note: Authentication library not found at - {}. This is OK if you're not using Entra ID Authentication.", mssqlauthDllPath.c_str());
+        driverPath = moduleDir + "/libs/" + archDir + "/macos/libmsodbcsql.18.dylib";
+        LOG("Using fallback macOS driver path: {}", driverPath);
+    }
+#endif
+
+    DriverHandle handle = LoadDriverLibrary(driverPath);
+    if (!handle) {
+        LOG("Failed to load driver: {}", GetLastErrorMessage());
+        ThrowStdException("Failed to load ODBC driver. Please check installation.");
     }
 
-    // Convert wstring to string for logging
-    LOG("Attempting to load driver from - {}", WideToUTF8(dllDir));
-    
-    HMODULE hModule = LoadLibraryW(dllDir.c_str());
-    if (!hModule) {
-        // Failed to load the DLL, get the error message
-        DWORD error = GetLastError();
-        char* messageBuffer = nullptr;
-        size_t size = FormatMessageA(
-            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-            NULL,
-            error,
-            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-            (LPSTR)&messageBuffer,
-            0,
-            NULL
-        );
-        std::string errorMessage = messageBuffer ? std::string(messageBuffer, size) : "Unknown error";
-        LocalFree(messageBuffer);
+    LOG("Driver library successfully loaded.");
 
-        // Log the error message        
-        LOG("Failed to load the driver with error code: {} - {}", error, errorMessage);
-        ThrowStdException("Failed to load the ODBC driver. Please check that it is installed correctly.");
-    }
+    // Load function pointers using helper
+    SQLAllocHandle_ptr = GetFunctionPointer<SQLAllocHandleFunc>(handle, "SQLAllocHandle");
+    SQLSetEnvAttr_ptr = GetFunctionPointer<SQLSetEnvAttrFunc>(handle, "SQLSetEnvAttr");
+    SQLSetConnectAttr_ptr = GetFunctionPointer<SQLSetConnectAttrFunc>(handle, "SQLSetConnectAttrW");
+    SQLSetStmtAttr_ptr = GetFunctionPointer<SQLSetStmtAttrFunc>(handle, "SQLSetStmtAttrW");
+    SQLGetConnectAttr_ptr = GetFunctionPointer<SQLGetConnectAttrFunc>(handle, "SQLGetConnectAttrW");
 
-    // If we got here, we've successfully loaded the DLL. Now get the function pointers.
-    // Environment and handle function loading
-    SQLAllocHandle_ptr = (SQLAllocHandleFunc)GetProcAddress(hModule, "SQLAllocHandle");
-    SQLSetEnvAttr_ptr = (SQLSetEnvAttrFunc)GetProcAddress(hModule, "SQLSetEnvAttr");
-    SQLSetConnectAttr_ptr = (SQLSetConnectAttrFunc)GetProcAddress(hModule, "SQLSetConnectAttrW");
-    SQLSetStmtAttr_ptr = (SQLSetStmtAttrFunc)GetProcAddress(hModule, "SQLSetStmtAttrW");
-    SQLGetConnectAttr_ptr = (SQLGetConnectAttrFunc)GetProcAddress(hModule, "SQLGetConnectAttrW");
+    SQLDriverConnect_ptr = GetFunctionPointer<SQLDriverConnectFunc>(handle, "SQLDriverConnectW");
+    SQLExecDirect_ptr = GetFunctionPointer<SQLExecDirectFunc>(handle, "SQLExecDirectW");
+    SQLPrepare_ptr = GetFunctionPointer<SQLPrepareFunc>(handle, "SQLPrepareW");
+    SQLBindParameter_ptr = GetFunctionPointer<SQLBindParameterFunc>(handle, "SQLBindParameter");
+    SQLExecute_ptr = GetFunctionPointer<SQLExecuteFunc>(handle, "SQLExecute");
+    SQLRowCount_ptr = GetFunctionPointer<SQLRowCountFunc>(handle, "SQLRowCount");
+    SQLGetStmtAttr_ptr = GetFunctionPointer<SQLGetStmtAttrFunc>(handle, "SQLGetStmtAttrW");
+    SQLSetDescField_ptr = GetFunctionPointer<SQLSetDescFieldFunc>(handle, "SQLSetDescFieldW");
 
-    // Connection and statement function loading
-    SQLDriverConnect_ptr = (SQLDriverConnectFunc)GetProcAddress(hModule, "SQLDriverConnectW");
-    SQLExecDirect_ptr = (SQLExecDirectFunc)GetProcAddress(hModule, "SQLExecDirectW");
-    SQLPrepare_ptr = (SQLPrepareFunc)GetProcAddress(hModule, "SQLPrepareW");
-    SQLBindParameter_ptr = (SQLBindParameterFunc)GetProcAddress(hModule, "SQLBindParameter");
-    SQLExecute_ptr = (SQLExecuteFunc)GetProcAddress(hModule, "SQLExecute");
-    SQLRowCount_ptr = (SQLRowCountFunc)GetProcAddress(hModule, "SQLRowCount");
-    SQLGetStmtAttr_ptr = (SQLGetStmtAttrFunc)GetProcAddress(hModule, "SQLGetStmtAttrW");
-    SQLSetDescField_ptr = (SQLSetDescFieldFunc)GetProcAddress(hModule, "SQLSetDescFieldW");
+    SQLFetch_ptr = GetFunctionPointer<SQLFetchFunc>(handle, "SQLFetch");
+    SQLFetchScroll_ptr = GetFunctionPointer<SQLFetchScrollFunc>(handle, "SQLFetchScroll");
+    SQLGetData_ptr = GetFunctionPointer<SQLGetDataFunc>(handle, "SQLGetData");
+    SQLNumResultCols_ptr = GetFunctionPointer<SQLNumResultColsFunc>(handle, "SQLNumResultCols");
+    SQLBindCol_ptr = GetFunctionPointer<SQLBindColFunc>(handle, "SQLBindCol");
+    SQLDescribeCol_ptr = GetFunctionPointer<SQLDescribeColFunc>(handle, "SQLDescribeColW");
+    SQLMoreResults_ptr = GetFunctionPointer<SQLMoreResultsFunc>(handle, "SQLMoreResults");
+    SQLColAttribute_ptr = GetFunctionPointer<SQLColAttributeFunc>(handle, "SQLColAttributeW");
 
-    // Fetch and data retrieval function loading
-    SQLFetch_ptr = (SQLFetchFunc)GetProcAddress(hModule, "SQLFetch");
-    SQLFetchScroll_ptr = (SQLFetchScrollFunc)GetProcAddress(hModule, "SQLFetchScroll");
-    SQLGetData_ptr = (SQLGetDataFunc)GetProcAddress(hModule, "SQLGetData");
-    SQLNumResultCols_ptr = (SQLNumResultColsFunc)GetProcAddress(hModule, "SQLNumResultCols");
-    SQLBindCol_ptr = (SQLBindColFunc)GetProcAddress(hModule, "SQLBindCol");
-    SQLDescribeCol_ptr = (SQLDescribeColFunc)GetProcAddress(hModule, "SQLDescribeColW");
-    SQLMoreResults_ptr = (SQLMoreResultsFunc)GetProcAddress(hModule, "SQLMoreResults");
-    SQLColAttribute_ptr = (SQLColAttributeFunc)GetProcAddress(hModule, "SQLColAttributeW");
+    SQLEndTran_ptr = GetFunctionPointer<SQLEndTranFunc>(handle, "SQLEndTran");
+    SQLDisconnect_ptr = GetFunctionPointer<SQLDisconnectFunc>(handle, "SQLDisconnect");
+    SQLFreeHandle_ptr = GetFunctionPointer<SQLFreeHandleFunc>(handle, "SQLFreeHandle");
+    SQLFreeStmt_ptr = GetFunctionPointer<SQLFreeStmtFunc>(handle, "SQLFreeStmt");
 
-    // Transaction functions loading
-    SQLEndTran_ptr = (SQLEndTranFunc)GetProcAddress(hModule, "SQLEndTran");
+    SQLGetDiagRec_ptr = GetFunctionPointer<SQLGetDiagRecFunc>(handle, "SQLGetDiagRecW");
 
-    // Disconnect and free functions loading
-    SQLFreeHandle_ptr = (SQLFreeHandleFunc)GetProcAddress(hModule, "SQLFreeHandle");
-    SQLDisconnect_ptr = (SQLDisconnectFunc)GetProcAddress(hModule, "SQLDisconnect");
-    SQLFreeStmt_ptr = (SQLFreeStmtFunc)GetProcAddress(hModule, "SQLFreeStmt");
-
-    // Diagnostic record function Loading
-    SQLGetDiagRec_ptr = (SQLGetDiagRecFunc)GetProcAddress(hModule, "SQLGetDiagRecW");
-
-    bool success = SQLAllocHandle_ptr && SQLSetEnvAttr_ptr && SQLSetConnectAttr_ptr &&
-                   SQLSetStmtAttr_ptr && SQLGetConnectAttr_ptr && SQLDriverConnect_ptr &&
-                   SQLExecDirect_ptr && SQLPrepare_ptr && SQLBindParameter_ptr && SQLExecute_ptr &&
-                   SQLRowCount_ptr && SQLGetStmtAttr_ptr && SQLSetDescField_ptr && SQLFetch_ptr &&
-                   SQLFetchScroll_ptr && SQLGetData_ptr && SQLNumResultCols_ptr &&
-                   SQLBindCol_ptr && SQLDescribeCol_ptr && SQLMoreResults_ptr &&
-                   SQLColAttribute_ptr && SQLEndTran_ptr && SQLFreeHandle_ptr &&
-                   SQLDisconnect_ptr && SQLFreeStmt_ptr && SQLGetDiagRec_ptr;
+    bool success =
+        SQLAllocHandle_ptr && SQLSetEnvAttr_ptr && SQLSetConnectAttr_ptr &&
+        SQLSetStmtAttr_ptr && SQLGetConnectAttr_ptr && SQLDriverConnect_ptr &&
+        SQLExecDirect_ptr && SQLPrepare_ptr && SQLBindParameter_ptr &&
+        SQLExecute_ptr && SQLRowCount_ptr && SQLGetStmtAttr_ptr &&
+        SQLSetDescField_ptr && SQLFetch_ptr && SQLFetchScroll_ptr &&
+        SQLGetData_ptr && SQLNumResultCols_ptr && SQLBindCol_ptr &&
+        SQLDescribeCol_ptr && SQLMoreResults_ptr && SQLColAttribute_ptr &&
+        SQLEndTran_ptr && SQLDisconnect_ptr && SQLFreeHandle_ptr &&
+        SQLFreeStmt_ptr && SQLGetDiagRec_ptr;
 
     if (!success) {
-        ThrowStdException("Failed to load required function pointers from driver");
+        ThrowStdException("Missing required ODBC function pointers.");
     }
-    LOG("Successfully loaded function pointers from driver");
-    
-    return dllDir;
+
+    LOG("All driver function pointers successfully loaded.");
+    return handle;
 }
 
 // DriverLoader definition 
@@ -729,7 +922,14 @@ SQLRETURN SQLExecDirect_wrap(SqlHandlePtr StatementHandle, const std::wstring& Q
         DriverLoader::getInstance().loadDriver();  // Load the driver
     }
 
-    SQLRETURN ret = SQLExecDirect_ptr(StatementHandle->get(), const_cast<SQLWCHAR*>(Query.c_str()), SQL_NTS);
+    SQLWCHAR* queryPtr;
+#if defined(__APPLE__)
+    std::vector<SQLWCHAR> queryBuffer = WStringToSQLWCHAR(Query);
+    queryPtr = queryBuffer.data();
+#else
+    queryPtr = const_cast<SQLWCHAR*>(Query.c_str());
+#endif
+    SQLRETURN ret = SQLExecDirect_ptr(StatementHandle->get(), queryPtr, SQL_NTS);
     if (!SQL_SUCCEEDED(ret)) {
         LOG("Failed to execute query directly");
     }
@@ -761,7 +961,13 @@ SQLRETURN SQLExecute_wrap(const SqlHandlePtr statementHandle,
     if (!statementHandle || !statementHandle->get()) {
         LOG("Statement handle is null or empty");
     }
-    SQLWCHAR* queryPtr = const_cast<SQLWCHAR*>(query.c_str());
+    SQLWCHAR* queryPtr;
+#if defined(__APPLE__)
+    std::vector<SQLWCHAR> queryBuffer = WStringToSQLWCHAR(query);
+    queryPtr = queryBuffer.data();
+#else
+    queryPtr = const_cast<SQLWCHAR*>(query.c_str());
+#endif
     if (params.size() == 0) {
         // Execute statement directly if the statement is not parametrized. This is the
         // fastest way to submit a SQL statement for one-time execution according to
@@ -861,7 +1067,11 @@ SQLRETURN SQLDescribeCol_wrap(SqlHandlePtr StatementHandle, py::list& ColumnMeta
         if (SQL_SUCCEEDED(retcode)) {
             // Append a named py::dict to ColumnMetadata
             // TODO: Should we define a struct for this task instead of dict?
+#if defined(__APPLE__)
+            ColumnMetadata.append(py::dict("ColumnName"_a = SQLWCHARToWString(ColumnName),
+#else
             ColumnMetadata.append(py::dict("ColumnName"_a = std::wstring(ColumnName),
+#endif
                                            "DataType"_a = DataType, "ColumnSize"_a = ColumnSize,
                                            "DecimalDigits"_a = DecimalDigits,
                                            "Nullable"_a = Nullable));
@@ -932,7 +1142,13 @@ SQLRETURN SQLGetData_wrap(SqlHandlePtr StatementHandle, SQLUSMALLINT colCount, p
                         // NOTE: dataBuffer.size() includes null-terminator, dataLen doesn't. Hence use '<'.
 						if (numCharsInData < dataBuffer.size()) {
                             // SQLGetData will null-terminate the data
+#if defined(__APPLE__)
+                            std::string fullStr(reinterpret_cast<char*>(dataBuffer.data()));
+                            row.append(fullStr);
+                            LOG("macOS: Appended CHAR string of length {} to result row", fullStr.length());
+#else
                             row.append(std::string(reinterpret_cast<char*>(dataBuffer.data())));
+#endif
 						} else {
                             // In this case, buffer size is smaller, and data to be retrieved is longer
                             // TODO: Revisit
@@ -975,7 +1191,11 @@ SQLRETURN SQLGetData_wrap(SqlHandlePtr StatementHandle, SQLUSMALLINT colCount, p
                         uint64_t numCharsInData = dataLen / sizeof(SQLWCHAR);
 						if (numCharsInData < dataBuffer.size()) {
                             // SQLGetData will null-terminate the data
+#if defined(__APPLE__)
+                            row.append(SQLWCHARToWString(dataBuffer.data()));
+#else
                             row.append(std::wstring(dataBuffer.data()));
+#endif
 						} else {
                             // In this case, buffer size is smaller, and data to be retrieved is longer
                             // TODO: Revisit
@@ -1484,9 +1704,17 @@ SQLRETURN FetchBatchData(SQLHSTMT hStmt, ColumnBuffers& buffers, py::list& colum
 					// fetchBufferSize includes null-terminator, numCharsInData doesn't. Hence '<'
                     if (numCharsInData < fetchBufferSize) {
                         // SQLFetch will nullterminate the data
+#if defined(__APPLE__)
+                        // Use macOS-specific conversion to handle the wchar_t/SQLWCHAR size difference
+                        SQLWCHAR* wcharData = &buffers.wcharBuffers[col - 1][i * fetchBufferSize];
+                        std::wstring wstr = SQLWCHARToWString(wcharData, numCharsInData);
+                        row.append(wstr);
+#else
+                        // On Windows, wchar_t and SQLWCHAR are both 2 bytes, so direct cast works
                         row.append(std::wstring(
                             reinterpret_cast<wchar_t*>(&buffers.wcharBuffers[col - 1][i * fetchBufferSize]),
                             numCharsInData));
+#endif                        
                     } else {
                         // In this case, buffer size is smaller, and data to be retrieved is longer
                         // TODO: Revisit


### PR DESCRIPTION
This pull request includes significant changes to the pipeline configuration and platform-specific code in the `mssql_python` module. The pipeline changes primarily involve the removal of Windows-based and macOS-specific test jobs, while the code changes introduce platform-specific handling for macOS in the `mssql_python` module to improve compatibility and maintainability.

### Pipeline Configuration Changes:
* Removed the `PytestOnWindows` job, including all steps related to setting up the environment, running tests, and publishing results. This simplifies the pipeline by eliminating Windows-specific configurations.
* Removed commented-out macOS-specific Docker setup steps and related SQL Server container initialization, further streamlining the pipeline configuration.
* Removed the publication of test results and code coverage for macOS, likely as part of a broader pipeline cleanup.

### Platform-Specific Code Enhancements:
* Added macOS-specific handling for connection strings in `Connection::connect` to ensure proper encoding and memory safety for SQLWCHAR buffers.
* Introduced platform-specific headers and helper functions in `ddbc_bindings.h` for macOS, including string conversion utilities and platform-agnostic driver handle management. [[1]](diffhunk://#diff-85167a2d59779df18704284ab7ce46220c3619408fbf22c631ffdf29f794d635R18-R63) [[2]](diffhunk://#diff-85167a2d59779df18704284ab7ce46220c3619408fbf22c631ffdf29f794d635R179-R202)
* Included macOS-specific modules (`mac_fix.h` and `mac_buffers.h`) for Unicode encoding and buffer handling to address platform-specific quirks.
### Checklist  
- [ ] **Tests Passed** (if applicable)  