### PR TITLE
FEAT: Bulk Copy Wrapper 

### DIFF
--- a/mssql_python/pybind/CMakeLists.txt
+++ b/mssql_python/pybind/CMakeLists.txt
@@ -190,7 +190,7 @@ else()
     set(DDBC_SOURCE "ddbc_bindings.cpp")
     message(STATUS "Using standard source file: ${DDBC_SOURCE}")
     # Include connection module for Windows
-    add_library(ddbc_bindings MODULE ${DDBC_SOURCE} connection/connection.cpp connection/connection_pool.cpp)
+    add_library(ddbc_bindings MODULE ${DDBC_SOURCE} connection/connection.cpp connection/connection_pool.cpp bcp/bcp_wrapper.cpp)
 endif()
 
 # Set the output name to include Python version and architecture
@@ -231,6 +231,7 @@ message(STATUS "Using ODBC include directory: ${ODBC_INCLUDE_DIR}")
 target_include_directories(ddbc_bindings PRIVATE 
     ${CMAKE_CURRENT_SOURCE_DIR}             # Root directory (for ddbc_bindings.h)
     ${CMAKE_CURRENT_SOURCE_DIR}/connection  # connection directory (for connection.h)
+    ${CMAKE_CURRENT_SOURCE_DIR}/bcp         # connection directory (for bcp_wrapper.h)
     ${PYTHON_INCLUDE_DIR}
     ${PYBIND11_INCLUDE_DIR}
 )

