### PR TITLE
FIX: Making type objects and constructor compatible with pyodbc

### DIFF
--- a/mssql_python/type.py
+++ b/mssql_python/type.py
@@ -9,50 +9,50 @@ import time
 
 
 # Type Objects
-class STRING:
+class STRING(str):
     """
     This type object is used to describe columns in a database that are string-based (e.g. CHAR).
     """
 
-    def __init__(self) -> None:
-        self.type = "STRING"
+    def __new__(cls):
+        return str.__new__(cls, "")
 
 
-class BINARY:
+class BINARY(bytearray):
     """
     This type object is used to describe (long)
     binary columns in a database (e.g. LONG, RAW, BLOBs).
     """
 
-    def __init__(self) -> None:
-        self.type = "BINARY"
+    def __new__(cls):
+        return bytearray.__new__(cls)
 
 
-class NUMBER:
+class NUMBER(float):
     """
     This type object is used to describe numeric columns in a database.
     """
 
-    def __init__(self) -> None:
-        self.type = "NUMBER"
+    def __new__(cls):
+        return float.__new__(cls, 0.0)
 
 
-class DATETIME:
+class DATETIME(datetime.datetime):
     """
     This type object is used to describe date/time columns in a database.
     """
 
-    def __init__(self) -> None:
-        self.type = "DATETIME"
+    def __new__(cls, year: int = 1, month: int = 1, day: int = 1):
+        return datetime.datetime.__new__(cls, year, month, day)
 
 
-class ROWID:
+class ROWID(int):
     """
-    This type object is used to describe the “Row ID” column in a database.
+    This type object is used to describe the "Row ID" column in a database.
     """
 
-    def __init__(self) -> None:
-        self.type = "ROWID"
+    def __new__(cls):
+        return int.__new__(cls, 0)
 
 
 # Type Constructors
@@ -90,18 +90,24 @@ def TimeFromTicks(ticks: int) -> datetime.time:
     """
     Generates a time object from ticks.
     """
-    return datetime.time(*time.gmtime(ticks)[3:6])
+    return datetime.time(*time.localtime(ticks)[3:6])
 
 
 def TimestampFromTicks(ticks: int) -> datetime.datetime:
     """
     Generates a timestamp object from ticks.
     """
-    return datetime.datetime.fromtimestamp(ticks, datetime.timezone.utc)
+    return datetime.datetime.fromtimestamp(ticks)
 
 
-def Binary(string: str) -> bytes:
+def Binary(string) -> bytes:
     """
-    Converts a string to bytes using UTF-8 encoding.
+    Converts a string or bytes to bytes using UTF-8 encoding.
     """
-    return bytes(string, "utf-8")
+    if isinstance(string, bytes):
+        return string
+    elif isinstance(string, str):
+        return bytes(string, "utf-8")
+    else:
+        # Handle other types by converting to string first
+        return bytes(str(string), "utf-8")

--- a/mssql_python/type.py
+++ b/mssql_python/type.py
@@ -102,12 +102,32 @@ def TimestampFromTicks(ticks: int) -> datetime.datetime:
 
 def Binary(value) -> bytes:
     """
-    Converts a string or bytes to bytes using UTF-8 encoding.
+    Converts a string or bytes to bytes for use with binary database columns.
+    
+    This function follows the DB-API 2.0 specification and pyodbc compatibility.
+    It accepts only str and bytes/bytearray types to ensure type safety.
+    
+    Args:
+        value: A string (str) or bytes-like object (bytes, bytearray)
+        
+    Returns:
+        bytes: The input converted to bytes
+        
+    Raises:
+        TypeError: If the input type is not supported
+        
+    Examples:
+        Binary("hello")           # Returns b"hello"
+        Binary(b"hello")          # Returns b"hello"  
+        Binary(bytearray(b"hi"))  # Returns b"hi"
     """
     if isinstance(value, bytes):
         return value
+    elif isinstance(value, bytearray):
+        return bytes(value)
     elif isinstance(value, str):
-        return bytes(value, "utf-8")
+        return value.encode("utf-8")
     else:
-        # Handle other types by converting to string first
-        return bytes(str(value), "utf-8")
+        # Raise TypeError for unsupported types to improve type safety
+        raise TypeError(f"Cannot convert type {type(value).__name__} to bytes. "
+                       f"Binary() only accepts str, bytes, or bytearray objects.")

--- a/mssql_python/type.py
+++ b/mssql_python/type.py
@@ -100,14 +100,14 @@ def TimestampFromTicks(ticks: int) -> datetime.datetime:
     return datetime.datetime.fromtimestamp(ticks)
 
 
-def Binary(string) -> bytes:
+def Binary(value) -> bytes:
     """
     Converts a string or bytes to bytes using UTF-8 encoding.
     """
-    if isinstance(string, bytes):
-        return string
-    elif isinstance(string, str):
-        return bytes(string, "utf-8")
+    if isinstance(value, bytes):
+        return value
+    elif isinstance(value, str):
+        return bytes(value, "utf-8")
     else:
         # Handle other types by converting to string first
-        return bytes(str(string), "utf-8")
+        return bytes(str(value), "utf-8")

--- a/tests/test_002_types.py
+++ b/tests/test_002_types.py
@@ -1,5 +1,6 @@
 import pytest
 import datetime
+import time
 from mssql_python.type import STRING, BINARY, NUMBER, DATETIME, ROWID, Date, Time, Timestamp, DateFromTicks, TimeFromTicks, TimestampFromTicks, Binary
 
 def test_string_type():
@@ -42,16 +43,16 @@ def test_date_from_ticks():
     assert date == datetime.date(2023, 10, 5), "DateFromTicks returned incorrect date"
 
 def test_time_from_ticks():
-    ticks = 1696500000  # Corresponds to 10:00:00
-    time = TimeFromTicks(ticks)
-    assert isinstance(time, datetime.time), "TimeFromTicks did not return a time object"
-    assert time == datetime.time(15, 30, 0), "TimeFromTicks returned incorrect time"
+    ticks = 1696500000  # Corresponds to local
+    time_var = TimeFromTicks(ticks)
+    assert isinstance(time_var, datetime.time), "TimeFromTicks did not return a time object"
+    assert time_var == datetime.time(*time.localtime(ticks)[3:6]), "TimeFromTicks returned incorrect time"
 
 def test_timestamp_from_ticks():
-    ticks = 1696500000  # Corresponds to 2023-10-05 10:00:00
+    ticks = 1696500000  # Corresponds to 2023-10-05 local time
     timestamp = TimestampFromTicks(ticks)
     assert isinstance(timestamp, datetime.datetime), "TimestampFromTicks did not return a datetime object"
-    assert timestamp == datetime.datetime(2023, 10, 5, 15, 30, 0), "TimestampFromTicks returned incorrect timestamp"
+    assert timestamp == datetime.datetime.fromtimestamp(ticks), "TimestampFromTicks returned incorrect timestamp"
 
 def test_binary_constructor():
     binary = Binary("test".encode('utf-8'))

--- a/tests/test_002_types.py
+++ b/tests/test_002_types.py
@@ -3,19 +3,20 @@ import datetime
 from mssql_python.type import STRING, BINARY, NUMBER, DATETIME, ROWID, Date, Time, Timestamp, DateFromTicks, TimeFromTicks, TimestampFromTicks, Binary
 
 def test_string_type():
-    assert STRING().type == "STRING", "STRING type mismatch"
+    assert STRING() == str(), "STRING type mismatch"
+    
 
 def test_binary_type():
-    assert BINARY().type == "BINARY", "BINARY type mismatch"
+    assert BINARY() == bytearray(), "BINARY type mismatch"
 
 def test_number_type():
-    assert NUMBER().type == "NUMBER", "NUMBER type mismatch"
+    assert NUMBER() == float(), "NUMBER type mismatch"
 
 def test_datetime_type():
-    assert DATETIME().type == "DATETIME", "DATETIME type mismatch"
+    assert DATETIME(2025, 1, 1) == datetime.datetime(2025, 1, 1), "DATETIME type mismatch"
 
 def test_rowid_type():
-    assert ROWID().type == "ROWID", "ROWID type mismatch"
+    assert ROWID() == int(), "ROWID type mismatch"
 
 def test_date_constructor():
     date = Date(2023, 10, 5)
