### PR TITLE
REFACTOR: Shift `get_driver_path` from Python to DDBC bindings

### DIFF
--- a/mssql_python/helpers.py
+++ b/mssql_python/helpers.py
@@ -146,45 +146,6 @@ def detect_linux_distro():
 
     return distro_name
 
-def get_driver_path(module_dir, architecture):
-    """
-    Get the platform-specific ODBC driver path.
-
-    Args:
-        module_dir (str): Base module directory
-        architecture (str): Target architecture (x64, arm64, x86, etc.)
-
-    Returns:
-        str: Full path to the ODBC driver file
-
-    Raises:
-        RuntimeError: If driver not found or unsupported platform
-    """
-
-    platform_name = platform.system().lower()
-    normalized_arch = normalize_architecture(platform_name, architecture)
-
-    if platform_name == "windows":
-        driver_path = Path(module_dir) / "libs" / "windows" / normalized_arch / "msodbcsql18.dll"
-
-    elif platform_name == "darwin":
-        driver_path = Path(module_dir) / "libs" / "macos" / normalized_arch / "lib" / "libmsodbcsql.18.dylib"
-
-    elif platform_name == "linux":
-        distro_name = detect_linux_distro()
-        driver_path = Path(module_dir) / "libs" / "linux" / distro_name / normalized_arch / "lib" / "libmsodbcsql-18.5.so.1.1"
-
-    else:
-        raise RuntimeError(f"Unsupported platform: {platform_name}")
-
-    driver_path_str = str(driver_path)
-
-    # Check if file exists
-    if not driver_path.exists():
-        raise RuntimeError(f"ODBC driver not found at: {driver_path_str}")
-
-    return driver_path_str
-
 
 def sanitize_connection_string(conn_str: str) -> str:
     """

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -637,20 +637,80 @@ std::string GetLastErrorMessage() {
 #endif
 }
 
-// Function to call Python get_driver_path function
-std::string GetDriverPathFromPython(const std::string& moduleDir, const std::string& architecture) {
-    try {
-        py::module_ helpers = py::module_::import("mssql_python.helpers");
-        py::object get_driver_path = helpers.attr("get_driver_path");
-        py::str result = get_driver_path(moduleDir, architecture);
-        return std::string(result);
-    } catch (const py::error_already_set& e) {
-        LOG("Python error in get_driver_path: {}", e.what());
-        ThrowStdException("Failed to get driver path from Python: " + std::string(e.what()));
-    } catch (const std::exception& e) {
-        LOG("Error calling get_driver_path: {}", e.what());
-        ThrowStdException("Failed to get driver path: " + std::string(e.what()));
-    }
+
+/*
+ * DRIVER PATH RESOLUTION: C++ Only Implementation
+ * 
+ * This function handles all ODBC driver path resolution in C++ rather than calling 
+ * Python helpers to avoid circular import issues on Alpine Linux.
+ * 
+ * BACKGROUND:
+ * Originally, driver path resolution was handled by a Python function in helpers.py
+ * (get_driver_path) that was called from C++ during module initialization. This worked
+ * fine on most platforms but caused a critical circular import issue specifically on
+ * Alpine Linux.
+ * 
+ * THE ALPINE PROBLEM:
+ * 1. Alpine Linux uses musl libc instead of glibc (used by Ubuntu/RHEL/macOS)
+ * 2. musl's dynamic loader has stricter rules about circular dependencies during 
+ *    module initialization
+ * 3. The circular import chain was:
+ *    - ddbc_bindings.cpp starts loading
+ *    - LoadDriverOrThrowException() calls GetDriverPathFromPython()
+ *    - This tries to import mssql_python.helpers
+ *    - helpers.py tries to import ddbc_bindings (not fully loaded yet)
+ *    - Alpine/musl fails with circular import error
+ *    - Ubuntu/macOS/glibc systems handle this gracefully
+ * 
+ * THE SOLUTION:
+ * By implementing driver path resolution entirely in C++, we:
+ * 1. Eliminate all Python dependencies during critical driver initialization
+ * 2. Avoid the circular import issue completely on all platforms
+*/
+std::string GetDriverPathCpp(const std::string& moduleDir) {
+    namespace fs = std::filesystem;
+    fs::path basePath(moduleDir);
+
+    std::string platform;
+    std::string arch;
+
+    // Detect architecture
+    #if defined(__aarch64__) || defined(_M_ARM64)
+        arch = "arm64";
+    #elif defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64)
+        arch = "x86_64";  // maps to "x64" on Windows
+    #else
+        throw std::runtime_error("Unsupported architecture");
+    #endif
+
+    // Detect platform and set path
+    #ifdef __linux__
+        if (fs::exists("/etc/alpine-release")) {
+            platform = "alpine";
+        } else if (fs::exists("/etc/redhat-release") || fs::exists("/etc/centos-release")) {
+            platform = "rhel";
+        } else {
+            platform = "ubuntu";
+        }
+
+        fs::path driverPath = basePath / "libs" / "linux" / platform / arch / "lib" / "libmsodbcsql-18.5.so.1.1";
+        return driverPath.string();
+
+    #elif defined(__APPLE__)
+        platform = "macos";
+        fs::path driverPath = basePath / "libs" / platform / arch / "lib" / "libmsodbcsql.18.dylib";
+        return driverPath.string();
+
+    #elif defined(_WIN32)
+        platform = "windows";
+        // Normalize x86_64 to x64 for Windows naming
+        if (arch == "x86_64") arch = "x64";
+        fs::path driverPath = basePath / "libs" / platform / arch / "lib" / "msodbcsql18.dll";
+        return driverPath.string();
+
+    #else
+        throw std::runtime_error("Unsupported platform");
+    #endif
 }
 
 DriverHandle LoadDriverOrThrowException() {
@@ -662,8 +722,11 @@ DriverHandle LoadDriverOrThrowException() {
     std::string archStr = ARCHITECTURE;
     LOG("Architecture: {}", archStr);
 
-    // Use Python function to get the correct driver path for the platform
-    std::string driverPathStr = GetDriverPathFromPython(moduleDir, archStr);
+    // Use only C++ function for driver path resolution
+    // Not using Python function since it causes circular import issues on Alpine Linux
+    // and other platforms with strict module loading rules.
+    std::string driverPathStr = GetDriverPathCpp(moduleDir);
+    
     fs::path driverPath(driverPathStr);
     
     LOG("Driver path determined: {}", driverPath.string());
@@ -2448,7 +2511,7 @@ PYBIND11_MODULE(ddbc_bindings, m) {
     
     // Expose the C++ functions to Python
     m.def("ThrowStdException", &ThrowStdException);
-    m.def("get_driver_path", &GetDriverPathFromPython, "Get platform-specific ODBC driver path");
+    m.def("GetDriverPathCpp", &GetDriverPathCpp, "Get the path to the ODBC driver");
 
     // Define parameter info class
     py::class_<ParamInfo>(m, "ParamInfo")


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below (e.g. AB#37452)
For external contributors: Insert Github Issue number below (e.g. #149)
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> AB#38102

<!-- External contributors: GitHub Issue -->
> GitHub Issue: #<ISSUE_NUMBER>

-------------------------------------------------------------------
### Summary   
<!-- Insert your summary of changes below. Minimum 10 characters required. -->  
This pull request refactors the ODBC driver path resolution logic to be implemented entirely in C++ instead of Python. The main motivation is to eliminate a circular import issue that caused failures on Alpine Linux due to musl libc's stricter dynamic loading rules. The Python helper and its associated test have been removed, and equivalent logic is now handled in C++. The test suite has been updated to validate the new C++-based resolution.

Refactor: Move driver path resolution to C++

* Removed the `get_driver_path` function from `mssql_python/helpers.py`, eliminating Python-based driver path resolution.
* Implemented `GetDriverPathCpp` in `mssql_python/pybind/ddbc_bindings.cpp` to handle all platform and architecture-specific ODBC driver path resolution in C++. This avoids Python dependencies during module initialization and resolves the Alpine Linux circular import issue. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L640-R713) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L665-R729)
* Updated the C++ Python bindings to expose `GetDriverPathCpp` instead of the removed Python function.

Testing updates

* Removed tests for the old Python helper and added a new test to validate the C++ `GetDriverPathCpp` function against expected driver paths derived in Python. [[1]](diffhunk://#diff-e489a2a29f29954dcd0b17a34b15e53ee2aa4fa1def0a5a466bcee81df59ddf0L318-L332) [[2]](diffhunk://#diff-e489a2a29f29954dcd0b17a34b15e53ee2aa4fa1def0a5a466bcee81df59ddf0R364-R380)
* Added helper imports and a method to compute the expected driver path in the test suite for accurate cross-validation. [[1]](diffhunk://#diff-e489a2a29f29954dcd0b17a34b15e53ee2aa4fa1def0a5a466bcee81df59ddf0R12-R14) [[2]](diffhunk://#diff-e489a2a29f29954dcd0b17a34b15e53ee2aa4fa1def0a5a466bcee81df59ddf0R170-L168)

<!-- 
### PR Title Guide

> For feature requests
FEAT: (short-description)

> For non-feature requests like test case updates, config updates , dependency updates etc
CHORE: (short-description) 

> For Fix requests
FIX: (short-description)

> For doc update requests 
DOC: (short-description)

> For Formatting, indentation, or styling update
STYLE: (short-description)

> For Refactor, without any feature changes
REFACTOR: (short-description)

> For release related changes, without any feature changes
RELEASE: #<RELEASE_VERSION> (short-description) 

### Contribution Guidelines

External contributors:
- Create a GitHub issue first: https://github.com/microsoft/mssql-python/issues/new
- Link the GitHub issue in the "GitHub Issue" section above
- Follow the PR title format and provide a meaningful summary

mssql-python maintainers:
- Create an ADO Work Item following internal processes
- Link the ADO Work Item in the "ADO Work Item" section above  
- Follow the PR title format and provide a meaningful summary
-->