### PR TITLE
FEAT: Unify DDBC Bindings - Common Code Consolidation Across Windows/macOS

### DIFF
--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -11,10 +11,7 @@
 #include <iomanip>  // std::setw, std::setfill
 #include <iostream>
 #include <utility>  // std::forward
-
-// Replace std::filesystem usage with Windows-specific headers
-#include <shlwapi.h>
-#pragma comment(lib, "shlwapi.lib")
+#include <filesystem>
 
 //-------------------------------------------------------------------------------------------------
 // Macro definitions
@@ -193,9 +190,11 @@ ParamType* AllocateParamBuffer(std::vector<std::shared_ptr<void>>& paramBuffers,
 SQLRETURN BindParameters(SQLHANDLE hStmt, const py::list& params,
                          const std::vector<ParamInfo>& paramInfos,
                          std::vector<std::shared_ptr<void>>& paramBuffers) {
+    LOG("Starting parameter binding. Number of parameters: {}", params.size());
     for (int paramIndex = 0; paramIndex < params.size(); paramIndex++) {
         const auto& param = params[paramIndex];
         const ParamInfo& paramInfo = paramInfos[paramIndex];
+        LOG("Binding parameter {} - C Type: {}, SQL Type: {}", paramIndex, paramInfo.paramCType, paramInfo.paramSQLType);
         void* dataPtr = nullptr;
         SQLLEN bufferLength = 0;
         SQLLEN* strLenOrIndPtr = nullptr;
@@ -233,8 +232,46 @@ SQLRETURN BindParameters(SQLHANDLE hStmt, const py::list& params,
                         "Streaming parameters is not yet supported. Parameter size"
                         " must be less than 8192 bytes");
                 }
+                
+                // Log detailed parameter information
+                LOG("SQL_C_WCHAR Parameter[{}]: Length={}, Content='{}'",
+                    paramIndex,
+                    strParam->size(),
+                    (strParam->size() <= 100
+                        ? WideToUTF8(std::wstring(strParam->begin(), strParam->end()))
+                        : WideToUTF8(std::wstring(strParam->begin(), strParam->begin() + 100)) + "..."));
+
+                // Log each character's code point for debugging
+                if (strParam->size() <= 20) {
+                    for (size_t i = 0; i < strParam->size(); i++) {
+                        LOG("  char[{}] = {} ({})", i, static_cast<int>((*strParam)[i]),
+                            ((*strParam)[i] >= 32 && (*strParam)[i] <= 126) ?
+                            static_cast<char>((*strParam)[i]) : '?');
+                    }
+                }
+#if defined(__APPLE__)
+                // On macOS, we need special handling for wide characters
+                // Create a properly encoded SQLWCHAR buffer for the parameter
+                std::vector<SQLWCHAR>* sqlwcharBuffer =
+                    AllocateParamBuffer<std::vector<SQLWCHAR>>(paramBuffers);
+
+                // Reserve space and convert from wstring to SQLWCHAR array
+                sqlwcharBuffer->resize(strParam->size() + 1, 0); // +1 for null terminator
+
+                // Convert each wchar_t (4 bytes on macOS) to SQLWCHAR (2 bytes)
+                for (size_t i = 0; i < strParam->size(); i++) {
+                    (*sqlwcharBuffer)[i] = static_cast<SQLWCHAR>((*strParam)[i]);
+                }
+
+                // Use the SQLWCHAR buffer instead of the wstring directly
+                dataPtr = sqlwcharBuffer->data();
+                bufferLength = (strParam->size() + 1) * sizeof(SQLWCHAR);
+                LOG("macOS: Created SQLWCHAR buffer for parameter with size: {} bytes", bufferLength);
+#else
+                // On Windows, wchar_t and SQLWCHAR are the same size, so direct cast works
                 dataPtr = const_cast<void*>(static_cast<const void*>(strParam->c_str()));
                 bufferLength = (strParam->size() + 1 /* null terminator */) * sizeof(wchar_t);
+#endif
                 strLenOrIndPtr = AllocateParamBuffer<SQLLEN>(paramBuffers);
                 *strLenOrIndPtr = SQL_NTS;
                 break;
@@ -464,6 +501,7 @@ SQLRETURN BindParameters(SQLHANDLE hStmt, const py::list& params,
             }
         }
     }
