### PR TITLE
FEAT: adding tests for connection pooling speed and basic functionality

### DIFF
--- a/tests/test_003_connection.py
+++ b/tests/test_003_connection.py
@@ -11,7 +11,8 @@ Note: The cursor function is not yet implemented, so related tests are commented
 """
 
 import pytest
-from mssql_python import Connection, connect
+import time
+from mssql_python import Connection, connect, pooling
 
 def drop_table_if_exists(cursor, table_name):
     """Drop the table if it exists"""
@@ -177,5 +178,49 @@ def test_connection_close(conn_str):
     # Create a separate connection just for this test
     temp_conn = connect(conn_str)
     # Check if the database connection can be closed
-    temp_conn.close()
+    temp_conn.close()    
+
+def test_connection_pooling_speed(conn_str):
+    # No pooling
+    start_no_pool = time.perf_counter()
+    conn1 = connect(conn_str)
+    conn1.close()
+    end_no_pool = time.perf_counter()
+    no_pool_duration = end_no_pool - start_no_pool
+
+    # Second connection
+    start2 = time.perf_counter()
+    conn2 = connect(conn_str)
+    conn2.close()
+    end2 = time.perf_counter()
+    duration2 = end2 - start2
+
+    # Pooling enabled
+    pooling(max_size=2, idle_timeout=10)
+    connect(conn_str).close()
+
+    # Pooled connection (should be reused, hence faster)
+    start_pool = time.perf_counter()
+    conn2 = connect(conn_str)
+    conn2.close()
+    end_pool = time.perf_counter()
+    pool_duration = end_pool - start_pool
+    assert pool_duration < no_pool_duration, "Expected faster connection with pooling"
+
+def test_connection_pooling_basic(conn_str):
+    # Enable pooling with small pool size
+    pooling(max_size=2, idle_timeout=5)
+    conn1 = connect(conn_str)
+    conn2 = connect(conn_str)
+    assert conn1 is not None
+    assert conn2 is not None
+    try:
+        conn3 = connect(conn_str)
+        assert conn3 is not None, "Third connection failed — pooling is not working or limit is too strict"
+        conn3.close()
+    except Exception as e:
+        print(f"Expected: Could not open third connection due to max_size=2: {e}")
+
+    conn1.close()
+    conn2.close()
     


### PR DESCRIPTION
This pull request introduces new functionality to test connection pooling in the `mssql_python` library, along with some minor updates to imports in the test file. The most significant changes include adding tests for connection pooling speed and basic functionality, as well as updating the import statement to include the `pooling` module.

### Connection pooling tests:

* [`tests/test_003_connection.py`](diffhunk://#diff-ca315ffd463e0f93f3d45ace0869a4a3b1e572941da6723d7e9ce028cf9d2278R182-R225): Added `test_connection_pooling_speed` to measure the performance improvement when using connection pooling compared to no pooling. Includes assertions to validate that pooled connections are faster.
* [`tests/test_003_connection.py`](diffhunk://#diff-ca315ffd463e0f93f3d45ace0869a4a3b1e572941da6723d7e9ce028cf9d2278R182-R225): Added `test_connection_pooling_basic` to verify the functionality of connection pooling with a small pool size, ensuring connections are reused and respecting the pool size limit. Includes assertions and exception handling for edge cases.

### Import updates:

* [`tests/test_003_connection.py`](diffhunk://#diff-ca315ffd463e0f93f3d45ace0869a4a3b1e572941da6723d7e9ce028cf9d2278L14-R15): Updated import statement to include the `pooling` module, which is required for the new connection pooling tests.