### PR TITLE
FIX: Interactive on Windows

### DIFF
--- a/mssql_python/auth.py
+++ b/mssql_python/auth.py
@@ -84,10 +84,11 @@ def process_auth_parameters(parameters: list) -> Tuple[list, Optional[str]]:
         if key_lower == "authentication":
             # Check for supported authentication types and set auth_type accordingly
             if value_lower == AuthType.INTERACTIVE.value:
+                auth_type = "interactive"
                 # Interactive authentication (browser-based); only append parameter for non-Windows
                 if platform.system().lower() == "windows":
-                    continue  # Skip adding this parameter for Windows
-                auth_type = "interactive"
+                    auth_type = None  # Let Windows handle AADInteractive natively
+                
             elif value_lower == AuthType.DEVICE_CODE.value:
                 # Device code authentication (for devices without browser)
                 auth_type = "devicecode"

--- a/tests/test_008_auth.py
+++ b/tests/test_008_auth.py
@@ -137,7 +137,7 @@ class TestProcessAuthParameters:
         monkeypatch.setattr(platform, "system", lambda: "Windows")
         params = ["Authentication=ActiveDirectoryInteractive", "Server=test"]
         modified_params, auth_type = process_auth_parameters(params)
-        assert "Authentication=ActiveDirectoryInteractive" not in modified_params
+        assert "Authentication=ActiveDirectoryInteractive" in modified_params
         assert auth_type == None
 
     def test_interactive_auth_non_windows(self, monkeypatch):

--- a/tests/test_008_auth.py
+++ b/tests/test_008_auth.py
@@ -143,18 +143,17 @@ class TestProcessAuthParameters:
     def test_interactive_auth_non_windows(self, monkeypatch):
         monkeypatch.setattr(platform, "system", lambda: "Darwin")
         params = ["Authentication=ActiveDirectoryInteractive", "Server=test"]
-        modified_params, auth_type = process_auth_parameters(params)
-        assert "Authentication=ActiveDirectoryInteractive" in modified_params
+        _, auth_type = process_auth_parameters(params)
         assert auth_type == "interactive"
 
     def test_device_code_auth(self):
         params = ["Authentication=ActiveDirectoryDeviceCode", "Server=test"]
-        modified_params, auth_type = process_auth_parameters(params)
+        _, auth_type = process_auth_parameters(params)
         assert auth_type == "devicecode"
 
     def test_default_auth(self):
         params = ["Authentication=ActiveDirectoryDefault", "Server=test"]
-        modified_params, auth_type = process_auth_parameters(params)
+        _, auth_type = process_auth_parameters(params)
         assert auth_type == "default"
 
 class TestRemoveSensitiveParams:


### PR DESCRIPTION
### ADO Work Item Reference  
<!-- Insert your ADO Work Item ID below (e.g. AB#37452) -->
> [AB#38007](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/38007)
-------------------------------------------------------------------
### Summary   
This pull request includes a small change to the `process_auth_parameters` function in `mssql_python/auth.py`. The change adjusts how the `auth_type` is handled for interactive authentication on Windows, ensuring compatibility with native handling of AADInteractive.