--- a/mssql_python/pybind/bcp/bcp_wrapper.cpp
+++ b/mssql_python/pybind/bcp/bcp_wrapper.cpp
@@ -1,0 +1,361 @@
+#include "bcp_wrapper.h" // Includes ddbc_bindings.h (and thus sql.h, sqlext.h, <string>, <memory>) and connection.h
+
+// Pybind11 headers (needed for py::cast and potentially std::optional if used with pybind types)
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h> 
+#include <pybind11/pytypes.h> // Ensure this is included for py::bytes if not transitively
+
+// Standard C++ headers (not covered by ddbc_bindings.h)
+#include <vector>
+#include <stdexcept>
+#include <unordered_map>
+#include <string> // For std::to_string, std::string
+#include <iostream> // Added for std::cout
+
+namespace py = pybind11; // Alias for pybind11 namespace
+
+// Helper to manage BCP properties for bcp_control
+enum class BCPCtrlPropType { INT, WSTRING };
+struct BCPCtrlPropertyInfo {
+    INT option_code;
+    BCPCtrlPropType type;
+};
+
+// Map property names to their ODBC codes and types
+const std::unordered_map<std::wstring, BCPCtrlPropertyInfo> bcp_control_properties = {
+    {L"BCPMAXERRS",     {BCPMAXERRS,        BCPCtrlPropType::INT}},
+    {L"BCPBATCH",       {BCPBATCH,          BCPCtrlPropType::INT}},
+    {L"BCPKEEPNULLS",   {BCPKEEPNULLS,      BCPCtrlPropType::INT}},
+    {L"BCPKEEPIDENTITY",{BCPKEEPIDENTITY,   BCPCtrlPropType::INT}},
+    {L"BCPHINTS",       {BCPHINTS,          BCPCtrlPropType::WSTRING}},
+    {L"BCPFILECP",      {BCPFILECP,         BCPCtrlPropType::INT}},
+    // Example if you were to add global terminators via bcp_control:
+    // {L"BCPFIELDTERM",   {BCPFIELDTERM_Constant, BCPCtrlPropType::BYTES}}, // Assuming BCPFIELDTERM_Constant is the ODBC int
+    // {L"BCPROWTERM",     {BCPROWTERM_Constant,   BCPCtrlPropType::BYTES}}, // Assuming BCPROWTERM_Constant is the ODBC int
+};
+
+// Helper for bcp_init direction string
+INT get_bcp_direction_code(const std::wstring& direction_str) {
+    if (direction_str == L"in") return DB_IN;
+    if (direction_str == L"out" || direction_str == L"queryout") return DB_OUT;
+    throw std::runtime_error("Invalid BCP direction string: " + py::cast(direction_str).cast<std::string>());
+}
+
+// Helper function (can be a static private method or a lambda in C++11 and later)
+// to retrieve ODBC diagnostic messages and populate ErrorInfo.
+// This uses SQLGetDiagRec_ptr directly, which is loaded by DriverLoader.
+static ErrorInfo get_odbc_diagnostics_for_handle(SQLSMALLINT handle_type, SQLHANDLE handle) {
+    ErrorInfo error_info;
+    error_info.sqlState = L""; // Initialize
+    error_info.ddbcErrorMsg = L""; // Initialize
+
+    if (!SQLGetDiagRec_ptr) {
+        LOG("get_odbc_diagnostics_for_handle: SQLGetDiagRec_ptr is null.");
+        error_info.ddbcErrorMsg = L"SQLGetDiagRec_ptr not loaded. Cannot retrieve diagnostics.";
+        return error_info;
+    }
+
+    SQLWCHAR sql_state_w[6];
+    SQLINTEGER native_error;
+    SQLWCHAR message_text_w[SQL_MAX_MESSAGE_LENGTH];
+    SQLSMALLINT text_length;
+    SQLSMALLINT rec_number = 1;
+    std::wstring combined_messages;
+
+    while (SQLGetDiagRec_ptr(handle_type, handle, rec_number, sql_state_w, &native_error,
+                             message_text_w, SQL_MAX_MESSAGE_LENGTH, &text_length) == SQL_SUCCESS) {
+        if (rec_number == 1) {
+            error_info.sqlState = std::wstring(sql_state_w);
+        }
+        if (!combined_messages.empty()) {
+            combined_messages += L" | ";
+        }
+        combined_messages += std::wstring(message_text_w, text_length) + L" (Native: " + std::to_wstring(native_error) + L")";
+        rec_number++;
+    }
+    error_info.ddbcErrorMsg = combined_messages;
+    if (combined_messages.empty() && rec_number == 1) { // No records found
+         error_info.ddbcErrorMsg = L"No ODBC diagnostic records found for the handle.";
+    }
+    return error_info;
+}
+
+BCPWrapper::BCPWrapper(ConnectionHandle& conn) // Changed to Connection&
+    : _bcp_initialized(false), _bcp_finished(true) { // Initialize reference
+    try {
+        _hdbc = conn.getConnection()->getDbcHandle()->get();
+        if (!_hdbc || _hdbc == SQL_NULL_HDBC) {
+            LOG("BCPWrapper Error: Invalid HDBC from Connection object.");
+            throw std::runtime_error("BCPWrapper: Invalid HDBC from Connection object.");
+        }
+    } catch (const std::runtime_error& e) {
+        // Re-throw with more context or just let it propagate
+        throw std::runtime_error(std::string("BCPWrapper Constructor: Failed to get valid HDBC - ") + e.what());
+    }
+}
+
+BCPWrapper::~BCPWrapper() {
+    LOG("BCPWrapper: Destructor called.");
+    // try {
+    //     close(); 
+    // } catch (const std::exception& e) {
+    //     LOG("BCPWrapper Error: Exception in destructor: " + std::string(e.what()));
+    // } catch (...) {
+    //     LOG("BCPWrapper Error: Unknown exception in destructor.");
+    // }
+    LOG("BCPWrapper: Destructor finished.");
+}
+
+SQLRETURN BCPWrapper::bcp_initialize_operation(const std::wstring& table,
+                                               const std::wstring& data_file,
+                                               const std::wstring& error_file,
+                                               const std::wstring& direction) {
+    if (_bcp_initialized) {
+        LOG("BCPWrapper Warning: bcp_initialize_operation called but BCP already initialized. Call finish() or close() first.");
+        return SQL_ERROR; 
+    }
+
+    INT dir_code = get_bcp_direction_code(direction);
+
+    LPCWSTR pTable = table.empty() ? nullptr : table.c_str();
+    LPCWSTR pDataFile = data_file.empty() ? nullptr : data_file.c_str();
+    LPCWSTR pErrorFile = error_file.empty() ? nullptr : error_file.c_str();
+
+    LOG("BCPWrapper: Calling BCPInitW_ptr with HDBC: " + std::to_string(reinterpret_cast<uintptr_t>(_hdbc)) + ", table: " 
+        + (pTable ? py::cast(table).cast<std::string>() : "nullptr") 
+        + ", data_file: " + (pDataFile ? py::cast(data_file).cast<std::string>() : "nullptr")
+        + ", error_file: " + (pErrorFile ? py::cast(error_file).cast<std::string>() : "nullptr")
+        + ", direction code: " + std::to_string(dir_code));
+    // Call BCPInitW with the correct parameters
+    SQLRETURN ret = BCPInitW_ptr(_hdbc, pTable, pDataFile, pErrorFile, dir_code);
+    LOG("BCPWrapper: HELLOOOO " + std::to_string(ret));
+    
+    if (ret != FAIL) {
+        _bcp_initialized = true;
+        _bcp_finished = false;
+        LOG("BCPWrapper: bcp_initW successful.");
+    } else {
+        LOG("BCPWrapper Error: bcp_initW failed. Ret: " + std::to_string(ret));
+    }
+    return ret;
+}
+
+SQLRETURN BCPWrapper::bcp_control(const std::wstring& property_name, int value) {
+    if (!_bcp_initialized || _bcp_finished) {
+        LOG("BCPWrapper Warning: bcp_control(int) called in invalid state (not initialized or already finished).");
+        // Throw an exception instead of returning SQL_ERROR for better Python-side error handling
+        throw std::runtime_error("BCPWrapper: bcp_control(int) called in invalid state.");
+    }
+
+    auto it = bcp_control_properties.find(property_name);
+    if (it == bcp_control_properties.end() || it->second.type != BCPCtrlPropType::INT) {
+        std::string msg = "BCPWrapper Error: bcp_control(int) - property '" + py::cast(property_name).cast<std::string>() + "' not found or type mismatch.";
+        LOG(msg);
+        throw std::runtime_error(msg);
+    }
+    
+    LOG("BCPWrapper: Calling bcp_controlW for property '" + py::cast(property_name).cast<std::string>() + "' with int value " + std::to_string(value) + ".");
+    // Correctly pass integer values to bcp_control.
+    SQLRETURN ret = BCPControlW_ptr(_hdbc, it->second.option_code, (LPVOID)(SQLLEN)value);
+    if (ret == FAIL) {
+        std::string msg = "BCPWrapper Error: bcp_controlW (int value) failed for property '" + py::cast(property_name).cast<std::string>() + "'. Ret: " + std::to_string(ret);
+        ErrorInfo diag = get_odbc_diagnostics_for_handle(SQL_HANDLE_DBC, _hdbc);
+        msg += " ODBC Diag: SQLState: " + py::cast(diag.sqlState).cast<std::string>() + ", Message: " + py::cast(diag.ddbcErrorMsg).cast<std::string>();
+        LOG(msg);
+        throw std::runtime_error(msg);
+    }
+    return ret;
+}
+
+SQLRETURN BCPWrapper::bcp_control(const std::wstring& property_name, const std::wstring& value) {
+    if (!_bcp_initialized || _bcp_finished) {
+        LOG("BCPWrapper Warning: bcp_control(wstring) called in invalid state.");
+        return SQL_ERROR;
+    }
+
+    auto it = bcp_control_properties.find(property_name);
+    LOG("BCPWrapper: bcp_control(wstring) called for property '" + py::cast(property_name).cast<std::string>() + "'.");
+    
+    // Check if the property exists and is of type WSTRING
+    // Note: For WSTRING properties, we expect the value to be a wide string (std::wstring).
+    // If the property is not found or is not of type WSTRING, we return an error.
+    LOG("BCPWrapper: bcp_control value: '" + py::cast(value).cast<std::string>() + "'.");
+    LOG("BCPWrapper: bcp_control property name: '" + py::cast(property_name).cast<std::string>() + "'.");
+    
+    if (it == bcp_control_properties.end() || it->second.type != BCPCtrlPropType::WSTRING) {
+        LOG("BCPWrapper Error: bcp_control(wstring) - property '" + py::cast(property_name).cast<std::string>() + "' not found or type mismatch.");
+        return SQL_ERROR; 
+    }
+    
+    LOG("BCPWrapper: Calling bcp_controlW for property '" + py::cast(property_name).cast<std::string>() + "' with wstring value '" + py::cast(value).cast<std::string>() + "'.");
+    
+    std::string value_utf8 = py::cast(value).cast<std::string>();
+    // Fix the BCPHINTS issue: use the wide string directly rather than converting to narrow
+    SQLRETURN ret = BCPControlW_ptr(_hdbc, it->second.option_code, (LPVOID)value_utf8.c_str());
+    
+    if (ret == FAIL) {
+        std::string msg = "BCPWrapper Error: bcp_controlW (wstring value) failed for property '" + py::cast(property_name).cast<std::string>() + "'. Ret: " + std::to_string(ret);
+        ErrorInfo diag = get_odbc_diagnostics_for_handle(SQL_HANDLE_DBC, _hdbc);
+        msg += " ODBC Diag: SQLState: " + py::cast(diag.sqlState).cast<std::string>() + ", Message: " + py::cast(diag.ddbcErrorMsg).cast<std::string>();
+        LOG(msg);
+        throw std::runtime_error("BCPWrapper: bcp_controlW (wstring value) failed.");
+    }
+    return ret;
+}
+
+SQLRETURN BCPWrapper::read_format_file(const std::wstring& file_path) {
+    if (!_bcp_initialized || _bcp_finished) {
+        LOG("BCPWrapper Warning: read_format_file called in invalid state.");
+        return SQL_ERROR;
+    }
+    if (file_path.empty()) {
+        LOG("BCPWrapper Error: read_format_file - file path cannot be empty.");
+        return SQL_ERROR;
+    }
+
+    LOG("BCPWrapper: Calling bcp_readfmtW for file '" + py::cast(file_path).cast<std::string>() + "'.");
+    SQLRETURN ret = BCPReadFmtW_ptr(_hdbc, file_path.c_str());
+    if (ret == FAIL) {
+        LOG("BCPWrapper Error: bcp_readfmtW failed for file '" + py::cast(file_path).cast<std::string>() + "'. Ret: " + std::to_string(ret));
+    }
+    return ret;
+}
+
+SQLRETURN BCPWrapper::define_columns(int num_cols) {
+    if (!_bcp_initialized || _bcp_finished) {
+        LOG("BCPWrapper Warning: define_columns called in invalid state.");
+        return SQL_ERROR;
+    }
+    if (num_cols <= 0) {
+        LOG("BCPWrapper Error: define_columns - invalid number of columns: " + std::to_string(num_cols));
+        return SQL_ERROR;
+    }
+
+    LOG("BCPWrapper: Calling bcp_columns with " + std::to_string(num_cols) + " columns.");
+    SQLRETURN ret = BCPColumns_ptr(_hdbc, num_cols);
+    if (ret == FAIL) {
+        LOG("BCPWrapper Error: bcp_columns failed for " + std::to_string(num_cols) + " columns. Ret: " + std::to_string(ret));
+    }
+    LOG("BCPWrapper: bcp_columns returned " + std::to_string(ret));
+    return ret;
+}
+
+SQLRETURN BCPWrapper::define_column_format(int file_col_idx,
+                                           int user_data_type,
+                                           int indicator_length,
+                                           long long user_data_length,
+                                           const std::optional<py::bytes>& terminator_bytes_py, 
+                                           int terminator_length,
+                                           int server_col_idx) {
+    if (!_bcp_initialized || _bcp_finished) {
+         throw std::runtime_error("BCPWrapper: define_column_format called in invalid state.");
+    }
+
+    const BYTE* pTerminator = nullptr;
+    std::string terminator_str_holder; 
+
+    if (terminator_bytes_py) {
+        terminator_str_holder = terminator_bytes_py->cast<std::string>(); 
+        if (!terminator_str_holder.empty()) {
+            LOG("BCPWrapper: Terminator bytes provided: " + py::cast(terminator_str_holder).cast<std::string>());
+            pTerminator = reinterpret_cast<const BYTE*>(terminator_str_holder.data());
+            LOG("BCPWrapper: Terminator pointer: " + std::to_string(reinterpret_cast<uintptr_t>(pTerminator)));
+            LOG("BCPWRapper: Terminator pointer type: " + std::string(typeid(pTerminator).name()));
+            
+            std::string hex_dump = "Terminator content hex dump: ";
+            for (size_t i = 0; i < terminator_str_holder.size(); i++) {
+                char hex_buf[8];
+                snprintf(hex_buf, sizeof(hex_buf), "%02x ", (unsigned char)terminator_str_holder[i]);
+                hex_dump += hex_buf;
+            }
+            LOG(hex_dump);
+        } else {
+            LOG("Warning: Terminator string is empty!");
+        }
+    } else {
+        LOG("Warning: No terminator bytes provided!");
+    }
+
+    DBINT bcp_user_data_len = static_cast<DBINT>(user_data_length); 
+
+    LOG("BCPWrapper: Calling bcp_colfmtW for file_col " + std::to_string(file_col_idx)
+        + ", server_col " + std::to_string(server_col_idx)
+        + ", user_data_type " + std::to_string(user_data_type)
+        + ", indicator_len " + std::to_string(indicator_length)
+        + ", user_data_len " + std::to_string(static_cast<long long>(bcp_user_data_len))
+        + ", terminator_len " + std::to_string(terminator_length) 
+        + ", terminator_ptr " + std::to_string(reinterpret_cast<uintptr_t>(pTerminator)));
+
+    LOG("BCPWrapper: user_data_type: " + std::to_string(static_cast<BYTE>(user_data_type)));
+
+    SQLRETURN ret = BCPColFmtW_ptr(_hdbc,
+                                   file_col_idx,
+                                   static_cast<BYTE>(user_data_type),
+                                   indicator_length,
+                                   bcp_user_data_len,
+                                   pTerminator, 
+                                   terminator_length, 
+                                   server_col_idx
+                                   );
+    if (ret == FAIL) {
+        std::string msg = "BCPWrapper Error: bcp_colfmtW failed for file_col " + std::to_string(file_col_idx)
+                  + ", server_col " + std::to_string(server_col_idx)
+                  + ". Ret: " + std::to_string(ret);
+        ErrorInfo diag = get_odbc_diagnostics_for_handle(SQL_HANDLE_DBC, _hdbc);
+        msg += " ODBC Diag: SQLState: " + py::cast(diag.sqlState).cast<std::string>() + ", Message: " + py::cast(diag.ddbcErrorMsg).cast<std::string>();
+        LOG(msg);
+        throw std::runtime_error(msg);
+    }
+    return ret;
+}
+
+SQLRETURN BCPWrapper::exec_bcp() {
+    if (!_bcp_initialized || _bcp_finished) {
+        throw std::runtime_error("BCPWrapper: exec_bcp called in invalid state.");
+    }
+
+    DBINT rows_copied_in_batch = 0; 
+    LOG("BCPWrapper: Calling bcp_exec.");
+    DBINT bcp_ret = BCPExec_ptr(_hdbc, &rows_copied_in_batch);
+    
+    if (bcp_ret == FAIL) { 
+        std::string msg = "BCPWrapper Error: bcp_exec failed (returned -1). Rows in this batch (if any before error): " + std::to_string(static_cast<long long>(rows_copied_in_batch));
+        ErrorInfo diag = get_odbc_diagnostics_for_handle(SQL_HANDLE_DBC, _hdbc);
+        msg += " ODBC Diag: SQLState: " + py::cast(diag.sqlState).cast<std::string>() + ", Message: " + py::cast(diag.ddbcErrorMsg).cast<std::string>();
+        LOG(msg);
+        throw std::runtime_error(msg);
+    }
+    LOG("BCPWrapper: bcp_exec returned " + std::to_string(static_cast<long long>(bcp_ret)) + ". Rows parameter output: " + std::to_string(static_cast<long long>(rows_copied_in_batch)));
+    return SQL_SUCCESS; 
+}
+
+SQLRETURN BCPWrapper::finish() {
+    if (!_bcp_initialized) {
+        LOG("BCPWrapper Info: finish called but BCP not initialized. No action taken.");
+        return SQL_SUCCESS; 
+    }
+    if (_bcp_finished) {
+        LOG("BCPWrapper Info: finish called but BCP already finished. No action taken.");
+        return SQL_SUCCESS;
+    }
+
+    LOG("BCPWrapper: Calling bcp_done.");
+    SQLRETURN ret = BCPDone_ptr(_hdbc);
+    if (ret != FAIL) {
+        _bcp_finished = true;
+        LOG("BCPWrapper: bcp_done successful.");
+    } else {
+        LOG("BCPWrapper Error: bcp_done failed. Ret: " + std::to_string(ret));
+    }
+    return ret;
+}
+
+SQLRETURN BCPWrapper::close() {
+    LOG("BCPWrapper: close() called.");
+    SQLRETURN ret = SQL_SUCCESS;
+    if (_bcp_initialized && !_bcp_finished) {
+        LOG("BCPWrapper: Active BCP operation found in close(), calling finish().");
+        ret = finish();
+    }
+    return ret;
+}

