### PR TITLE
FEAT: Support for streaming large parameters in execute()

### DIFF
--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -437,7 +437,13 @@ class Cursor:
             )
 
         # For safety: unknown/unhandled Python types should not silently go to SQL
-        raise TypeError("Unsupported parameter type: The driver cannot safely convert it to a SQL type.")
+        # raise TypeError("Unsupported parameter type: The driver cannot safely convert it to a SQL type.")
+        return (
+            ddbc_sql_const.SQL_VARCHAR.value,
+            ddbc_sql_const.SQL_C_CHAR.value,
+            len(str(param)),
+            0,
+        )
 
     def _initialize_cursor(self) -> None:
         """
@@ -793,6 +799,7 @@ class Cursor:
         except Exception as e:
             log('warning', "Execute failed, resetting cursor: %s", e)
             self._reset_cursor()
+            raise
 
         
         # Capture any diagnostic messages (SQL_SUCCESS_WITH_INFO, etc.)

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -233,7 +233,7 @@ class Cursor:
             return (
                 ddbc_sql_const.SQL_VARCHAR.value, # TODO: Add SQLDescribeParam to get correct type
                 ddbc_sql_const.SQL_C_DEFAULT.value,
-                1,
+                0,
                 0,
                 False,
             )
@@ -513,6 +513,18 @@ class Cursor:
             paraminfo.
         """
         paraminfo = param_info()
+        # Explicit None handling
+        if parameter is None:
+            paraminfo.paramSQLType = ddbc_sql_const.SQL_VARCHAR.value
+            paraminfo.paramCType = ddbc_sql_const.SQL_C_CHAR.value
+            paraminfo.columnSize = 0
+            paraminfo.decimalDigits = 0
+            paraminfo.isDAE = False
+            paraminfo.inputOutputType = ddbc_sql_const.SQL_PARAM_INPUT.value
+            paraminfo.strLenOrInd = ddbc_sql_const.SQL_NULL_DATA.value
+            paraminfo.dataPtr = None
+            return paraminfo
+
         sql_type, c_type, column_size, decimal_digits, is_dae = self._map_sql_type(
             parameter, parameters_list, i
         )

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -233,7 +233,7 @@ class Cursor:
             return (
                 ddbc_sql_const.SQL_VARCHAR.value, # TODO: Add SQLDescribeParam to get correct type
                 ddbc_sql_const.SQL_C_DEFAULT.value,
-                0,
+                1,
                 0,
                 False,
             )
@@ -513,18 +513,6 @@ class Cursor:
             paraminfo.
         """
         paraminfo = param_info()
-        # Explicit None handling
-        if parameter is None:
-            paraminfo.paramSQLType = ddbc_sql_const.SQL_VARCHAR.value
-            paraminfo.paramCType = ddbc_sql_const.SQL_C_CHAR.value
-            paraminfo.columnSize = 0
-            paraminfo.decimalDigits = 0
-            paraminfo.isDAE = False
-            paraminfo.inputOutputType = ddbc_sql_const.SQL_PARAM_INPUT.value
-            paraminfo.strLenOrInd = ddbc_sql_const.SQL_NULL_DATA.value
-            paraminfo.dataPtr = None
-            return paraminfo
-
         sql_type, c_type, column_size, decimal_digits, is_dae = self._map_sql_type(
             parameter, parameters_list, i
         )

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -437,13 +437,7 @@ class Cursor:
             )
 
         # For safety: unknown/unhandled Python types should not silently go to SQL
-        # raise TypeError("Unsupported parameter type: The driver cannot safely convert it to a SQL type.")
-        return (
-            ddbc_sql_const.SQL_VARCHAR.value,
-            ddbc_sql_const.SQL_C_CHAR.value,
-            len(str(param)),
-            0,
-        )
+        raise TypeError("Unsupported parameter type: The driver cannot safely convert it to a SQL type.")
 
     def _initialize_cursor(self) -> None:
         """

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -408,16 +408,6 @@ class Cursor:
                 0,
                 False,
             )