+    LOG("Finished parameter binding. Number of parameters: {}", params.size());
     return SQL_SUCCESS;
 }
 
@@ -495,14 +533,6 @@ void LOG(const std::string& formatString, Args&&... args) {
     logging.attr("debug")(message);
 }
 
-std::string WideToUTF8(const std::wstring& wstr) {
-    if (wstr.empty()) return {};
-    int size_needed = WideCharToMultiByte(CP_UTF8, 0, wstr.data(), (int)wstr.size(), nullptr, 0, nullptr, nullptr);
-    std::string result(size_needed, 0);
-    WideCharToMultiByte(CP_UTF8, 0, wstr.data(), (int)wstr.size(), result.data(), size_needed, nullptr, nullptr);
-    return result;
-}
-
 // TODO: Add more nuanced exception classes
 void ThrowStdException(const std::string& message) { throw std::runtime_error(message); }
 
@@ -511,130 +541,168 @@ std::string GetModuleDirectory() {
     py::object module_path = module.attr("__file__");
     std::string module_file = module_path.cast<std::string>();
     
+#ifdef _WIN32
+    // Windows-specific path handling
     char path[MAX_PATH];
     strncpy_s(path, MAX_PATH, module_file.c_str(), module_file.length());
     PathRemoveFileSpecA(path);
     return std::string(path);
+#else
+    // macOS/Unix path handling without using std::filesystem
+    std::string::size_type pos = module_file.find_last_of('/');
+    if (pos != std::string::npos) {
+        std::string dir = module_file.substr(0, pos);
+        return dir;
+    }
+    std::cerr << "DEBUG: Could not extract directory from path: " << module_file << std::endl;
+    return module_file;
+#endif
+}
+
+// Platform-agnostic function to load the driver dynamic library
+DriverHandle LoadDriverLibrary(const std::string& driverPath) {
+    LOG("Loading driver from path: {}", driverPath);
+
+#ifdef _WIN32
+    // Windows: Convert string to wide string for LoadLibraryW
+    std::wstring widePath(driverPath.begin(), driverPath.end());
+    return LoadLibraryW(widePath.c_str());
+#else
+    // macOS/Unix: Use dlopen
+    return dlopen(driverPath.c_str(), RTLD_LAZY);
+#endif
+}
+
+// Platform-agnostic function to get last error message
+std::string GetLastErrorMessage() {
+#ifdef _WIN32
+    // Windows: Use FormatMessageA
+    DWORD error = GetLastError();
+    char* messageBuffer = nullptr;
+    size_t size = FormatMessageA(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL,
+        error,
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        (LPSTR)&messageBuffer,
+        0,
+        NULL
+    );
+    std::string errorMessage = messageBuffer ? std::string(messageBuffer, size) : "Unknown error";
+    LocalFree(messageBuffer);
+    return "Error code: " + std::to_string(error) + " - " + errorMessage;
+#else
+    // macOS/Unix: Use dlerror
+    const char* error = dlerror();
+    return error ? std::string(error) : "Unknown error";
+#endif
 }
 
 // Helper to load the driver
 // TODO: We don't need to do explicit linking using LoadLibrary. We can just use implicit
 //       linking to load this DLL. It will simplify the code a lot.