--- a/mssql_python/pybind/bcp/bcp_wrapper.h
+++ b/mssql_python/pybind/bcp/bcp_wrapper.h
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "ddbc_bindings.h" // For SQLRETURN and other ODBC types/macros
+#include "../connection/connection.h" // For the Connection class
+#include <optional> // For std::optional
+#include <pybind11/pytypes.h> // For py::bytes
+
+class BCPWrapper {
+public:
+    // Constructor: Requires a reference to an active Connection object.
+    // The BCPWrapper does not take ownership of the Connection object.
+    BCPWrapper(ConnectionHandle& conn); // Changed to Connection&
+
+    // Destructor: Ensures BCP operations are properly terminated if active.
+    ~BCPWrapper();
+
+    // Initializes a BCP operation for a specific table, data file, error file, and direction.
+    // Maps to ODBC bcp_init.
+    SQLRETURN bcp_initialize_operation(const std::wstring& table,
+                                       const std::wstring& data_file,
+                                       const std::wstring& error_file,
+                                       const std::wstring& direction);
+
+    // Sets various BCP control options using an integer value.
+    // Maps to ODBC bcp_control.
+    SQLRETURN bcp_control(const std::wstring& property_name, int value);
+
+    // Sets various BCP control options using a string value.
+    // Maps to ODBC bcp_control.
+    SQLRETURN bcp_control(const std::wstring& property_name, const std::wstring& value);
+
+    // Sets the bulk copy mode (e.g., "native", "char").
+    // This might internally call bcp_control or affect column format definitions.
+    SQLRETURN set_bulk_mode(const std::wstring& mode, 
+                            const std::optional<py::bytes>& field_terminator = std::nullopt, // Changed type
+                            const std::optional<py::bytes>& row_terminator = std::nullopt      // Changed type
+                        );
+
+    // Reads column format information from a BCP format file.
+    // Maps to ODBC bcp_readfmt.
+    SQLRETURN read_format_file(const std::wstring& file_path);
+
+    // Specifies the total number of columns in the user data file.
+    // Maps to ODBC bcp_columns.
+    SQLRETURN define_columns(int num_cols);
+
+    // Defines the format of data in the data file for a specific column.
+    // Maps to ODBC bcp_colfmt.
+    SQLRETURN define_column_format(int file_col_idx,         // User data file column number (1-based), maps to idxUserDataCol
+                                   int user_data_type,       // Data type in user file (e.g., SQLCHARACTER), maps to eUserDataType
+                                   int indicator_length,     // Length of prefix/indicator (0, 1, 2, 4, 8, or SQL_VARLEN_DATA), maps to cbIndicator
+                                   long long user_data_length, // Max length of data in user file (bytes), maps to cbUserData
+                                   const std::optional<py::bytes>& terminator_bytes_py, // Changed type
+                                   int terminator_length, // Length of terminator bytes (1 for single byte, 2 for double byte, etc.), maps to cbTerminator
+                                   int server_col_idx        // Server table column number (1-based), maps to idxServerCol
+                                   );
+
+    // Executes the BCP operation, transferring data.
+    // Maps to ODBC bcp_exec.
+    SQLRETURN exec_bcp();
+
+    // Completes the BCP operation and releases associated resources.
+    // Maps to ODBC bcp_done.
+    SQLRETURN finish();
+
+    // Optional method to explicitly close/cleanup BCP resources.
+    // May call finish() if BCP operation is still active.
+    SQLRETURN close();
+
+private:
+    SQLHDBC _hdbc;
+    bool _bcp_initialized; // Flag to track if bcp_init has been called successfully
+    bool _bcp_finished;    // Flag to track if bcp_finish (or bcp_done) has been called
+};

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -196,6 +196,12 @@ void Connection::applyAttrsBefore(const py::dict& attrs) {
                 ThrowStdException("Failed to set access token before connect");
             }
         }