-        
-        # if isinstance(param, (bytes, bytearray)):
-        #     is_large = len(param) > 8000
-        #     return (
-        #         ddbc_sql_const.SQL_VARBINARY.value if is_large else ddbc_sql_const.SQL_BINARY.value,
-        #         ddbc_sql_const.SQL_C_BINARY.value,
-        #         len(param),
-        #         0,
-        #         is_large,
-        #     )
 
         if isinstance(param, datetime.datetime):
             return (

--- a/mssql_python/pybind/CMakeLists.txt
+++ b/mssql_python/pybind/CMakeLists.txt
@@ -272,7 +272,7 @@ target_compile_definitions(ddbc_bindings PRIVATE
 
 # Add warning level flags for MSVC
 if(MSVC)
-    target_compile_options(ddbc_bindings PRIVATE /W4 /WX)
+    target_compile_options(ddbc_bindings PRIVATE /W4 )
 endif()
 
 # Add macOS-specific string conversion fix

--- a/mssql_python/pybind/CMakeLists.txt
+++ b/mssql_python/pybind/CMakeLists.txt
@@ -272,7 +272,7 @@ target_compile_definitions(ddbc_bindings PRIVATE
 
 # Add warning level flags for MSVC
 if(MSVC)
-    target_compile_options(ddbc_bindings PRIVATE /W4 )
+    target_compile_options(ddbc_bindings PRIVATE /W4 /WX)
 endif()
 
 # Add macOS-specific string conversion fix

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -1195,7 +1195,7 @@ SQLRETURN SQLExecute_wrap(const SqlHandlePtr statementHandle,
                         ThrowStdException("Error encoding string to UTF-16: " + std::string(e.what()));
                     }
                     const char* dataPtr = utf16_str.data();
-                    SQLLEN totalBytes = static_cast<SQLLEN>(utf16_str.size());
+                    size_t totalBytes = utf16_str.size();
                     const size_t chunkSize = DAE_CHUNK_SIZE;
                     for (size_t offset = 0; offset < totalBytes; offset += chunkSize) {
                         size_t len = std::min(chunkSize, totalBytes - offset);

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -258,40 +258,14 @@ SQLRETURN BindParameters(SQLHANDLE hStmt, const py::list& params,
                     bufferLength = 0;
                 } else {
                     // Normal small-string case
-            //         std::wstring* strParam =
-            //             AllocateParamBuffer<std::wstring>(paramBuffers, param.cast<std::wstring>());
-            //         LOG("SQL_C_WCHAR Parameter[{}]: Length={}, isDAE={}", paramIndex, strParam->size(), paramInfo.isDAE);
-            // #if defined(__APPLE__) || defined(__linux__)
-            //         std::vector<SQLWCHAR>* sqlwcharBuffer =
-            //             AllocateParamBuffer<std::vector<SQLWCHAR>>(paramBuffers);
-            //         sqlwcharBuffer->resize(strParam->size() + 1, 0);
-            //         for (size_t i = 0; i < strParam->size(); i++) {
-            //             (*sqlwcharBuffer)[i] = static_cast<SQLWCHAR>((*strParam)[i]);
-            //         }
-            //         dataPtr = sqlwcharBuffer->data();
-            //         bufferLength = (strParam->size() + 1) * sizeof(SQLWCHAR);
-            // #else
-            //         dataPtr = const_cast<void*>(static_cast<const void*>(strParam->c_str()));
-            //         bufferLength = (strParam->size() + 1) * sizeof(wchar_t);
-            // #endif
-            //         strLenOrIndPtr = AllocateParamBuffer<SQLLEN>(paramBuffers);
-            //         *strLenOrIndPtr = SQL_NTS;
-                    // Normal small-string case
                     std::wstring* strParam =
                         AllocateParamBuffer<std::wstring>(paramBuffers, param.cast<std::wstring>());
-
                     LOG("SQL_C_WCHAR Parameter[{}]: Length={}, isDAE={}", paramIndex, strParam->size(), paramInfo.isDAE);
-
-                    // Always transcode wstring -> UTF-16 (SQLWCHAR) using the helper
                     std::vector<SQLWCHAR>* sqlwcharBuffer =
                         AllocateParamBuffer<std::vector<SQLWCHAR>>(paramBuffers, WStringToSQLWCHAR(*strParam));
-
                     dataPtr = sqlwcharBuffer->data();
-                    // IMPORTANT: bufferLength must reflect the *encoded* length, including null
                     bufferLength = sqlwcharBuffer->size() * sizeof(SQLWCHAR);
-
                     strLenOrIndPtr = AllocateParamBuffer<SQLLEN>(paramBuffers);
-                    // For SQL_C_WCHAR with a null-terminated buffer, SQL_NTS is correct
                     *strLenOrIndPtr = SQL_NTS;
 
                 }

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -258,24 +258,42 @@ SQLRETURN BindParameters(SQLHANDLE hStmt, const py::list& params,
                     bufferLength = 0;
                 } else {
                     // Normal small-string case
+            //         std::wstring* strParam =
+            //             AllocateParamBuffer<std::wstring>(paramBuffers, param.cast<std::wstring>());
+            //         LOG("SQL_C_WCHAR Parameter[{}]: Length={}, isDAE={}", paramIndex, strParam->size(), paramInfo.isDAE);
+            // #if defined(__APPLE__) || defined(__linux__)
+            //         std::vector<SQLWCHAR>* sqlwcharBuffer =
+            //             AllocateParamBuffer<std::vector<SQLWCHAR>>(paramBuffers);
+            //         sqlwcharBuffer->resize(strParam->size() + 1, 0);
+            //         for (size_t i = 0; i < strParam->size(); i++) {
+            //             (*sqlwcharBuffer)[i] = static_cast<SQLWCHAR>((*strParam)[i]);
+            //         }
+            //         dataPtr = sqlwcharBuffer->data();
+            //         bufferLength = (strParam->size() + 1) * sizeof(SQLWCHAR);
+            // #else
+            //         dataPtr = const_cast<void*>(static_cast<const void*>(strParam->c_str()));
+            //         bufferLength = (strParam->size() + 1) * sizeof(wchar_t);
+            // #endif
+            //         strLenOrIndPtr = AllocateParamBuffer<SQLLEN>(paramBuffers);
+            //         *strLenOrIndPtr = SQL_NTS;
+                    // Normal small-string case
                     std::wstring* strParam =
                         AllocateParamBuffer<std::wstring>(paramBuffers, param.cast<std::wstring>());
+
                     LOG("SQL_C_WCHAR Parameter[{}]: Length={}, isDAE={}", paramIndex, strParam->size(), paramInfo.isDAE);
-            #if defined(__APPLE__) || defined(__linux__)
+
+                    // Always transcode wstring -> UTF-16 (SQLWCHAR) using the helper
                     std::vector<SQLWCHAR>* sqlwcharBuffer =
-                        AllocateParamBuffer<std::vector<SQLWCHAR>>(paramBuffers);
-                    sqlwcharBuffer->resize(strParam->size() + 1, 0);
-                    for (size_t i = 0; i < strParam->size(); i++) {
-                        (*sqlwcharBuffer)[i] = static_cast<SQLWCHAR>((*strParam)[i]);
-                    }
+                        AllocateParamBuffer<std::vector<SQLWCHAR>>(paramBuffers, WStringToSQLWCHAR(*strParam));
+
                     dataPtr = sqlwcharBuffer->data();
-                    bufferLength = (strParam->size() + 1) * sizeof(SQLWCHAR);
-            #else
-                    dataPtr = const_cast<void*>(static_cast<const void*>(strParam->c_str()));
-                    bufferLength = (strParam->size() + 1) * sizeof(wchar_t);
-            #endif
+                    // IMPORTANT: bufferLength must reflect the *encoded* length, including null
+                    bufferLength = sqlwcharBuffer->size() * sizeof(SQLWCHAR);
+
                     strLenOrIndPtr = AllocateParamBuffer<SQLLEN>(paramBuffers);
+                    // For SQL_C_WCHAR with a null-terminated buffer, SQL_NTS is correct
                     *strLenOrIndPtr = SQL_NTS;
+
                 }
                 break;
             }

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -45,7 +45,10 @@ struct ParamInfo {
     SQLSMALLINT decimalDigits;
     // TODO: Reuse python buffer for large data using Python buffer protocol
     // Stores pointer to the python object that holds parameter value
-    // py::object* dataPtr;
+    
+    SQLLEN strLenOrInd = 0;  // Required for DAE
+    bool isDAE = false;      // Indicates if we need to stream via SQLPutData
+    py::object dataPtr; 
 };
 
 // Mirrors the SQL_NUMERIC_STRUCT. But redefined to replace val char array
@@ -134,6 +137,10 @@ SQLFreeStmtFunc SQLFreeStmt_ptr = nullptr;
 
 // Diagnostic APIs
 SQLGetDiagRecFunc SQLGetDiagRec_ptr = nullptr;
+
+// DAE APIs
+SQLParamDataFunc SQLParamData_ptr = nullptr;
+SQLPutDataFunc SQLPutData_ptr = nullptr;
 SQLTablesFunc SQLTables_ptr = nullptr;
 
 namespace {
@@ -245,57 +252,41 @@ SQLRETURN BindParameters(SQLHANDLE hStmt, const py::list& params,
                     !py::isinstance<py::bytes>(param)) {
                     ThrowStdException(MakeParamMismatchErrorStr(paramInfo.paramCType, paramIndex));
                 }
-                std::wstring* strParam =
-                    AllocateParamBuffer<std::wstring>(paramBuffers, param.cast<std::wstring>());
-                if (strParam->size() > 4096 /* TODO: Fix max length */) {
-                    ThrowStdException(
-                        "Streaming parameters is not yet supported. Parameter size"
-                        " must be less than 8192 bytes");
-                }
-                
-                // Log detailed parameter information
-                LOG("SQL_C_WCHAR Parameter[{}]: Length={}, Content='{}'",
-                    paramIndex,
-                    strParam->size(),
-                    (strParam->size() <= 100
-                        ? WideToUTF8(std::wstring(strParam->begin(), strParam->end()))
-                        : WideToUTF8(std::wstring(strParam->begin(), strParam->begin() + 100)) + "..."));
 
-                // Log each character's code point for debugging
-                if (strParam->size() <= 20) {
+                if (paramInfo.isDAE) {
+                    // deferred execution
+                    LOG("Parameter[{}] is marked for DAE streaming", paramIndex);
+                    dataPtr = const_cast<void*>(reinterpret_cast<const void*>(&paramInfos[paramIndex]));
+                    strLenOrIndPtr = AllocateParamBuffer<SQLLEN>(paramBuffers);
+                    *strLenOrIndPtr = SQL_LEN_DATA_AT_EXEC(0);
+                    bufferLength = 0;  // Not used
+                } else {
+                    // Normal small-string case
+                    std::wstring* strParam =
+                        AllocateParamBuffer<std::wstring>(paramBuffers, param.cast<std::wstring>());
+                    LOG("SQL_C_WCHAR Parameter[{}]: Length={}, Content='{}'",
+                        paramIndex,
+                        strParam->size(),
+                        (strParam->size() <= 100
+                            ? WideToUTF8(std::wstring(strParam->begin(), strParam->end()))
+                            : WideToUTF8(std::wstring(strParam->begin(), strParam->begin() + 100)) + "..."));
+
+            #if defined(__APPLE__) || defined(__linux__)
+                    std::vector<SQLWCHAR>* sqlwcharBuffer =
+                        AllocateParamBuffer<std::vector<SQLWCHAR>>(paramBuffers);
+                    sqlwcharBuffer->resize(strParam->size() + 1, 0);
                     for (size_t i = 0; i < strParam->size(); i++) {
-                        unsigned char ch = static_cast<unsigned char>((*strParam)[i]);
-                        LOG("  char[{}] = {} ({})", i, static_cast<int>(ch), DescribeChar(ch));
+                        (*sqlwcharBuffer)[i] = static_cast<SQLWCHAR>((*strParam)[i]);
                     }
+                    dataPtr = sqlwcharBuffer->data();
+                    bufferLength = (strParam->size() + 1) * sizeof(SQLWCHAR);
+            #else
+                    dataPtr = const_cast<void*>(static_cast<const void*>(strParam->c_str()));
+                    bufferLength = (strParam->size() + 1) * sizeof(wchar_t);
+            #endif
+                    strLenOrIndPtr = AllocateParamBuffer<SQLLEN>(paramBuffers);
+                    *strLenOrIndPtr = SQL_NTS;
                 }
-#if defined(__APPLE__) || defined(__linux__)
-                // On macOS/Linux, we need special handling for wide characters
-                // Create a properly encoded SQLWCHAR buffer for the parameter
-                std::vector<SQLWCHAR>* sqlwcharBuffer =
-                    AllocateParamBuffer<std::vector<SQLWCHAR>>(paramBuffers);
-
-                // Reserve space and convert from wstring to SQLWCHAR array
-                std::vector<SQLWCHAR> utf16 = WStringToSQLWCHAR(*strParam);
-                if (utf16.size() < strParam->size()) {
-                    LOG("Warning: UTF-16 encoding shrank string? input={} output={}",
-                        strParam->size(), utf16.size());
-                }
-                if (utf16.size() > strParam->size() * 2 + 1) {
-                    LOG("Warning: UTF-16 expansion unusually large: input={} output={}",
-                        strParam->size(), utf16.size());
-                }
-                *sqlwcharBuffer = std::move(utf16);
-                // Use the SQLWCHAR buffer instead of the wstring directly
-                dataPtr = sqlwcharBuffer->data();
-                bufferLength = sqlwcharBuffer->size() * sizeof(SQLWCHAR);
-                LOG("macOS: Created SQLWCHAR buffer for parameter with size: {} bytes", bufferLength);
-#else
-                // On Windows, wchar_t and SQLWCHAR are the same size, so direct cast works
-                dataPtr = const_cast<void*>(static_cast<const void*>(strParam->c_str()));
-                bufferLength = (strParam->size() + 1 /* null terminator */) * sizeof(wchar_t);
-#endif
-                strLenOrIndPtr = AllocateParamBuffer<SQLLEN>(paramBuffers);
-                *strLenOrIndPtr = SQL_NTS;
                 break;
             }
             case SQL_C_BIT: {
@@ -791,6 +782,9 @@ DriverHandle LoadDriverOrThrowException() {
     SQLFreeStmt_ptr = GetFunctionPointer<SQLFreeStmtFunc>(handle, "SQLFreeStmt");
 
     SQLGetDiagRec_ptr = GetFunctionPointer<SQLGetDiagRecFunc>(handle, "SQLGetDiagRecW");
+
+    SQLParamData_ptr = GetFunctionPointer<SQLParamDataFunc>(handle, "SQLParamData");
+    SQLPutData_ptr = GetFunctionPointer<SQLPutDataFunc>(handle, "SQLPutData");
     SQLTables_ptr = GetFunctionPointer<SQLTablesFunc>(handle, "SQLTablesW");
 
     bool success =
@@ -802,7 +796,8 @@ DriverHandle LoadDriverOrThrowException() {
         SQLGetData_ptr && SQLNumResultCols_ptr && SQLBindCol_ptr &&
         SQLDescribeCol_ptr && SQLMoreResults_ptr && SQLColAttribute_ptr &&
         SQLEndTran_ptr && SQLDisconnect_ptr && SQLFreeHandle_ptr &&
-        SQLFreeStmt_ptr && SQLGetDiagRec_ptr && SQLTables_ptr;
+        SQLFreeStmt_ptr && SQLGetDiagRec_ptr && SQLParamData_ptr &&
+        SQLPutData_ptr && SQLTables_ptr;
 
     if (!success) {
         ThrowStdException("Failed to load required function pointers from driver.");
@@ -1176,16 +1171,61 @@ SQLRETURN SQLExecute_wrap(const SqlHandlePtr statementHandle,
         }
 
         rc = SQLExecute_ptr(hStmt);
+        if (rc == SQL_NEED_DATA) {
+            LOG("Beginning SQLParamData/SQLPutData loop for DAE.");
+            SQLPOINTER paramToken = nullptr;            
+            while ((rc = SQLParamData_ptr(hStmt, &paramToken)) == SQL_NEED_DATA) {
+                // Find the paramInfo that matches the returned token
+                const ParamInfo* matchedInfo = nullptr;
+                for (auto& info : paramInfos) {
+                    if (reinterpret_cast<SQLPOINTER>(const_cast<ParamInfo*>(&info)) == paramToken) {
+                        matchedInfo = &info;
+                        break;
+                    }
+                }
+                if (!matchedInfo) {
+                    ThrowStdException("Unrecognized paramToken returned by SQLParamData");
+                }
+
+                const py::object& pyObj = matchedInfo->dataPtr;
+                if (pyObj.is_none()) {
+                    SQLPutData_ptr(hStmt, nullptr, 0);
+                    continue;
+                }
+                if (py::isinstance<py::str>(pyObj)) {
+                    std::string utf16_str = pyObj.attr("encode")("utf-16-le").cast<py::bytes>();
+                    const char* dataPtr = utf16_str.data();
+                    SQLLEN totalBytes = static_cast<SQLLEN>(utf16_str.size());
+
+                    const size_t chunkSize = 8192;
+                    for (size_t offset = 0; offset < totalBytes; offset += chunkSize) {
+                        size_t len = std::min(chunkSize, totalBytes - offset);
+                        rc = SQLPutData_ptr(hStmt, (SQLPOINTER)(dataPtr + offset), static_cast<SQLLEN>(len));
+                        if (!SQL_SUCCEEDED(rc)) {
+                            LOG("SQLPutData failed.");
+                            return rc;
+                        }
+                    }
+                } else {
+                    ThrowStdException("DAE only supported for str or bytes");
+                }
+            }
+
+            if (!SQL_SUCCEEDED(rc)) {
+                LOG("SQLParamData final rc: {}", rc);
+                return rc;
+            }
+            LOG("DAE complete, SQLExecute resumed internally.");
+        }
+
         if (!SQL_SUCCEEDED(rc) && rc != SQL_NO_DATA) {
             LOG("DDBCSQLExecute: Error during execution of the statement");
             return rc;
         }
-        // TODO: Handle huge input parameters by checking rc == SQL_NEED_DATA
 
         // Unbind the bound buffers for all parameters coz the buffers' memory will
         // be freed when this function exits (parambuffers goes out of scope)
         rc = SQLFreeStmt_ptr(hStmt, SQL_RESET_PARAMS);
-
         return rc;
     }
 }
@@ -2731,8 +2771,11 @@ PYBIND11_MODULE(ddbc_bindings, m) {
         .def_readwrite("paramCType", &ParamInfo::paramCType)
         .def_readwrite("paramSQLType", &ParamInfo::paramSQLType)
         .def_readwrite("columnSize", &ParamInfo::columnSize)
-        .def_readwrite("decimalDigits", &ParamInfo::decimalDigits);
-    
+        .def_readwrite("decimalDigits", &ParamInfo::decimalDigits)
+        .def_readwrite("strLenOrInd", &ParamInfo::strLenOrInd)
+        .def_readwrite("dataPtr", &ParamInfo::dataPtr)
+        .def_readwrite("isDAE", &ParamInfo::isDAE);
+
     // Define numeric data class
     py::class_<NumericData>(m, "NumericData")
         .def(py::init<>())

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -31,6 +31,13 @@ using namespace pybind11::literals;
 
 #include <sql.h>
 #include <sqlext.h>
+#if defined(_WIN32)
+inline std::vector<SQLWCHAR> WStringToSQLWCHAR(const std::wstring& str) {
+    std::vector<SQLWCHAR> result(str.begin(), str.end());
+    result.push_back(0);
+    return result;
+}
+#endif
 
 #if defined(__APPLE__) || defined(__linux__)
 #include <dlfcn.h>

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -203,6 +203,9 @@ typedef SQLRETURN (SQL_API* SQLFreeStmtFunc)(SQLHSTMT, SQLUSMALLINT);
 typedef SQLRETURN (SQL_API* SQLGetDiagRecFunc)(SQLSMALLINT, SQLHANDLE, SQLSMALLINT, SQLWCHAR*, SQLINTEGER*,
                                        SQLWCHAR*, SQLSMALLINT, SQLSMALLINT*);
 
+// DAE APIs
+typedef SQLRETURN (SQL_API* SQLParamDataFunc)(SQLHSTMT, SQLPOINTER*);
+typedef SQLRETURN (SQL_API* SQLPutDataFunc)(SQLHSTMT, SQLPOINTER, SQLLEN);
 //-------------------------------------------------------------------------------------------------
 // Extern function pointer declarations (defined in ddbc_bindings.cpp)
 //-------------------------------------------------------------------------------------------------
@@ -245,6 +248,10 @@ extern SQLFreeStmtFunc SQLFreeStmt_ptr;
 
 // Diagnostic APIs
 extern SQLGetDiagRecFunc SQLGetDiagRec_ptr;
+
+// DAE APIs
+extern SQLParamDataFunc SQLParamData_ptr;
+extern SQLPutDataFunc SQLPutData_ptr;
 
 // Logging utility
 template <typename... Args>

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -31,6 +31,7 @@ using namespace pybind11::literals;
 
 #include <sql.h>
 #include <sqlext.h>
+
 #if defined(_WIN32)
 inline std::vector<SQLWCHAR> WStringToSQLWCHAR(const std::wstring& str) {
     std::vector<SQLWCHAR> result(str.begin(), str.end());

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -32,108 +32,138 @@ using namespace pybind11::literals;
 #include <sql.h>
 #include <sqlext.h>
 
+// #if defined(__APPLE__) || defined(__linux__)
+// #include <dlfcn.h>
+
+// // Unicode constants for surrogate ranges and max scalar value
+// constexpr uint32_t UNICODE_SURROGATE_HIGH_START = 0xD800;
+// constexpr uint32_t UNICODE_SURROGATE_HIGH_END   = 0xDBFF;
+// constexpr uint32_t UNICODE_SURROGATE_LOW_START  = 0xDC00;
+// constexpr uint32_t UNICODE_SURROGATE_LOW_END    = 0xDFFF;
+// constexpr uint32_t UNICODE_MAX_CODEPOINT        = 0x10FFFF;
+// constexpr uint32_t UNICODE_REPLACEMENT_CHAR     = 0xFFFD;
+
+// // Validate whether a code point is a legal Unicode scalar value
+// // (excludes surrogate halves and values beyond U+10FFFF)
+// inline bool IsValidUnicodeScalar(uint32_t cp) {
+//     return cp <= UNICODE_MAX_CODEPOINT &&
+//            !(cp >= UNICODE_SURROGATE_HIGH_START && cp <= UNICODE_SURROGATE_LOW_END);
+// }
+
+// inline std::wstring SQLWCHARToWString(const SQLWCHAR* sqlwStr, size_t length = SQL_NTS) {
+//     if (!sqlwStr) return std::wstring();
+
+//     if (length == SQL_NTS) {
+//         size_t i = 0;
+//         while (sqlwStr[i] != 0) ++i;
+//         length = i;
+//     }
+//     std::wstring result;
+//     result.reserve(length);
+
+//     if constexpr (sizeof(SQLWCHAR) == 2) {
+//         // Decode UTF-16 to UTF-32 (with surrogate pair handling)
+//         for (size_t i = 0; i < length; ++i) {
+//             uint16_t wc = static_cast<uint16_t>(sqlwStr[i]);
+//             // Check if this is a high surrogate (U+D800–U+DBFF)
+//             if (wc >= UNICODE_SURROGATE_HIGH_START && wc <= UNICODE_SURROGATE_HIGH_END && i + 1 < length) {
+//                 uint16_t low = static_cast<uint16_t>(sqlwStr[i + 1]);
+//                 // Check if the next code unit is a low surrogate (U+DC00–U+DFFF)
+//                 if (low >= UNICODE_SURROGATE_LOW_START && low <= UNICODE_SURROGATE_LOW_END) {
+//                     // Combine surrogate pair into a single code point
+//                     uint32_t cp = (((wc - UNICODE_SURROGATE_HIGH_START) << 10) | (low - UNICODE_SURROGATE_LOW_START)) + 0x10000;
+//                     result.push_back(static_cast<wchar_t>(cp));
+//                     ++i; // Skip the low surrogate
+//                     continue;
+//                 }
+//             }
+//             // If valid scalar then append, else append replacement char (U+FFFD)
+//             if (IsValidUnicodeScalar(wc)) {
+//                 result.push_back(static_cast<wchar_t>(wc));
+//             } else {
+//                 result.push_back(static_cast<wchar_t>(UNICODE_REPLACEMENT_CHAR));
+//             }
+//         }
+//     } else {
+//         // SQLWCHAR is UTF-32, so just copy with validation
+//         for (size_t i = 0; i < length; ++i) {
+//             uint32_t cp = static_cast<uint32_t>(sqlwStr[i]);
+//             if (IsValidUnicodeScalar(cp)) {
+//                 result.push_back(static_cast<wchar_t>(cp));
+//             } else {
+//                 result.push_back(static_cast<wchar_t>(UNICODE_REPLACEMENT_CHAR));
+//             }
+//         }
+//     }
+//     return result;
+// }
+
+// inline std::vector<SQLWCHAR> WStringToSQLWCHAR(const std::wstring& str) {
+//     std::vector<SQLWCHAR> result;
+//     result.reserve(str.size() + 2);
+//     if constexpr (sizeof(SQLWCHAR) == 2) {
+//         // Encode UTF-32 to UTF-16
+//         for (wchar_t wc : str) {
+//             uint32_t cp = static_cast<uint32_t>(wc);
+//             if (!IsValidUnicodeScalar(cp)) {
+//                 cp = UNICODE_REPLACEMENT_CHAR;
+//             }
+//             if (cp <= 0xFFFF) {
+//                 // Fits in a single UTF-16 code unit
+//                 result.push_back(static_cast<SQLWCHAR>(cp));
+//             } else {
+//                 // Encode as surrogate pair
+//                 cp -= 0x10000;
+//                 SQLWCHAR high = static_cast<SQLWCHAR>((cp >> 10) + UNICODE_SURROGATE_HIGH_START);
+//                 SQLWCHAR low  = static_cast<SQLWCHAR>((cp & 0x3FF) + UNICODE_SURROGATE_LOW_START);
+//                 result.push_back(high);
+//                 result.push_back(low);
+//             }
+//         }
+//     } else {
+//         // Encode UTF-32 directly
+//         for (wchar_t wc : str) {
+//             uint32_t cp = static_cast<uint32_t>(wc);
+//             if (IsValidUnicodeScalar(cp)) {
+//                 result.push_back(static_cast<SQLWCHAR>(cp));
+//             } else {
+//                 result.push_back(static_cast<SQLWCHAR>(UNICODE_REPLACEMENT_CHAR));
+//             }
+//         }
+//     }
+//     result.push_back(0); // null terminator
+//     return result;
+// }
+// #endif
+
 #if defined(__APPLE__) || defined(__linux__)
-#include <dlfcn.h>
+    // macOS-specific headers
+    #include <dlfcn.h>
 
-// Unicode constants for surrogate ranges and max scalar value
-constexpr uint32_t UNICODE_SURROGATE_HIGH_START = 0xD800;
-constexpr uint32_t UNICODE_SURROGATE_HIGH_END   = 0xDBFF;
-constexpr uint32_t UNICODE_SURROGATE_LOW_START  = 0xDC00;
-constexpr uint32_t UNICODE_SURROGATE_LOW_END    = 0xDFFF;
-constexpr uint32_t UNICODE_MAX_CODEPOINT        = 0x10FFFF;
-constexpr uint32_t UNICODE_REPLACEMENT_CHAR     = 0xFFFD;
+    inline std::wstring SQLWCHARToWString(const SQLWCHAR* sqlwStr, size_t length = SQL_NTS) {
+        if (!sqlwStr) return std::wstring();
 
-// Validate whether a code point is a legal Unicode scalar value
-// (excludes surrogate halves and values beyond U+10FFFF)
-inline bool IsValidUnicodeScalar(uint32_t cp) {
-    return cp <= UNICODE_MAX_CODEPOINT &&
-           !(cp >= UNICODE_SURROGATE_HIGH_START && cp <= UNICODE_SURROGATE_LOW_END);
-}
+        if (length == SQL_NTS) {
+            size_t i = 0;
+            while (sqlwStr[i] != 0) ++i;
+            length = i;
+        }
 
-inline std::wstring SQLWCHARToWString(const SQLWCHAR* sqlwStr, size_t length = SQL_NTS) {
-    if (!sqlwStr) return std::wstring();
-
-    if (length == SQL_NTS) {
-        size_t i = 0;
-        while (sqlwStr[i] != 0) ++i;
-        length = i;
-    }
-    std::wstring result;
-    result.reserve(length);
-
-    if constexpr (sizeof(SQLWCHAR) == 2) {
-        // Decode UTF-16 to UTF-32 (with surrogate pair handling)
+        std::wstring result;
+        result.reserve(length);
         for (size_t i = 0; i < length; ++i) {
-            uint16_t wc = static_cast<uint16_t>(sqlwStr[i]);
-            // Check if this is a high surrogate (U+D800–U+DBFF)
-            if (wc >= UNICODE_SURROGATE_HIGH_START && wc <= UNICODE_SURROGATE_HIGH_END && i + 1 < length) {
-                uint16_t low = static_cast<uint16_t>(sqlwStr[i + 1]);
-                // Check if the next code unit is a low surrogate (U+DC00–U+DFFF)
-                if (low >= UNICODE_SURROGATE_LOW_START && low <= UNICODE_SURROGATE_LOW_END) {
-                    // Combine surrogate pair into a single code point
-                    uint32_t cp = (((wc - UNICODE_SURROGATE_HIGH_START) << 10) | (low - UNICODE_SURROGATE_LOW_START)) + 0x10000;
-                    result.push_back(static_cast<wchar_t>(cp));
-                    ++i; // Skip the low surrogate
-                    continue;
-                }
-            }
-            // If valid scalar then append, else append replacement char (U+FFFD)
-            if (IsValidUnicodeScalar(wc)) {
-                result.push_back(static_cast<wchar_t>(wc));
-            } else {
-                result.push_back(static_cast<wchar_t>(UNICODE_REPLACEMENT_CHAR));
-            }
+            result.push_back(static_cast<wchar_t>(sqlwStr[i]));
         }
-    } else {
-        // SQLWCHAR is UTF-32, so just copy with validation
-        for (size_t i = 0; i < length; ++i) {
-            uint32_t cp = static_cast<uint32_t>(sqlwStr[i]);
-            if (IsValidUnicodeScalar(cp)) {
-                result.push_back(static_cast<wchar_t>(cp));
-            } else {
-                result.push_back(static_cast<wchar_t>(UNICODE_REPLACEMENT_CHAR));
-            }
-        }
+        return result;
     }
-    return result;
-}
 
-inline std::vector<SQLWCHAR> WStringToSQLWCHAR(const std::wstring& str) {
-    std::vector<SQLWCHAR> result;
-    result.reserve(str.size() + 2);
-    if constexpr (sizeof(SQLWCHAR) == 2) {
-        // Encode UTF-32 to UTF-16
-        for (wchar_t wc : str) {
-            uint32_t cp = static_cast<uint32_t>(wc);
-            if (!IsValidUnicodeScalar(cp)) {
-                cp = UNICODE_REPLACEMENT_CHAR;
-            }
-            if (cp <= 0xFFFF) {
-                // Fits in a single UTF-16 code unit
-                result.push_back(static_cast<SQLWCHAR>(cp));
-            } else {
-                // Encode as surrogate pair
-                cp -= 0x10000;
-                SQLWCHAR high = static_cast<SQLWCHAR>((cp >> 10) + UNICODE_SURROGATE_HIGH_START);
-                SQLWCHAR low  = static_cast<SQLWCHAR>((cp & 0x3FF) + UNICODE_SURROGATE_LOW_START);
-                result.push_back(high);
-                result.push_back(low);
-            }
+    inline std::vector<SQLWCHAR> WStringToSQLWCHAR(const std::wstring& str) {
+        std::vector<SQLWCHAR> result(str.size() + 1, 0);  // +1 for null terminator
+        for (size_t i = 0; i < str.size(); ++i) {
+            result[i] = static_cast<SQLWCHAR>(str[i]);
         }
-    } else {
-        // Encode UTF-32 directly
-        for (wchar_t wc : str) {
-            uint32_t cp = static_cast<uint32_t>(wc);
-            if (IsValidUnicodeScalar(cp)) {
-                result.push_back(static_cast<SQLWCHAR>(cp));
-            } else {
-                result.push_back(static_cast<SQLWCHAR>(UNICODE_REPLACEMENT_CHAR));
-            }
-        }
+        return result;
     }
-    result.push_back(0); // null terminator
-    return result;
-}
 #endif
 
 #if defined(__APPLE__) || defined(__linux__)


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below (e.g. AB#37452)
For external contributors: Insert Github Issue number below (e.g. #149)
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> [AB#33395](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/33395)

<!-- External contributors: GitHub Issue -->
> GitHub Issue: #<ISSUE_NUMBER>

-------------------------------------------------------------------
### Summary   
<!-- Insert your summary of changes below. Minimum 10 characters required. -->  
This pull request adds support for streaming large parameters to SQL Server using ODBC's Data At Execution (DAE) mechanism, particularly for long Unicode strings and binary data. The changes update both the Python and C++ layers to correctly identify large parameters, mark them for DAE, and handle the streaming process during execution. Additional refactoring improves parameter type mapping and memory handling for these cases.

**Large parameter streaming (DAE) support:**

* Updated the `_map_sql_type` method in `cursor.py` to return an `is_dae` flag for parameters that require streaming (e.g., long Unicode strings, long binary data), and to calculate the correct size for Unicode strings using UTF-16 encoding. [[1]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R227-R231) [[2]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R329-R366) [[3]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R376-R383) [[4]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R393-R419)
* Modified `_create_parameter_types_list` in `cursor.py` to set DAE-related fields (`isDAE`, `strLenOrInd`, `dataPtr`) in the parameter info when streaming is needed.

**C++ bindings and execution logic:**

* Extended the `ParamInfo` struct and its Python bindings to include DAE fields (`isDAE`, `strLenOrInd`, `dataPtr`) for use during parameter binding and streaming. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L48-R51) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L2509-R2556)
* Added ODBC DAE API function pointers (`SQLParamData`, `SQLPutData`) and integrated their loading and usage into the driver handle setup. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R141-R144) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R785-R787) [[3]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L799-R798) [[4]](diffhunk://#diff-85167a2d59779df18704284ab7ce46220c3619408fbf22c631ffdf29f794d635R121-R123)
* Refactored parameter binding and execution logic in `ddbc_bindings.cpp` to handle DAE parameters: if a parameter is marked for DAE, the code enters a loop to stream the data in chunks using `SQLParamData` and `SQLPutData`. This is done for large Unicode strings and (potentially) binary data. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R254-R288) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R997-L1007)

**Build and warning improvements:**

* Adjusted MSVC compiler flags to remove the "treat warnings as errors" option, making builds less strict on warnings.

<!-- 
### PR Title Guide

> For feature requests
FEAT: (short-description)

> For non-feature requests like test case updates, config updates , dependency updates etc
CHORE: (short-description) 

> For Fix requests
FIX: (short-description)

> For doc update requests 
DOC: (short-description)

> For Formatting, indentation, or styling update
STYLE: (short-description)

> For Refactor, without any feature changes
REFACTOR: (short-description)

> For release related changes, without any feature changes
RELEASE: #<RELEASE_VERSION> (short-description) 

### Contribution Guidelines

External contributors:
- Create a GitHub issue first: https://github.com/microsoft/mssql-python/issues/new
- Link the GitHub issue in the "GitHub Issue" section above
- Follow the PR title format and provide a meaningful summary

mssql-python maintainers:
- Create an ADO Work Item following internal processes
- Link the ADO Work Item in the "ADO Work Item" section above  
- Follow the PR title format and provide a meaningful summary
-->