### PR TITLE
FEAT: Adding statistics API in cursor class

### DIFF
--- a/mssql_python/constants.py
+++ b/mssql_python/constants.py
@@ -122,6 +122,10 @@ class ConstantsDDBC(Enum):
     SQL_ROWVER = 2
     SQL_NO_NULLS = 0
     SQL_NULLABLE_UNKNOWN = 2
+    SQL_INDEX_UNIQUE = 0
+    SQL_INDEX_ALL = 1
+    SQL_QUICK = 0
+    SQL_ENSURE = 1
 
 class AuthType(Enum):
     """Constants for authentication types"""

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -116,6 +116,9 @@ typedef SQLRETURN (SQL_API* SQLPrimaryKeysFunc)(SQLHSTMT, SQLWCHAR*, SQLSMALLINT
 typedef SQLRETURN (SQL_API* SQLSpecialColumnsFunc)(SQLHSTMT, SQLUSMALLINT, SQLWCHAR*, SQLSMALLINT, 
                                        SQLWCHAR*, SQLSMALLINT, SQLWCHAR*, SQLSMALLINT, 
                                        SQLUSMALLINT, SQLUSMALLINT);
+typedef SQLRETURN (SQL_API* SQLStatisticsFunc)(SQLHSTMT, SQLWCHAR*, SQLSMALLINT, SQLWCHAR*, 
+                                      SQLSMALLINT, SQLWCHAR*, SQLSMALLINT, 
+                                      SQLUSMALLINT, SQLUSMALLINT);
 
 // Transaction APIs
 typedef SQLRETURN (SQL_API* SQLEndTranFunc)(SQLSMALLINT, SQLHANDLE, SQLSMALLINT);
@@ -164,6 +167,7 @@ extern SQLProceduresFunc SQLProcedures_ptr;
 extern SQLForeignKeysFunc SQLForeignKeys_ptr;
 extern SQLPrimaryKeysFunc SQLPrimaryKeys_ptr;
 extern SQLSpecialColumnsFunc SQLSpecialColumns_ptr;
+extern SQLStatisticsFunc SQLStatistics_ptr;
 
 // Transaction APIs
 extern SQLEndTranFunc SQLEndTran_ptr;


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below (e.g. AB#37452)
For external contributors: Insert Github Issue number below (e.g. #149)
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> AB#34928

-------------------------------------------------------------------
### Summary   
This pull request adds support for retrieving table and index statistics via the ODBC `SQLStatistics` API in the `mssql_python` package. The main changes include implementing the `statistics` method on the Python cursor, exposing the required C++ bindings, defining new constants, and introducing comprehensive tests to ensure the new functionality works as expected.

**New statistics feature:**

* Added the `statistics` method to the `Cursor` class in `mssql_python/cursor.py`, allowing users to retrieve index and table statistics for a given table, with options to filter by uniqueness, catalog, schema, and quickness of statistics retrieval.
* Defined new constants (`SQL_INDEX_UNIQUE`, `SQL_INDEX_ALL`, `SQL_QUICK`, `SQL_ENSURE`) in `mssql_python/constants.py` to support the statistics method options.

**C++ binding and integration:**

* Added the `SQLStatisticsFunc` type and related function pointer to `mssql_python/pybind/ddbc_bindings.h` and initialized it in `mssql_python/pybind/ddbc_bindings.cpp`.
* Implemented the `SQLStatistics_wrap` function and exposed it to Python via the `DDBCSQLStatistics` binding in the pybind module. 

**Testing:**

* Added a comprehensive suite of tests in `tests/test_004_cursor.py` for the new `statistics` method, including tests for setup, basic functionality, unique index filtering, empty tables, non-existent tables, result structure, catalog filtering, the `quick` parameter, and cleanup.