+        if (key == SQL_COPT_SS_BCP) {   
+            SQLRETURN ret = setAttribute(key, py::reinterpret_borrow<py::object>(item.second));
+            if (!SQL_SUCCEEDED(ret)) {
+                ThrowStdException("Failed to set bcp before connect");
+            }
+        }
     }
 }
 

--- a/mssql_python/pybind/connection/connection.h
+++ b/mssql_python/pybind/connection/connection.h
@@ -41,6 +41,10 @@ public:
 
     // Allocate a new statement handle on this connection.
     SqlHandlePtr allocStatementHandle();
+    // Get connection handle.
+    SqlHandlePtr getDbcHandle() const {
+        return _dbcHandle;
+    }
 
 private:
     void allocateDbcHandle();
@@ -66,6 +70,9 @@ public:
     void setAutocommit(bool enabled);
     bool getAutocommit() const;
     SqlHandlePtr allocStatementHandle();
+    std::shared_ptr<Connection> getConnection() const {
+        return _conn;
+    }
 
 private:
     std::shared_ptr<Connection> _conn;

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -14,6 +14,7 @@
 #include <sqlext.h>
 #include <memory>
 #include <mutex>
+#include <odbcss.h>
 
 #include <pybind11/chrono.h>
 #include <pybind11/complex.h>
@@ -46,6 +47,17 @@ typedef SQLRETURN (SQL_API* SQLExecuteFunc)(SQLHANDLE);
 typedef SQLRETURN (SQL_API* SQLRowCountFunc)(SQLHSTMT, SQLLEN*);
 typedef SQLRETURN (SQL_API* SQLSetDescFieldFunc)(SQLHDESC, SQLSMALLINT, SQLSMALLINT, SQLPOINTER, SQLINTEGER);
 typedef SQLRETURN (SQL_API* SQLGetStmtAttrFunc)(SQLHSTMT, SQLINTEGER, SQLPOINTER, SQLINTEGER, SQLINTEGER*);
