### PR TITLE
FEAT: Adding Default Auth for Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ By adhering to the DB API 2.0 specification, the mssql-python module ensures com
  
 ### Support for Microsoft Entra ID Authentication
  
-The Microsoft mssql-python driver enables Python applications to connect to Microsoft SQL Server, Azure SQL Database, or Azure SQL Managed Instance using Microsoft Entra ID identities. It supports various authentication methods, including username and password, Microsoft Entra managed identity, and Integrated Windows Authentication in a federated, domain-joined environment. Additionally, the driver supports Microsoft Entra interactive authentication and Microsoft Entra managed identity authentication for both system-assigned and user-assigned managed identities.
+The Microsoft mssql-python driver enables Python applications to connect to Microsoft SQL Server, Azure SQL Database, or Azure SQL Managed Instance using Microsoft Entra ID identities. It supports a variety of authentication methods, including username and password, Microsoft Entra managed identity (system-assigned and user-assigned), Integrated Windows Authentication in a federated, domain-joined environment, interactive authentication via browser, device code flow for environments without browser access, and the default authentication method based on environment and configuration. This flexibility allows developers to choose the most suitable authentication approach for their deployment scenario.
 
 EntraID authentication is now fully supported on MacOS and Linux but with certain limitations as mentioned in the table:
 

--- a/README.md
+++ b/README.md
@@ -55,12 +55,16 @@ EntraID authentication is now fully supported on MacOS and Linux but with certai
 | Authentication Method | Windows Support | macOS/Linux Support | Notes |
 |----------------------|----------------|---------------------|-------|
 | ActiveDirectoryPassword | ✅ Yes | ✅ Yes | Username/password-based authentication |
-| ActiveDirectoryInteractive | ✅ Yes | ❌ No | Only works on Windows |
+| ActiveDirectoryInteractive | ✅ Yes | ✅ Yes | Interactive login via browser; requires user interaction |
 | ActiveDirectoryMSI (Managed Identity) | ✅ Yes | ✅ Yes | For Azure VMs/containers with managed identity |
 | ActiveDirectoryServicePrincipal | ✅ Yes | ✅ Yes | Use client ID and secret or certificate |
 | ActiveDirectoryIntegrated | ✅ Yes | ❌ No | Only works on Windows (requires Kerberos/SSPI) |
+| ActiveDirectoryDeviceCode | ✅ Yes | ✅ Yes | Device code flow for authentication; suitable for environments without browser access |
+| ActiveDirectoryDefault | ✅ Yes | ✅ Yes | Uses default authentication method based on environment and configuration |
 
-> **NOTE**: For using Access Token, the connection string *must not* contain `UID`, `PWD`, `Authentication`, or `Trusted_Connection` keywords.
+
+> **NOTE**: For using Access Token, the connection string **must not** contain `UID`, `PWD`, `Authentication`, or `Trusted_Connection` keywords.
+> **NOTE**: For using ActiveDirectoryDeviceCode, make sure to specify a `Connect Timeout` that provides enough time to go through the device code flow authentication process.
 
 ### Enhanced Pythonic Features
  

--- a/mssql_python/helpers.py
+++ b/mssql_python/helpers.py
@@ -145,7 +145,7 @@ def add_driver_name_to_app_parameter(connection_string):
     # Remove sensitive parameters for AAD auth
     if auth_type in ("default", "devicecode", "interactive"):
         exclude_keys = [
-            "uid=", "pwd=", "connection timeout=", "encrypt=", "trustservercertificate=", "authentication="
+            "uid=", "pwd=", "encrypt=", "trustservercertificate=", "authentication="
         ]
         modified_parameters = [
             param for param in modified_parameters
@@ -165,7 +165,6 @@ def add_driver_name_to_app_parameter(connection_string):
         return ";".join(modified_parameters) + ";", {1256: token_struct}
 
     if auth_type == "devicecode":
-        modified_parameters.append("Connection Timeout=180")
         try:
             from azure.identity import DeviceCodeCredential
             import struct


### PR DESCRIPTION
### ADO Work Item Reference  
<!-- Insert your ADO Work Item ID below (e.g. AB#37452) -->
> [AB#37927](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/37927)
-------------------------------------------------------------------
### Summary   
This pull request refactors the `add_driver_name_to_app_parameter` function in `mssql_python/helpers.py` to improve readability, modularity, and support for additional authentication types. Key changes include consolidating authentication handling logic, introducing a unified `auth_type` variable, and refining parameter filtering and token generation for different Azure Active Directory (AAD) authentication methods.

### Refactoring and code simplification:
* Replaced multiple boolean flags (`has_aad_interactive`, `has_aad_device_code`) with a single `auth_type` variable to track the authentication type, improving code clarity and reducing redundant logic.
* Simplified parameter filtering by using a unified list of keys (`exclude_keys`) to exclude sensitive parameters during AAD authentication.

### Enhanced support for AAD authentication:
* Added support for `ActiveDirectoryDefault` authentication by introducing a new case in the `auth_type` handling logic and using `DefaultAzureCredential` for token generation.
* Refactored token generation for `ActiveDirectoryDeviceCode` and `ActiveDirectoryInteractive` authentication to ensure consistent handling and modularity.

### Other improvements:
* Updated the logic to append the `APP=MSSQL-Python` parameter more consistently when the `APP` key is not found. (F