@@ -44,15 +45,15 @@ def test_time_from_ticks():
     ticks = 1696500000  # Corresponds to 10:00:00
     time = TimeFromTicks(ticks)
     assert isinstance(time, datetime.time), "TimeFromTicks did not return a time object"
-    assert time == datetime.time(10, 0, 0), "TimeFromTicks returned incorrect time"
+    assert time == datetime.time(15, 30, 0), "TimeFromTicks returned incorrect time"
 
 def test_timestamp_from_ticks():
     ticks = 1696500000  # Corresponds to 2023-10-05 10:00:00
     timestamp = TimestampFromTicks(ticks)
     assert isinstance(timestamp, datetime.datetime), "TimestampFromTicks did not return a datetime object"
-    assert timestamp == datetime.datetime(2023, 10, 5, 10, 0, 0, tzinfo=datetime.timezone.utc), "TimestampFromTicks returned incorrect timestamp"
+    assert timestamp == datetime.datetime(2023, 10, 5, 15, 30, 0), "TimestampFromTicks returned incorrect timestamp"
 
 def test_binary_constructor():
-    binary = Binary("test")
-    assert isinstance(binary, bytes), "Binary constructor did not return a bytes object"
+    binary = Binary("test".encode('utf-8'))
+    assert isinstance(binary, (bytes,bytearray)), "Binary constructor did not return a bytes object"
     assert binary == b"test", "Binary constructor returned incorrect bytes"

--- a/tests/test_002_types.py
+++ b/tests/test_002_types.py
@@ -55,5 +55,5 @@ def test_timestamp_from_ticks():
 
 def test_binary_constructor():
     binary = Binary("test".encode('utf-8'))
-    assert isinstance(binary, (bytes,bytearray)), "Binary constructor did not return a bytes object"
+    assert isinstance(binary, (bytes, bytearray)), "Binary constructor did not return a bytes object"
     assert binary == b"test", "Binary constructor returned incorrect bytes"


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below (e.g. AB#37452)
For external contributors: Insert Github Issue number below (e.g. #149)
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> [AB#38059](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/38059)

-------------------------------------------------------------------
### Summary   
This pull request refactors type objects in `mssql_python/type.py` to inherit from their respective Python built-in types, simplifies constructors, and updates related tests to align with the new implementation. Additionally, it modifies timestamp and time handling functions for better compatibility and enhances the `Binary` function to handle multiple input types.

### Refactoring of type objects:
- [`mssql_python/type.py`](diffhunk://#diff-57fcb124a0b5958b9034fbd0c3ee1bc65e4140e1671e642d5dcb5aabd60d55a7L12-R55): Changed type classes (`STRING`, `BINARY`, `NUMBER`, `DATETIME`, `ROWID`) to inherit from Python built-in types (`str`, `bytearray`, `float`, `datetime.datetime`, `int`) and replaced `__init__` methods with `__new__` methods for direct instantiation.

### Updates to utility functions:
- [`mssql_python/type.py`](diffhunk://#diff-57fcb124a0b5958b9034fbd0c3ee1bc65e4140e1671e642d5dcb5aabd60d55a7L93-R113): Modified `TimeFromTicks` to use `time.localtime` instead of `time.gmtime` and updated `TimestampFromTicks` to remove the UTC timezone. Enhanced `Binary` to handle both `str` and `bytes` inputs, with fallback for other types by converting to string first.

### Updates to tests:
- [`tests/test_002_types.py`](diffhunk://#diff-15437630102d01c37a02763e0080246da102ccedaeea931d7c433470ff0fb009L6-R19): Updated tests for type objects (`STRING`, `BINARY`, `NUMBER`, `DATETIME`, `ROWID`) to validate against their respective Python built-in types instead of custom attributes.
- [`tests/test_002_types.py`](diffhunk://#diff-15437630102d01c37a02763e0080246da102ccedaeea931d7c433470ff0fb009L47-R58): Adjusted `test_time_from_ticks` and `test_timestamp_from_ticks` to reflect changes in `TimeFromTicks` and `TimestampFromTicks` behavior. Improved `test_binary_constructor` to test compatibility with both `bytes` and `bytearray`.