+
+// BCP APIs (Bulk Copy Program)
+// Typedefs (ensure these match the function signatures in odbcss.h)
+typedef SQLRETURN (SQL_API* BCPInitWFunc)(SQLHDBC, LPCWSTR, LPCWSTR, LPCWSTR, INT);
+typedef SQLRETURN (SQL_API* BCPControlWFunc)(SQLHDBC, INT, LPVOID);
+// typedef SQLRETURN (SQL_API* BCPControlAFunc)(SQLHDBC, INT, LPVOID); 
+typedef SQLRETURN (SQL_API* BCPReadFmtWFunc)(SQLHDBC, LPCWSTR);
+typedef SQLRETURN (SQL_API* BCPColumnsFunc)(SQLHDBC, INT);
+typedef SQLRETURN (SQL_API* BCPColFmtWFunc)(SQLHDBC, INT, INT, INT, DBINT, LPCBYTE, INT, INT);
+typedef SQLRETURN  (SQL_API* BCPExecFunc)(SQLHDBC, DBINT*); 
+typedef SQLRETURN (SQL_API* BCPDoneFunc)(SQLHDBC);
 
 // Data retrieval APIs
 typedef SQLRETURN (SQL_API* SQLFetchFunc)(SQLHANDLE);
@@ -116,6 +128,15 @@ extern SQLFreeStmtFunc SQLFreeStmt_ptr;
 // Diagnostic APIs
 extern SQLGetDiagRecFunc SQLGetDiagRec_ptr;
 
+// BCP APIs (Bulk Copy Program)
+// Extern function pointer declarations for BCP APIs
+extern BCPInitWFunc BCPInitW_ptr;
+extern BCPControlWFunc BCPControlW_ptr;
+extern BCPReadFmtWFunc BCPReadFmtW_ptr;
+extern BCPColumnsFunc BCPColumns_ptr;
+extern BCPColFmtWFunc BCPColFmtW_ptr;
+extern BCPExecFunc BCPExec_ptr;
+extern BCPDoneFunc BCPDone_ptr;
 
 // Logging utility
 template <typename... Args>