-std::wstring LoadDriverOrThrowException() {
-    const std::wstring& modulePath = L"";
-    std::wstring ddbcModulePath = modulePath;
-    if (ddbcModulePath.empty()) {
-        // Get the module path if not provided
-        std::string path = GetModuleDirectory();
-        ddbcModulePath = std::wstring(path.begin(), path.end());
-    }
+DriverHandle LoadDriverOrThrowException() {
+    namespace fs = std::filesystem;
+    std::string moduleDir = GetModuleDirectory();
+    LOG("Module directory: {}", moduleDir);
+    std::string archStr = ARCHITECTURE;
+    std::string archDir =
+        (archStr == "win64" || archStr == "amd64" || archStr == "x64") ? "x64" :
+        (archStr == "arm64") ? "arm64" :
+        "x86";
 
-    std::wstring dllDir = ddbcModulePath;
-    dllDir += L"\\libs\\";
-    
-    // Convert ARCHITECTURE macro to wstring
-    std::wstring archStr(ARCHITECTURE, ARCHITECTURE + strlen(ARCHITECTURE));
-    
-    // Map architecture identifiers to correct subdirectory names
-    std::wstring archDir;
-    if (archStr == L"win64" || archStr == L"amd64" || archStr == L"x64") {
-        archDir = L"x64";
-    } else if (archStr == L"arm64") {
-        archDir = L"arm64";
+    fs::path driverPath;
+#ifdef _WIN32
+    fs::path dllDir = fs::path(moduleDir) / "libs" / archDir;
+
+    // Optionally load mssql-auth.dll if it exists
+    fs::path authDllPath = dllDir / "mssql-auth.dll";
+    if (fs::exists(authDllPath)) {
+        HMODULE hAuth = LoadLibraryW(std::wstring(authDllPath.native().begin(), authDllPath.native().end()).c_str());
+        if (hAuth) {
+            LOG("Authentication DLL loaded: {}", authDllPath.string());
+        } else {
+            LOG("Failed to load mssql-auth.dll: {}", GetLastErrorMessage());
+        }
     } else {
-        archDir = L"x86";
+        LOG("Note: mssql-auth.dll not found. This is OK if Entra ID is not in use.");
     }
-    dllDir += archDir;
-    std::wstring mssqlauthDllPath = dllDir + L"\\mssql-auth.dll";
-    dllDir += L"\\msodbcsql18.dll";
 
-    // Preload mssql-auth.dll from the same path if available
-    HMODULE hAuthModule = LoadLibraryW(mssqlauthDllPath.c_str());
-    if (hAuthModule) {
-        LOG("Authentication library loaded successfully from - {}", mssqlauthDllPath.c_str());
+    driverPath = dllDir / "msodbcsql18.dll";
+#else // macOS
+    std::string runtimeArch =
+    #if defined(__arm64__) || defined(__aarch64__)
+        "arm64";
+    #else
+        "x86_64";
+    #endif
+    fs::path primaryPath = fs::path(moduleDir) / "libs" / "macos" / runtimeArch / "lib" / "libmsodbcsql.18.dylib";
+    if (fs::exists(primaryPath)) {
+        driverPath = primaryPath;
+        LOG("macOS driver found at: {}", driverPath.string());
     } else {
-        LOG("Note: Authentication library not found at - {}. This is OK if you're not using Entra ID Authentication.", mssqlauthDllPath.c_str());
+        driverPath = fs::path(moduleDir) / "libs" / archDir / "macos" / "lib" / "libmsodbcsql.18.dylib";
+        LOG("Using fallback macOS driver path: {}", driverPath.string());
     }
-
-    // Convert wstring to string for logging
-    LOG("Attempting to load driver from - {}", WideToUTF8(dllDir));
-    
-    HMODULE hModule = LoadLibraryW(dllDir.c_str());
-    if (!hModule) {
-        // Failed to load the DLL, get the error message
-        DWORD error = GetLastError();
-        char* messageBuffer = nullptr;
-        size_t size = FormatMessageA(
-            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-            NULL,
-            error,
-            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-            (LPSTR)&messageBuffer,
-            0,
-            NULL
-        );
-        std::string errorMessage = messageBuffer ? std::string(messageBuffer, size) : "Unknown error";
-        LocalFree(messageBuffer);
-
-        // Log the error message        
-        LOG("Failed to load the driver with error code: {} - {}", error, errorMessage);
-        ThrowStdException("Failed to load the ODBC driver. Please check that it is installed correctly.");
+#endif
+    if (!fs::exists(driverPath)) {
+        ThrowStdException("ODBC driver not found at: " + driverPath.string());
     }
+    DriverHandle handle = LoadDriverLibrary(driverPath.string());
+    if (!handle) {
+        LOG("Failed to load driver: {}", GetLastErrorMessage());
+        ThrowStdException("Failed to load ODBC driver. Please check installation.");
+    }
+    LOG("Driver library successfully loaded.");
 
-    // If we got here, we've successfully loaded the DLL. Now get the function pointers.
-    // Environment and handle function loading
-    SQLAllocHandle_ptr = (SQLAllocHandleFunc)GetProcAddress(hModule, "SQLAllocHandle");
-    SQLSetEnvAttr_ptr = (SQLSetEnvAttrFunc)GetProcAddress(hModule, "SQLSetEnvAttr");
-    SQLSetConnectAttr_ptr = (SQLSetConnectAttrFunc)GetProcAddress(hModule, "SQLSetConnectAttrW");
-    SQLSetStmtAttr_ptr = (SQLSetStmtAttrFunc)GetProcAddress(hModule, "SQLSetStmtAttrW");
-    SQLGetConnectAttr_ptr = (SQLGetConnectAttrFunc)GetProcAddress(hModule, "SQLGetConnectAttrW");
+    // Load function pointers using helper
+    SQLAllocHandle_ptr = GetFunctionPointer<SQLAllocHandleFunc>(handle, "SQLAllocHandle");
+    SQLSetEnvAttr_ptr = GetFunctionPointer<SQLSetEnvAttrFunc>(handle, "SQLSetEnvAttr");
+    SQLSetConnectAttr_ptr = GetFunctionPointer<SQLSetConnectAttrFunc>(handle, "SQLSetConnectAttrW");
+    SQLSetStmtAttr_ptr = GetFunctionPointer<SQLSetStmtAttrFunc>(handle, "SQLSetStmtAttrW");
+    SQLGetConnectAttr_ptr = GetFunctionPointer<SQLGetConnectAttrFunc>(handle, "SQLGetConnectAttrW");
 
-    // Connection and statement function loading
-    SQLDriverConnect_ptr = (SQLDriverConnectFunc)GetProcAddress(hModule, "SQLDriverConnectW");
-    SQLExecDirect_ptr = (SQLExecDirectFunc)GetProcAddress(hModule, "SQLExecDirectW");
-    SQLPrepare_ptr = (SQLPrepareFunc)GetProcAddress(hModule, "SQLPrepareW");
-    SQLBindParameter_ptr = (SQLBindParameterFunc)GetProcAddress(hModule, "SQLBindParameter");
-    SQLExecute_ptr = (SQLExecuteFunc)GetProcAddress(hModule, "SQLExecute");
-    SQLRowCount_ptr = (SQLRowCountFunc)GetProcAddress(hModule, "SQLRowCount");
-    SQLGetStmtAttr_ptr = (SQLGetStmtAttrFunc)GetProcAddress(hModule, "SQLGetStmtAttrW");
-    SQLSetDescField_ptr = (SQLSetDescFieldFunc)GetProcAddress(hModule, "SQLSetDescFieldW");
+    SQLDriverConnect_ptr = GetFunctionPointer<SQLDriverConnectFunc>(handle, "SQLDriverConnectW");
+    SQLExecDirect_ptr = GetFunctionPointer<SQLExecDirectFunc>(handle, "SQLExecDirectW");
+    SQLPrepare_ptr = GetFunctionPointer<SQLPrepareFunc>(handle, "SQLPrepareW");
+    SQLBindParameter_ptr = GetFunctionPointer<SQLBindParameterFunc>(handle, "SQLBindParameter");
+    SQLExecute_ptr = GetFunctionPointer<SQLExecuteFunc>(handle, "SQLExecute");
+    SQLRowCount_ptr = GetFunctionPointer<SQLRowCountFunc>(handle, "SQLRowCount");
+    SQLGetStmtAttr_ptr = GetFunctionPointer<SQLGetStmtAttrFunc>(handle, "SQLGetStmtAttrW");
+    SQLSetDescField_ptr = GetFunctionPointer<SQLSetDescFieldFunc>(handle, "SQLSetDescFieldW");
 
-    // Fetch and data retrieval function loading
-    SQLFetch_ptr = (SQLFetchFunc)GetProcAddress(hModule, "SQLFetch");
-    SQLFetchScroll_ptr = (SQLFetchScrollFunc)GetProcAddress(hModule, "SQLFetchScroll");
-    SQLGetData_ptr = (SQLGetDataFunc)GetProcAddress(hModule, "SQLGetData");
-    SQLNumResultCols_ptr = (SQLNumResultColsFunc)GetProcAddress(hModule, "SQLNumResultCols");
-    SQLBindCol_ptr = (SQLBindColFunc)GetProcAddress(hModule, "SQLBindCol");
-    SQLDescribeCol_ptr = (SQLDescribeColFunc)GetProcAddress(hModule, "SQLDescribeColW");
-    SQLMoreResults_ptr = (SQLMoreResultsFunc)GetProcAddress(hModule, "SQLMoreResults");
-    SQLColAttribute_ptr = (SQLColAttributeFunc)GetProcAddress(hModule, "SQLColAttributeW");
+    SQLFetch_ptr = GetFunctionPointer<SQLFetchFunc>(handle, "SQLFetch");
+    SQLFetchScroll_ptr = GetFunctionPointer<SQLFetchScrollFunc>(handle, "SQLFetchScroll");
+    SQLGetData_ptr = GetFunctionPointer<SQLGetDataFunc>(handle, "SQLGetData");
+    SQLNumResultCols_ptr = GetFunctionPointer<SQLNumResultColsFunc>(handle, "SQLNumResultCols");
+    SQLBindCol_ptr = GetFunctionPointer<SQLBindColFunc>(handle, "SQLBindCol");
+    SQLDescribeCol_ptr = GetFunctionPointer<SQLDescribeColFunc>(handle, "SQLDescribeColW");
+    SQLMoreResults_ptr = GetFunctionPointer<SQLMoreResultsFunc>(handle, "SQLMoreResults");
+    SQLColAttribute_ptr = GetFunctionPointer<SQLColAttributeFunc>(handle, "SQLColAttributeW");
 
-    // Transaction functions loading
-    SQLEndTran_ptr = (SQLEndTranFunc)GetProcAddress(hModule, "SQLEndTran");
+    SQLEndTran_ptr = GetFunctionPointer<SQLEndTranFunc>(handle, "SQLEndTran");
+    SQLDisconnect_ptr = GetFunctionPointer<SQLDisconnectFunc>(handle, "SQLDisconnect");
+    SQLFreeHandle_ptr = GetFunctionPointer<SQLFreeHandleFunc>(handle, "SQLFreeHandle");
+    SQLFreeStmt_ptr = GetFunctionPointer<SQLFreeStmtFunc>(handle, "SQLFreeStmt");
 
-    // Disconnect and free functions loading
-    SQLFreeHandle_ptr = (SQLFreeHandleFunc)GetProcAddress(hModule, "SQLFreeHandle");
-    SQLDisconnect_ptr = (SQLDisconnectFunc)GetProcAddress(hModule, "SQLDisconnect");
-    SQLFreeStmt_ptr = (SQLFreeStmtFunc)GetProcAddress(hModule, "SQLFreeStmt");
+    SQLGetDiagRec_ptr = GetFunctionPointer<SQLGetDiagRecFunc>(handle, "SQLGetDiagRecW");
 
-    // Diagnostic record function Loading
-    SQLGetDiagRec_ptr = (SQLGetDiagRecFunc)GetProcAddress(hModule, "SQLGetDiagRecW");
-
-    bool success = SQLAllocHandle_ptr && SQLSetEnvAttr_ptr && SQLSetConnectAttr_ptr &&
-                   SQLSetStmtAttr_ptr && SQLGetConnectAttr_ptr && SQLDriverConnect_ptr &&
-                   SQLExecDirect_ptr && SQLPrepare_ptr && SQLBindParameter_ptr && SQLExecute_ptr &&
-                   SQLRowCount_ptr && SQLGetStmtAttr_ptr && SQLSetDescField_ptr && SQLFetch_ptr &&
-                   SQLFetchScroll_ptr && SQLGetData_ptr && SQLNumResultCols_ptr &&
-                   SQLBindCol_ptr && SQLDescribeCol_ptr && SQLMoreResults_ptr &&
-                   SQLColAttribute_ptr && SQLEndTran_ptr && SQLFreeHandle_ptr &&
-                   SQLDisconnect_ptr && SQLFreeStmt_ptr && SQLGetDiagRec_ptr;
+    bool success =
+        SQLAllocHandle_ptr && SQLSetEnvAttr_ptr && SQLSetConnectAttr_ptr &&
+        SQLSetStmtAttr_ptr && SQLGetConnectAttr_ptr && SQLDriverConnect_ptr &&
+        SQLExecDirect_ptr && SQLPrepare_ptr && SQLBindParameter_ptr &&
+        SQLExecute_ptr && SQLRowCount_ptr && SQLGetStmtAttr_ptr &&
+        SQLSetDescField_ptr && SQLFetch_ptr && SQLFetchScroll_ptr &&
+        SQLGetData_ptr && SQLNumResultCols_ptr && SQLBindCol_ptr &&
+        SQLDescribeCol_ptr && SQLMoreResults_ptr && SQLColAttribute_ptr &&
+        SQLEndTran_ptr && SQLDisconnect_ptr && SQLFreeHandle_ptr &&
+        SQLFreeStmt_ptr && SQLGetDiagRec_ptr;
 
     if (!success) {
-        ThrowStdException("Failed to load required function pointers from driver");
+        ThrowStdException("Missing required ODBC function pointers.");
     }
-    LOG("Successfully loaded function pointers from driver");
-    
-    return dllDir;
+    LOG("All driver function pointers successfully loaded.");
+    return handle;
 }
 
 // DriverLoader definition 
@@ -714,8 +782,15 @@ ErrorInfo SQLCheckError_Wrap(SQLSMALLINT handleType, SqlHandlePtr handle, SQLRET
                               &nativeError, message, SQL_MAX_MESSAGE_LENGTH, &messageLen);
 
         if (SQL_SUCCEEDED(diagReturn)) {
+#if defined(_WIN32)
+            // On Windows, SQLWCHAR and wchar_t are compatible
             errorInfo.sqlState = std::wstring(sqlState);
             errorInfo.ddbcErrorMsg = std::wstring(message);
+#else
+            // On macOS/Linux, need to convert SQLWCHAR (usually unsigned short) to wchar_t
+            errorInfo.sqlState = SQLWCHARToWString(sqlState);
+            errorInfo.ddbcErrorMsg = SQLWCHARToWString(message, messageLen);
+#endif
         }
     }
     return errorInfo;
@@ -729,7 +804,14 @@ SQLRETURN SQLExecDirect_wrap(SqlHandlePtr StatementHandle, const std::wstring& Q
         DriverLoader::getInstance().loadDriver();  // Load the driver
     }
 
-    SQLRETURN ret = SQLExecDirect_ptr(StatementHandle->get(), const_cast<SQLWCHAR*>(Query.c_str()), SQL_NTS);
+    SQLWCHAR* queryPtr;
+#if defined(__APPLE__)
+    std::vector<SQLWCHAR> queryBuffer = WStringToSQLWCHAR(Query);
+    queryPtr = queryBuffer.data();
+#else
+    queryPtr = const_cast<SQLWCHAR*>(Query.c_str());
+#endif
+    SQLRETURN ret = SQLExecDirect_ptr(StatementHandle->get(), queryPtr, SQL_NTS);
     if (!SQL_SUCCEEDED(ret)) {
         LOG("Failed to execute query directly");
     }
@@ -761,7 +843,13 @@ SQLRETURN SQLExecute_wrap(const SqlHandlePtr statementHandle,
     if (!statementHandle || !statementHandle->get()) {
         LOG("Statement handle is null or empty");
     }
-    SQLWCHAR* queryPtr = const_cast<SQLWCHAR*>(query.c_str());
+    SQLWCHAR* queryPtr;
+#if defined(__APPLE__)
+    std::vector<SQLWCHAR> queryBuffer = WStringToSQLWCHAR(query);
+    queryPtr = queryBuffer.data();
+#else
+    queryPtr = const_cast<SQLWCHAR*>(query.c_str());
+#endif
     if (params.size() == 0) {
         // Execute statement directly if the statement is not parametrized. This is the
         // fastest way to submit a SQL statement for one-time execution according to
@@ -861,7 +949,11 @@ SQLRETURN SQLDescribeCol_wrap(SqlHandlePtr StatementHandle, py::list& ColumnMeta
         if (SQL_SUCCEEDED(retcode)) {
             // Append a named py::dict to ColumnMetadata
             // TODO: Should we define a struct for this task instead of dict?
+#if defined(__APPLE__)
+            ColumnMetadata.append(py::dict("ColumnName"_a = SQLWCHARToWString(ColumnName, SQL_NTS),
+#else
             ColumnMetadata.append(py::dict("ColumnName"_a = std::wstring(ColumnName),
+#endif
                                            "DataType"_a = DataType, "ColumnSize"_a = ColumnSize,
                                            "DecimalDigits"_a = DecimalDigits,
                                            "Nullable"_a = Nullable));
@@ -932,7 +1024,13 @@ SQLRETURN SQLGetData_wrap(SqlHandlePtr StatementHandle, SQLUSMALLINT colCount, p
                         // NOTE: dataBuffer.size() includes null-terminator, dataLen doesn't. Hence use '<'.
 						if (numCharsInData < dataBuffer.size()) {
                             // SQLGetData will null-terminate the data
+#if defined(__APPLE__)
+                            std::string fullStr(reinterpret_cast<char*>(dataBuffer.data()));
+                            row.append(fullStr);
+                            LOG("macOS: Appended CHAR string of length {} to result row", fullStr.length());
+#else
                             row.append(std::string(reinterpret_cast<char*>(dataBuffer.data())));
+#endif
 						} else {
                             // In this case, buffer size is smaller, and data to be retrieved is longer
                             // TODO: Revisit
@@ -975,7 +1073,11 @@ SQLRETURN SQLGetData_wrap(SqlHandlePtr StatementHandle, SQLUSMALLINT colCount, p
                         uint64_t numCharsInData = dataLen / sizeof(SQLWCHAR);
 						if (numCharsInData < dataBuffer.size()) {
                             // SQLGetData will null-terminate the data
+#if defined(__APPLE__)
+                            row.append(SQLWCHARToWString(dataBuffer.data(), SQL_NTS));
+#else
                             row.append(std::wstring(dataBuffer.data()));
+#endif
 						} else {
                             // In this case, buffer size is smaller, and data to be retrieved is longer
                             // TODO: Revisit
@@ -1484,9 +1586,17 @@ SQLRETURN FetchBatchData(SQLHSTMT hStmt, ColumnBuffers& buffers, py::list& colum
 					// fetchBufferSize includes null-terminator, numCharsInData doesn't. Hence '<'
                     if (numCharsInData < fetchBufferSize) {
                         // SQLFetch will nullterminate the data
+#if defined(__APPLE__)
+                        // Use macOS-specific conversion to handle the wchar_t/SQLWCHAR size difference
+                        SQLWCHAR* wcharData = &buffers.wcharBuffers[col - 1][i * fetchBufferSize];
+                        std::wstring wstr = SQLWCHARToWString(wcharData, numCharsInData);
+                        row.append(wstr);
+#else
+                        // On Windows, wchar_t and SQLWCHAR are both 2 bytes, so direct cast works
                         row.append(std::wstring(
                             reinterpret_cast<wchar_t*>(&buffers.wcharBuffers[col - 1][i * fetchBufferSize]),
                             numCharsInData));
+#endif
                     } else {
                         // In this case, buffer size is smaller, and data to be retrieved is longer
                         // TODO: Revisit

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -554,7 +554,7 @@ std::string GetModuleDirectory() {
         std::string dir = module_file.substr(0, pos);
         return dir;
     }
-    std::cerr << "DEBUG: Could not extract directory from path: " << module_file << std::endl;
+    LOG("DEBUG: Could not extract directory from path: {}", module_file);
     return module_file;
 #endif
 }
@@ -641,7 +641,7 @@ DriverHandle LoadDriverOrThrowException() {
         driverPath = primaryPath;
         LOG("macOS driver found at: {}", driverPath.string());
     } else {
-        driverPath = fs::path(moduleDir) / "libs" / archDir / "macos" / "lib" / "libmsodbcsql.18.dylib";
+        driverPath = fs::path(moduleDir) / "libs" / archDir /  "macos/libmsodbcsql.18.dylib";
         LOG("Using fallback macOS driver path: {}", driverPath.string());
     }
 #endif

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -699,7 +699,7 @@ DriverHandle LoadDriverOrThrowException() {
         SQLFreeStmt_ptr && SQLGetDiagRec_ptr;
 
     if (!success) {
-        ThrowStdException("Missing required ODBC function pointers.");
+        ThrowStdException("Failed to load required function pointers from driver.");
     }
     LOG("All driver function pointers successfully loaded.");
     return handle;

--- a/mssql_python/pybind/ddbc_bindings_mac.cpp
+++ b/mssql_python/pybind/ddbc_bindings_mac.cpp
@@ -70,7 +70,7 @@
 #include <sqlext.h>
 
 #if defined(__APPLE__)
-#include "mac_fix.h"  // For macOS-specific Unicode encoding fixes
+#include "mac_utils.h"  // For macOS-specific Unicode encoding fixes
 #include "mac_buffers.h"  // For macOS-specific buffer handling
 #endif
 

--- a/mssql_python/pybind/mac_utils.cpp
+++ b/mssql_python/pybind/mac_utils.cpp
@@ -1,5 +1,10 @@
-// Mac OS specific fixes for the C++ code
-// This file contains patches to fix issues specific to macOS
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// This file defines utility functions for safely handling SQLWCHAR-based
+// wide-character data in ODBC operations on macOS. It includes conversions
+// between SQLWCHAR, std::wstring, and UTF-8 strings to bridge encoding
+// differences specific to macOS.
 
 #if defined(__APPLE__)
 // Constants for character encoding

--- a/mssql_python/pybind/mac_utils.h
+++ b/mssql_python/pybind/mac_utils.h
@@ -1,3 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// This header defines utility functions for safely handling SQLWCHAR-based
+// wide-character data in ODBC operations on macOS. It includes conversions
+// between SQLWCHAR, std::wstring, and UTF-8 strings to bridge encoding
+// differences specific to macOS.
+
 #pragma once
 
 #include <string>


### PR DESCRIPTION
This pull request refines cross-platform compatibility for the `mssql_python` bindings, improves logging, and simplifies driver loading and function handling. Key changes include replacing Windows-specific code with platform-agnostic alternatives, adding detailed logging for debugging, and introducing macOS-specific handling for wide character conversions.

### Cross-platform compatibility improvements:
* Replaced Windows-specific headers (`<shlwapi.h>`) with `<filesystem>` for path handling and removed direct `LoadLibraryW` calls in favor of platform-agnostic dynamic library loading (`LoadDriverLibrary`). [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L14-R14) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R544-R579) [[3]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R593-R705)

* Added macOS-specific handling for wide character conversions (`SQLWCHAR` to `wchar_t`) in various methods such as `SQLExecDirect_wrap`, `SQLExecute_wrap`, and `SQLGetData_wrap`. This ensures proper functionality on macOS and Linux platforms. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L732-R814) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L764-R852) [[3]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R1076-R1080)

### Enhanced logging:
* Introduced detailed logging throughout the `BindParameters` method to debug parameter binding, including character code points and buffer sizes. Added logs for macOS-specific SQLWCHAR buffer creation. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R193-R197) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R235-R274) [[3]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R504)

* Added logging for driver loading, including paths and error messages, and improved error reporting with platform-specific implementations of `GetLastErrorMessage`. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R544-R579) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R593-R705)

### Driver loading simplifications:
* Refactored the driver loading process to use `<filesystem>` for path construction and introduced platform-agnostic functions to load dynamic libraries and retrieve function pointers. Simplified handling of driver function pointers by consolidating repetitive code. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R544-R579) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R593-R705)

### Wide character handling improvements:
* Unified wide character string handling across platforms by introducing helper functions (`SQLWCHARToWString`, `WStringToSQLWCHAR`) for macOS/Linux compatibility in methods like `SQLDescribeCol_wrap` and `SQLGetData_wrap`. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R952-R956) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R1027-R1033) [[3]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R1076-R1080)

### Code cleanup:
* Removed unused methods such as `WideToUTF8` and legacy Windows-specific driver loading code, reducing clutter and improving maintainability. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L498-L505) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R593-R705)

### Issue Reference  
[AB#37626](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/37626)