--- a/tests/test_008_bcpMain.py
+++ b/tests/test_008_bcpMain.py
@@ -1,0 +1,632 @@
+import pytest
+import os
+import uuid
+import tempfile
+import time
+from pathlib import Path
+
+from mssql_python import connect as mssql_connect
+from mssql_python.bcp_options import BCPOptions, ColumnFormat
+from mssql_python.bcp_main import BCPClient
+
+# --- Constants for Tests ---
+SQL_COPT_SS_BCP = 1219  # BCP connection attribute
+
+
+# --- Database Connection Details from Environment Variables ---
+DB_CONNECTION_STRING = os.getenv("DB_CONNECTION_STRING")
+
+# Skip all tests in this file if connection string is not provided
+pytestmark = pytest.mark.skipif(
+    not DB_CONNECTION_STRING,
+    reason="DB_CONNECTION_STRING environment variable must be set for BCP integration tests."
+)
+
+def get_bcp_test_conn_str():
+    """Returns the connection string."""
+    if not DB_CONNECTION_STRING:
+        pytest.skip("DB_CONNECTION_STRING is not set.")
+    return DB_CONNECTION_STRING
+
+@pytest.fixture(scope="function")
+def format_test_setup():
+    """
+    Fixture to set up a BCP-enabled connection and a test table with sample data.
+    Creates format files for testing.
+    Cleans up all resources afterward.
+    """
+    conn_str = get_bcp_test_conn_str()
+    table_uuid = str(uuid.uuid4()).replace('-', '')[:8]
+    table_name = f"dbo.pytest_bcp_format_{table_uuid}"
+    
+    conn = None
+    cursor = None
+    temp_dir = tempfile.TemporaryDirectory()
+    
+    # Define paths for our test files
+    format_file_path = Path(temp_dir.name) / "test_format.fmt"
+    data_out_path = Path(temp_dir.name) / "data_out.bcp"
+    data_in_path = Path(temp_dir.name) / "data_in.bcp"
+    error_out_path = Path(temp_dir.name) / "error_out.log"
+    error_in_path = Path(temp_dir.name) / "error_in.log"
+    
+    try:
+        # Connect with BCP enabled
+        conn = mssql_connect(conn_str, attrs_before={SQL_COPT_SS_BCP: 1}, autocommit=True)
+        cursor = conn.cursor()
+        
+        # Create test table
+        cursor.execute(f"IF OBJECT_ID('{table_name}', 'U') IS NOT NULL DROP TABLE {table_name};")
+        cursor.execute(f"""
+            CREATE TABLE {table_name} (
+                id INT PRIMARY KEY,
+                name NVARCHAR(50) NOT NULL,
+                value DECIMAL(10,2) NULL
+            );
+        """)
+        
+        # Insert sample data
+        cursor.execute(f"""
+            INSERT INTO {table_name} (id, name, value)
+            VALUES 
+                (1, 'Item One', 10.50),
+                (2, 'Item Two', 20.75),
+                (3, 'Item Three', 30.00),
+                (4, 'Item Four', NULL);
+        """)
+        
+        # Create a format file - use a simpler format structure
+        # For native format (which is safer for BCP transfers)
+        format_content = """14.0
+3
+1       SQLINT      0       4       ""   1     id               ""
+2       SQLNCHAR    0       50      ""   2     name             Latin1_General_CI_AS
+3       SQLDECIMAL  0       17      ""   3     value            ""
+"""
+        
+        with open(format_file_path, 'w', encoding='utf-8') as f:
+            f.write(format_content)
+            
+        # Yield resources to test
+        yield {
+            'conn': conn,
+            'table_name': table_name,
+            'format_file': str(format_file_path),  # Convert to string to avoid Path object issues
+            'data_out': str(data_out_path),
+            'data_in': str(data_in_path),
+            'error_out': str(error_out_path),
+            'error_in': str(error_in_path),
+            'temp_dir': temp_dir  # Keep reference to prevent cleanup until fixture is done
+        }
+        
+    finally:
+        # Cleanup
+        if cursor:
+            try:
+                cursor.close()
+            except Exception as e:
+                print(f"Warning: Error closing cursor: {e}")
+                
+        if conn:
+            try:
+                cleanup_cursor = conn.cursor()
+                cleanup_cursor.execute(f"IF OBJECT_ID('{table_name}', 'U') IS NOT NULL DROP TABLE {table_name};")
+                cleanup_cursor.close()
+            except Exception as e:
+                print(f"Warning: Error during cleanup: {e}")
+            finally:
+                conn.close()
+
+
+class TestBCPFormatFile:
+    def test_bcp_out_with_format_file(self, format_test_setup):
+        """Test BCP OUT operation using a format file."""
+        # Get resources from setup
+        conn = format_test_setup['conn']
+        table_name = format_test_setup['table_name']
+        format_file = format_test_setup['format_file']
+        data_file = format_test_setup['data_out']
+        error_file = format_test_setup['error_out']
+        
+        # Create BCPClient
+        bcp_client = BCPClient(conn)
+        
+        # Create options for BCP OUT
+        options = BCPOptions(
+            direction="out",
+            data_file=data_file,
+            error_file=error_file,
+            format_file=format_file,
+            bulk_mode="native"  # Use native mode for format file
+        )
+        
+        # Execute BCP OUT
+        bcp_client.sql_bulk_copy(table=table_name, options=options)
+        
+        # Verify the operation succeeded
+        assert os.path.exists(data_file), "Output data file was not created"
+        assert os.path.getsize(data_file) > 0, "Output data file is empty"
+        
+        # Count rows in table to verify against BCP operation
+        cursor = conn.cursor()
+        cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+        row_count = cursor.fetchone()[0]
+        
+        # Additional verification could be done here
+        assert row_count == 4, f"Expected 4 rows in source table, got {row_count}"
+    
+    # Separate test for BCP IN to reduce complexity and potential issues
+    def test_bcp_in_with_format_file(self, format_test_setup):
+        """Test BCP IN operation using a format file."""
+        # Get resources from setup
+        conn = format_test_setup['conn']
+        table_name = format_test_setup['table_name']
+        format_file = format_test_setup['format_file']
+        
+        # Create test data file with known values
+        # Instead of doing BCP OUT first (which could fail), create a simple data file
+        # that matches the expected format for BCP IN
+        data_in_file = format_test_setup['data_in']
+        error_in_file = format_test_setup['error_in']
+        
+        # First, create a copy table for import
+        new_table = f"{table_name}_copy"
+        cursor = conn.cursor()
+        cursor.execute(f"IF OBJECT_ID('{new_table}', 'U') IS NOT NULL DROP TABLE {new_table};")
+        cursor.execute(f"SELECT TOP 0 * INTO {new_table} FROM {table_name}")
+        
+        try:
+            # Create BCPClient
+            bcp_client = BCPClient(conn)
+            
+            # Get row count before import
+            cursor.execute(f"SELECT COUNT(*) FROM {new_table}")
+            before_count = cursor.fetchone()[0]
+            assert before_count == 0, "Target table should be empty before import"
+            
+            # First do a BCP OUT to create sample data
+            test_out_file = format_test_setup['data_out']
+            test_err_file = format_test_setup['error_out']
+            
+            out_options = BCPOptions(
+                direction="out",
+                data_file=test_out_file,
+                error_file=test_err_file,
+                format_file=format_file,
+                bulk_mode="native"
+            )
+            
+            # Do BCP OUT first to create input data
+            bcp_client.sql_bulk_copy(table=table_name, options=out_options)
+            
+            # Ensure the file was created
+            assert os.path.exists(test_out_file), "BCP OUT file not created"
+            assert os.path.getsize(test_out_file) > 0, "BCP OUT file is empty"
+            
+            # Copy the data file to the input location
+            with open(test_out_file, 'rb') as src, open(data_in_file, 'wb') as dst:
+                dst.write(src.read())
+            
+            # Create a new BCP client to avoid any state issues
+            bcp_client_in = BCPClient(conn)
+            
+            # Now do BCP IN
+            in_options = BCPOptions(
+                direction="in",
+                data_file=data_in_file,
+                error_file=error_in_file,
+                format_file=format_file,
+                bulk_mode="native"
+            )
+            
+            # Execute BCP IN
+            bcp_client_in.sql_bulk_copy(table=new_table, options=in_options)
+            
+            # Force a small delay to ensure all operations complete
+            time.sleep(0.5)
+            
+            # Verify data was imported
+            cursor.execute(f"SELECT COUNT(*) FROM {new_table}")
+            after_count = cursor.fetchone()[0]
+            
+            # Get expected count
+            cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+            expected_count = cursor.fetchone()[0]
+            
+            assert after_count > 0, "No rows were imported"
+            assert after_count == expected_count, f"Expected {expected_count} rows, got {after_count}"
+            
+        finally:
+            # Clean up
+            cursor.execute(f"IF OBJECT_ID('{new_table}', 'U') IS NOT NULL DROP TABLE {new_table};")
+
+class TestBCPColumnFmt:
+    def test_bcp_colfmt(self, format_test_setup):
+        """Test BCP operations with explicit column formatting instead of format files."""
+        # Get resources from setup
+        conn = format_test_setup['conn']
+        table_name = format_test_setup['table_name']
+        data_out = format_test_setup['data_out']
+        data_in = format_test_setup['data_in']
+        error_out = format_test_setup['error_out']
+        error_in = format_test_setup['error_in']
+        
+        # Create a new table for column format testing
+        col_fmt_table = f"{table_name}_colfmt"
+        cursor = conn.cursor()
+        cursor.execute(f"IF OBJECT_ID('{col_fmt_table}', 'U') IS NOT NULL DROP TABLE {col_fmt_table};")
+        cursor.execute(f"""
+            CREATE TABLE {col_fmt_table} (
+                id INT PRIMARY KEY,
+                name NVARCHAR(50) NOT NULL,
+                value DECIMAL(10,2) NULL
+            );
+        """)
+        
+        try:
+            # Create BCPClient for export
+            bcp_client_out = BCPClient(conn)
+            
+            # Create options for BCP OUT with column formatting
+            out_options = BCPOptions(
+                direction="out",
+                data_file=data_out,
+                error_file=error_out,
+                bulk_mode="char"  # Use character mode for column formatting
+            )
+            
+            # Set up column formats for OUT operation by directly creating ColumnFormat objects
+            # and adding them to the columns list
+            col1 = ColumnFormat(
+                prefix_len=0,
+                data_len=8,
+                field_terminator=b"\r\t",
+                terminator_len=2,  # Length of the terminator
+                server_col=1,
+                file_col=1,
+                user_data_type= 47  # SQLINT
+            )
+            
+            col2 = ColumnFormat(
+                prefix_len=0,
+                data_len=50,
+                field_terminator=b"\r\t", 
+                terminator_len=2,  # Length of the terminator
+                server_col=2,
+                file_col=2,
+                user_data_type= 47  # SQLNCHAR would be different, using placeholder
+            )
+            
+            col3 = ColumnFormat(
+                prefix_len=0,
+                data_len=12,
+                field_terminator=b"\r\n",
+                terminator_len=2,  # Length of the terminator
+                server_col=3, 
+                file_col=3,
+                user_data_type= 47  # SQLDECIMAL would be different, using placeholder
+            )
+            
+            # Add columns to the options
+            out_options.columns = [col1, col2, col3]
+            
+            # Execute BCP OUT using column formatting
+            bcp_client_out.sql_bulk_copy(table=table_name, options=out_options)
+            
+            # Verify the operation succeeded
+            assert os.path.exists(data_out), "Output data file was not created"
+            assert os.path.getsize(data_out) > 0, "Output data file is empty"
+            
+            # Create BCPClient for import
+            bcp_client_in = BCPClient(conn)
+            
+            # Create options for BCP IN with column formatting
+            in_options = BCPOptions(
+                direction="in",
+                data_file=data_out,  # Use the data we just exported
+                error_file=error_in,
+                bulk_mode="char"  # Use character mode for column formatting
+            )
+            
+            # Set up column formats for IN operation - must match OUT operation
+            in_options.columns = [
+                ColumnFormat(
+                    prefix_len=0,
+                    data_len=8,
+                    field_terminator=b"\r\t",
+                    terminator_len=2,  # Length of the terminator
+                    server_col=1,
+                    file_col=1,
+                    user_data_type= 47  # SQLINT
+                ),
+                ColumnFormat(
+                    prefix_len=0,
+                    data_len=50,
+                    field_terminator=b"\r\t",
+                    terminator_len=2,  # Length of the terminator
+                    server_col=2,
+                    file_col=2,
+                    user_data_type= 47 # SQLNCHAR placeholder
+                ),
+                ColumnFormat(
+                    prefix_len=0,
+                    data_len=12,
+                    field_terminator=b"\r\n",
+                    terminator_len=2,  # Length of the terminator
+                    server_col=3,
+                    file_col=3,
+                    user_data_type= 47  # SQLDECIMAL placeholder
+                )
+            ]
+            
+            # Execute BCP IN using column formatting
+            bcp_client_in.sql_bulk_copy(table=col_fmt_table, options=in_options)
+            
+            # Verify data was imported correctly
+            cursor.execute(f"SELECT COUNT(*) FROM {col_fmt_table}")
+            imported_count = cursor.fetchone()[0]
+            
+            cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+            original_count = cursor.fetchone()[0]
+            
+            assert imported_count == original_count, f"Expected {original_count} rows, got {imported_count}"
+            
+            # Compare actual data to ensure it was imported correctly
+            cursor.execute(f"SELECT id, name, value FROM {table_name} ORDER BY id")
+            original_rows = cursor.fetchall()
+            
+            cursor.execute(f"SELECT id, name, value FROM {col_fmt_table} ORDER BY id")
+            imported_rows = cursor.fetchall()
+            
+            assert len(original_rows) == len(imported_rows), "Row count mismatch in detailed comparison"
+            
+            for orig, imp in zip(original_rows, imported_rows):
+                assert orig == imp, f"Data mismatch: original={orig}, imported={imp}"
+            
+        finally:
+            # Clean up
+            cursor.execute(f"IF OBJECT_ID('{col_fmt_table}', 'U') IS NOT NULL DROP TABLE {col_fmt_table};")
+            cursor.close()
+
+    def test_bcp_colfmt_with_row_terminator(self, format_test_setup):
+        """Test BCP operations with column formatting and explicit row terminator."""
+        # Get resources from setup
+        conn = format_test_setup['conn']
+        table_name = format_test_setup['table_name']
+        data_out = format_test_setup['data_out'] + ".row"
+        data_in = format_test_setup['data_in'] + ".row"
+        error_out = format_test_setup['error_out']
+        error_in = format_test_setup['error_in']
+        
+        # Create a new table for column format testing
+        row_term_table = f"{table_name}_rowterm"
+        cursor = conn.cursor()
+        cursor.execute(f"IF OBJECT_ID('{row_term_table}', 'U') IS NOT NULL DROP TABLE {row_term_table};")
+        cursor.execute(f"SELECT * INTO {row_term_table} FROM {table_name} WHERE 1=0")
+        
+        try:
+            # Create BCPClient for export
+            bcp_client_out = BCPClient(conn)
+            
+            # Create options for BCP OUT with column formatting
+            # Note: we'll specify row terminator in the last column's row_terminator field
+            out_options = BCPOptions(
+                direction="out",
+                data_file=data_out,
+                error_file=error_out,
+                bulk_mode="char"  # Use character mode for column formatting
+            )
+            
+            # Set up column formats for OUT operation with row terminator in the last column
+            out_options.columns = [
+                ColumnFormat(
+                    prefix_len=0,
+                    data_len=8,
+                    field_terminator=b",",
+                    terminator_len=1,  # Length of the terminator
+                    server_col=1,
+                    file_col=1,
+                    user_data_type=47  # SQLINT
+                ),
+                ColumnFormat(
+                    prefix_len=0,
+                    data_len=50,
+                    field_terminator=b",",
+                    terminator_len=1,  # Length of the terminator
+                    server_col=2,
+                    file_col=2,
+                    user_data_type=47  # SQLNCHAR placeholder
+                ),
+                ColumnFormat(
+                    prefix_len=0,
+                    data_len=12,
+                    field_terminator=b"\r\n",  # Use row terminator on last column
+                    terminator_len=2,  # Length of the terminator
+                    server_col=3,
+                    file_col=3,
+                    user_data_type=47 # SQLDECIMAL placeholder
+                )
+            ]
+            
+            # Execute BCP OUT using column formatting
+            bcp_client_out.sql_bulk_copy(table=table_name, options=out_options)
+            
+            # Verify the operation succeeded
+            assert os.path.exists(data_out), "Output data file was not created"
+            assert os.path.getsize(data_out) > 0, "Output data file is empty"
+            
+            # Create BCPClient for import
+            bcp_client_in = BCPClient(conn)
+            
+            # Create options for BCP IN with column formatting
+            in_options = BCPOptions(
+                direction="in",
+                data_file=data_out,  # Use the data we just exported
+                error_file=error_in,
+                bulk_mode="char"  # Use character mode for column formatting
+            )
+            
+            # Set up column formats for IN operation - must match OUT operation
+            in_options.columns = [
+                ColumnFormat(
+                    prefix_len=0,
+                    data_len=8,
+                    field_terminator=b",",
+                    terminator_len=1,  # Length of the terminator
+                    server_col=1,
+                    file_col=1,
+                    user_data_type=47 # SQLINT
+                ),
+                ColumnFormat(
+                    prefix_len=0,
+                    data_len=50,
+                    field_terminator=b",",
+                    terminator_len=1,  # Length of the terminator
+                    server_col=2,
+                    file_col=2,
+                    user_data_type=47  # SQLNCHAR placeholder
+                ),
+                ColumnFormat(
+                    prefix_len=0,
+                    data_len=12,
+                    field_terminator=b"\r\n",  # Use row terminator on last column
+                    terminator_len=2,  # Length of the terminator
+                    server_col=3,
+                    file_col=3,
+                    user_data_type=47  # SQLDECIMAL placeholder
+                )
+            ]
+            
+            # Execute BCP IN using column formatting
+            bcp_client_in.sql_bulk_copy(table=row_term_table, options=in_options)
+            
+            # Verify data was imported correctly
+            cursor.execute(f"SELECT COUNT(*) FROM {row_term_table}")
+            imported_count = cursor.fetchone()[0]
+            
+            cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+            original_count = cursor.fetchone()[0]
+            
+            assert imported_count == original_count, f"Expected {original_count} rows, got {imported_count}"
+            
+        finally:
+            # Clean up
+            cursor.execute(f"IF OBJECT_ID('{row_term_table}', 'U') IS NOT NULL DROP TABLE {row_term_table};")
+            cursor.close()
+
+class TestBCPQueryOut:
+    def test_bcp_query_out_using_formatfile(self, format_test_setup):
+        """Test BCP OUT operation using a query and a format file."""
+        # Get resources from setup
+        conn = format_test_setup['conn']
+        table_name = format_test_setup['table_name']
+        format_file = format_test_setup['format_file']
+        data_file = format_test_setup['data_out']
+        error_file = format_test_setup['error_out']
+        
+        # Create BCPClient
+        bcp_client = BCPClient(conn)
+        
+        # Create options for BCP OUT with query
+        options = BCPOptions(
+            direction="queryout",
+            data_file=data_file,
+            error_file=error_file,
+            format_file=format_file,
+            query=f"SELECT * FROM {table_name}"  # Use a query instead of a table name
+        )
+        
+        # Ensure the data file is clean before running BCP OUT
+        if os.path.exists(data_file):
+            os.remove(data_file)
+        
+        # Check if table exists and has data
+        cursor = conn.cursor()
+        cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+        count = cursor.fetchone()[0]
+        if count == 0:
+            pytest.skip(f"No data in table {table_name} to export with BCP OUT.")
+        # Log the number of rows to export
+        print(f"Rows to export from {table_name}: {count}")
+        
+        # Execute BCP OUT
+        bcp_client.sql_bulk_copy(options=options)
+        
+        # Verify the operation succeeded
+        assert os.path.exists(data_file), "Output data file was not created"
+        assert os.path.getsize(data_file) > 0, "Output data file is empty"
+        
+        # Count rows in table to verify against BCP operation
+        cursor = conn.cursor()
+        cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+        row_count = cursor.fetchone()[0]
+        
+        # Additional verification could be done here
+        assert row_count == 4, f"Expected 4 rows in source table, got {row_count}"
+
+    def test_bcp_query_out_with_columns(self, format_test_setup):
+        """Test BCP OUT operation using a query and explicit column formatting."""
+        # Get resources from setup
+        conn = format_test_setup['conn']
+        table_name = format_test_setup['table_name']
+        data_file = format_test_setup['data_out']
+        error_file = format_test_setup['error_out']
+        
+        # Create BCPClient
+        bcp_client = BCPClient(conn)
+        
+        # Create options for BCP OUT with query and columns
+        options = BCPOptions(
+            direction="queryout",
+            data_file=data_file,
+            error_file=error_file,
+            query=f"SELECT id, name FROM {table_name}",  # Select specific columns
+            columns=[
+                ColumnFormat(
+                    prefix_len=0,
+                    data_len=8,
+                    field_terminator=b",",
+                    terminator_len=1,  # Length of the terminator
+                    server_col=1,
+                    file_col=1,
+                    user_data_type=47  # SQLINT
+                ),
+                ColumnFormat(
+                    prefix_len=0,
+                    data_len=50,
+                    field_terminator=b"\r\n",  # Use row terminator on last column
+                    terminator_len=2,  # Length of the terminator
+                    server_col=2,
+                    file_col=2,
+                    user_data_type=47  # SQLNCHAR placeholder
+                )
+            ]
+        )
+        
+        # Ensure the data file is clean before running BCP OUT
+        if os.path.exists(data_file):
+            os.remove(data_file)
+        
+        # Check if table exists and has data
+        cursor = conn.cursor()
+        cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+        count = cursor.fetchone()[0]
+        if count == 0:
+            pytest.skip(f"No data in table {table_name} to export with BCP OUT.")
+        
+        # Log the number of rows to export
+        print(f"Rows to export from {table_name}: {count}")
+        
+        # Execute BCP OUT
+        bcp_client.sql_bulk_copy(options=options)
+        
+        # Verify the operation succeeded
+        assert os.path.exists(data_file), "Output data file was not created"
+        assert os.path.getsize(data_file) > 0, "Output data file is empty"
+        
+        # Count rows in table to verify against BCP operation
+        cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+        row_count = cursor.fetchone()[0]
+
+        # Additional verification could be done here
+        assert row_count == 4, f"Expected 4 rows in source table, got {row_count}"


### PR DESCRIPTION
This pull request introduces support for Bulk Copy Program (BCP) functionality in the `mssql_python` project. The changes include adding a new `BCPWrapper` class, integrating BCP APIs, and modifying existing classes to support BCP operations. Below is a summary of the most important changes:

### Integration of BCP Functionality

* **New `BCPWrapper` Class**: Added `BCPWrapper` in `mssql_python/pybind/bcp/bcp_wrapper.{cpp,h}` to encapsulate BCP operations such as initialization, control, column formatting, and execution. This class interfaces with ODBC BCP APIs and handles diagnostic messages for error reporting.
* **BCP API Pointers**: Declared and initialized function pointers for ODBC BCP APIs (`BCPInitW`, `BCPControlW`, `BCPReadFmtW`, etc.) in `ddbc_bindings.cpp`. These are used by `BCPWrapper` to interact with BCP operations.

### Modifications to Support BCP

* **CMake Configuration**: Updated `CMakeLists.txt` to include the new `bcp_wrapper.cpp` file and its corresponding header directory. This ensures the new functionality is compiled and linked.

* **Connection Class Enhancements**: Added methods to retrieve the database connection handle (`getDbcHandle`) and the `Connection` object (`getConnection`) in `connection.h`. These are required by `BCPWrapper` to access the underlying ODBC connection handle.

* **BCP Attribute Setting**: Modified `applyAttrsBefore` in `connection.cpp` to support setting the `SQL_COPT_SS_BCP` attribute before establishing a connection. This enables bulk copy mode for connections.

### General Updates

* **Header Inclusion**: Added `bcp_wrapper.h` to `ddbc_bindings.cpp` to ensure the new `BCPWrapper` class and BCP-related functionality are accessible.

These changes collectively add robust support for BCP operations, enabling efficient bulk data transfer in the `mssql_python` library.

### ADO
* [USER STORY 34946](https://sqlclientdrivers.visualstudio.com/mssql-python/_workitems/edit/34946)