### PR TITLE
FEAT: streaming support for nvarcharmax in fetch

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,21 +1,190 @@
-from mssql_python import connect
-from mssql_python import setup_logging
-import os
-import decimal
+# from mssql_python import connect
+# from mssql_python import setup_logging
+# import os
+# import decimal
 
-setup_logging('stdout')
+# setup_logging('stdout')
 
-conn_str = os.getenv("DB_CONNECTION_STRING")
-conn = connect(conn_str)
+# conn_str = os.getenv("DB_CONNECTION_STRING")
+# conn = connect(conn_str)
 
-# conn.autocommit = True
+# # conn.autocommit = True
 
-cursor = conn.cursor()
-cursor.execute("SELECT database_id, name from sys.databases;")
-rows = cursor.fetchall()
+# cursor = conn.cursor()
+# cursor.execute("SELECT database_id, name from sys.databases;")
+# rows = cursor.fetchall()
 
-for row in rows:
-    print(f"Database ID: {row[0]}, Name: {row[1]}")
+# for row in rows:
+#     print(f"Database ID: {row[0]}, Name: {row[1]}")
 
-cursor.close()
-conn.close()
+# cursor.close()
+# conn.close()
+
+# from mssql_python import connect  # Replace with actual module name
+# from mssql_python import setup_logging
+# # setup_logging('stdout')
+
+# def test_large_nvarchar():
+#     # Replace with your actual connection string
+#     conn_str = "Server=Saumya;DATABASE=master;UID=sa;PWD=HappyPass1234;Trust_Connection=yes;TrustServerCertificate=yes;"
+
+#     # Connect
+#     conn = connect(conn_str)
+#     cursor = conn.cursor()
+
+#     # Prepare test table
+#     cursor.execute("""
+#         IF OBJECT_ID('dbo.LargeTextTest', 'U') IS NOT NULL DROP TABLE dbo.LargeTextTest;
+#         CREATE TABLE dbo.LargeTextTest (
+#             id INT PRIMARY KEY IDENTITY(1,1),
+#             content NVARCHAR(MAX)
+#         )
+#     """)
+#     conn.commit()
+
+#     # Prepare large string (~1MB)
+#     large_text = "AB" * (1024 * 1024)  # 1MB of 'A'
+
+#     # Insert using parameterized query (should trigger DAE path)
+#     cursor.execute("INSERT INTO dbo.LargeTextTest (content) VALUES (?)", [large_text])
+#     conn.commit()
+
+#     print("✅ Large text inserted successfully!")
+
+#     # Read back
+#     cursor.execute("SELECT DATALENGTH(content), LEFT(content, 100) FROM dbo.LargeTextTest")
+#     row = cursor.fetchone()
+#     if row:
+#         size_bytes, preview = row
+#         print(f"Read back size: {size_bytes} bytes")
+#         print(f"Preview: {preview[:50]}...")
+#     else:
+#         print("❌ No row returned!")
+
+# if __name__ == "__main__":
+#     test_large_nvarchar()
+
+from mssql_python import connect, setup_logging
+
+# setup_logging('stdout')
+def test_small_nvarchar():
+    conn_str = "Server=Saumya;DATABASE=master;UID=sa;PWD=HappyPass1234;Trust_Connection=yes;TrustServerCertificate=yes;"
+    conn = connect(conn_str)
+    cursor = conn.cursor()
+
+    cursor.execute("""
+        IF OBJECT_ID('dbo.SmallTextTest', 'U') IS NOT NULL DROP TABLE dbo.SmallTextTest;
+        CREATE TABLE dbo.SmallTextTest (
+            id INT PRIMARY KEY IDENTITY(1,1),
+            content NVARCHAR(100)  -- small, will use single-fetch path
+        )
+    """)
+    conn.commit()
+
+    small_text = "Hello, this is a short test string ✅"
+    cursor.execute("INSERT INTO dbo.SmallTextTest (content) VALUES (?)", [small_text])
+    conn.commit()
+    print("✅ Small text inserted successfully!")
+
+    cursor.execute("SELECT DATALENGTH(content), content FROM dbo.SmallTextTest")
+    row = cursor.fetchone()
+    if not row:
+        print("❌ No row returned!")
+        return
+
+    size_bytes, full_text = row
+    print(f"Read back size: {size_bytes} bytes")
+    print(f"Fetched text: {full_text}")
+
+    # --- validation ---
+    if full_text == small_text:
+        print("✅ Round-trip validation passed (small string).")
+    else:
+        print("❌ Round-trip validation FAILED!")
+        print(f"Inserted: {small_text}")
+        print(f"Fetched:  {full_text}")
+
+def test_large_nvarchar():
+    conn_str = "Server=Saumya;DATABASE=master;UID=sa;PWD=HappyPass1234;Trust_Connection=yes;TrustServerCertificate=yes;"
+
+
+    conn = connect(conn_str)
+    cursor = conn.cursor()
+
+    cursor.execute("""
+        IF OBJECT_ID('dbo.LargeTextTest', 'U') IS NOT NULL DROP TABLE dbo.LargeTextTest;
+        CREATE TABLE dbo.LargeTextTest (
+            id INT PRIMARY KEY IDENTITY(1,1),
+            content NVARCHAR(MAX)
+        )
+    """)
+    conn.commit()
+
+    large_text = "AB" * (1024 * 1024)  # ~1MB string
+    cursor.execute("INSERT INTO dbo.LargeTextTest (content) VALUES (?)", [large_text])
+    conn.commit()
+    print("✅ Large text inserted successfully!")
+
+    cursor.execute("SELECT DATALENGTH(content), content FROM dbo.LargeTextTest")
+    row = cursor.fetchone()
+    if not row:
+        print("❌ No row returned!")
+        return
+
+    size_bytes, full_text = row
+    print(f"Read back size: {size_bytes} bytes")
+    print(f"Preview: {full_text[:50]}...")
+
+    # --- round-trip validation ---
+    if full_text == large_text:
+        print("✅ Round-trip validation passed (fetched text matches inserted text).")
+    else:
+        print("❌ Round-trip validation FAILED!")
+        print(f"Inserted length: {len(large_text)}, Fetched length: {len(full_text)}")
+
+def test_fetch_modes():
+    conn_str = "Server=Saumya;DATABASE=master;UID=sa;PWD=HappyPass1234;Trust_Connection=yes;TrustServerCertificate=yes;"
+    conn = connect(conn_str)
+    cursor = conn.cursor()
+
+    cursor.execute("DROP TABLE IF EXISTS dbo.MixedTextTest;")
+    cursor.execute("""
+        CREATE TABLE dbo.MixedTextTest (
+            id INT PRIMARY KEY IDENTITY(1,1),
+            small_col NVARCHAR(100),
+            large_col NVARCHAR(MAX)
+        )
+    """)
+    conn.commit()
+
+    small_text = "Short string ✅"
+    large_text = "AB" * (1024 * 1024)  # ~2MB text
+
+    cursor.execute("INSERT INTO dbo.MixedTextTest (small_col, large_col) VALUES (?, ?)", [small_text, large_text])
+    conn.commit()
+    print("✅ Inserted mixed test row")
+
+    # --- FetchOne ---
+    cursor.execute("SELECT small_col, large_col FROM dbo.MixedTextTest")
+    row = cursor.fetchone()
+    print(f"FetchOne -> small len={len(row[0])}, large len={len(row[1])}")
+
+    # --- FetchMany ---
+    cursor.execute("SELECT small_col, large_col FROM dbo.MixedTextTest")
+    rows = cursor.fetchmany(1)
+    print(f"FetchMany -> got {len(rows)} row(s), small len={len(rows[0][0])}, large len={len(rows[0][1])}")
+
+    # --- FetchAll ---
+    cursor.execute("SELECT small_col, large_col FROM dbo.MixedTextTest")
+    rows = cursor.fetchall()
+    print(f"FetchAll -> got {len(rows)} row(s), small len={len(rows[0][0])}, large len={len(rows[0][1])}")
+
+    # Round-trip validation
+    assert row[0] == small_text, "Small text mismatch!"
+    assert row[1] == large_text, "Large text mismatch!"
+    print("✅ Round-trip validation passed for all fetch modes")
+
+if __name__ == "__main__":
+    test_large_nvarchar()
+    test_small_nvarchar()
+    test_fetch_modes()

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -399,16 +399,6 @@ class Cursor:
                 0,
                 False,
             )
-        
-        # if isinstance(param, (bytes, bytearray)):
-        #     is_large = len(param) > 8000
-        #     return (
-        #         ddbc_sql_const.SQL_VARBINARY.value if is_large else ddbc_sql_const.SQL_BINARY.value,
-        #         ddbc_sql_const.SQL_C_BINARY.value,
-        #         len(param),
-        #         0,
-        #         is_large,
-        #     )
 
         if isinstance(param, datetime.datetime):
             return (

--- a/mssql_python/pybind/CMakeLists.txt
+++ b/mssql_python/pybind/CMakeLists.txt
@@ -272,7 +272,7 @@ target_compile_definitions(ddbc_bindings PRIVATE
 
 # Add warning level flags for MSVC
 if(MSVC)
-    target_compile_options(ddbc_bindings PRIVATE /W4 /WX)
+    target_compile_options(ddbc_bindings PRIVATE /W4 )
 endif()
 
 # Add macOS-specific string conversion fix

--- a/mssql_python/pybind/CMakeLists.txt
+++ b/mssql_python/pybind/CMakeLists.txt
@@ -272,7 +272,7 @@ target_compile_definitions(ddbc_bindings PRIVATE
 
 # Add warning level flags for MSVC
 if(MSVC)
-    target_compile_options(ddbc_bindings PRIVATE /W4 )
+    target_compile_options(ddbc_bindings PRIVATE /W4 /WX)
 endif()
 
 # Add macOS-specific string conversion fix

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -30,7 +30,7 @@
 #ifndef ARCHITECTURE
 #define ARCHITECTURE "win64"  // Default to win64 if not defined during compilation
 #endif
-
+#define DAE_CHUNK_SIZE 8192
 //-------------------------------------------------------------------------------------------------
 // Class definitions
 //-------------------------------------------------------------------------------------------------
@@ -43,11 +43,8 @@ struct ParamInfo {
     SQLSMALLINT paramSQLType;
     SQLULEN columnSize;
     SQLSMALLINT decimalDigits;
-    // TODO: Reuse python buffer for large data using Python buffer protocol
-    // Stores pointer to the python object that holds parameter value
-    
     SQLLEN strLenOrInd = 0;  // Required for DAE
-    bool isDAE = false;      // Indicates if we need to stream via SQLPutData
+    bool isDAE = false;      // Indicates if we need to stream
     py::object dataPtr; 
 };
 
@@ -251,14 +248,13 @@ SQLRETURN BindParameters(SQLHANDLE hStmt, const py::list& params,
                     !py::isinstance<py::bytes>(param)) {
                     ThrowStdException(MakeParamMismatchErrorStr(paramInfo.paramCType, paramIndex));
                 }
-
                 if (paramInfo.isDAE) {
                     // deferred execution
                     LOG("Parameter[{}] is marked for DAE streaming", paramIndex);
                     dataPtr = const_cast<void*>(reinterpret_cast<const void*>(&paramInfos[paramIndex]));
                     strLenOrIndPtr = AllocateParamBuffer<SQLLEN>(paramBuffers);
                     *strLenOrIndPtr = SQL_LEN_DATA_AT_EXEC(0);
-                    bufferLength = 0;  // Not used
+                    bufferLength = 0;
                 } else {
                     // Normal small-string case
                     std::wstring* strParam =
@@ -784,7 +780,6 @@ DriverHandle LoadDriverOrThrowException() {
 
     SQLParamData_ptr = GetFunctionPointer<SQLParamDataFunc>(handle, "SQLParamData");
     SQLPutData_ptr = GetFunctionPointer<SQLPutDataFunc>(handle, "SQLPutData");
-
     bool success =
         SQLAllocHandle_ptr && SQLSetEnvAttr_ptr && SQLSetConnectAttr_ptr &&
         SQLSetStmtAttr_ptr && SQLGetConnectAttr_ptr && SQLDriverConnect_ptr &&
@@ -998,7 +993,7 @@ SQLRETURN SQLExecute_wrap(const SqlHandlePtr statementHandle,
             LOG("Beginning SQLParamData/SQLPutData loop for DAE.");
             SQLPOINTER paramToken = nullptr;            
             while ((rc = SQLParamData_ptr(hStmt, &paramToken)) == SQL_NEED_DATA) {
-                // Find the paramInfo that matches the returned token
+                // Finding the paramInfo that matches the returned token
                 const ParamInfo* matchedInfo = nullptr;
                 for (auto& info : paramInfos) {
                     if (reinterpret_cast<SQLPOINTER>(const_cast<ParamInfo*>(&info)) == paramToken) {
@@ -1009,18 +1004,21 @@ SQLRETURN SQLExecute_wrap(const SqlHandlePtr statementHandle,
                 if (!matchedInfo) {
                     ThrowStdException("Unrecognized paramToken returned by SQLParamData");
                 }
-
                 const py::object& pyObj = matchedInfo->dataPtr;
                 if (pyObj.is_none()) {
                     SQLPutData_ptr(hStmt, nullptr, 0);
                     continue;
                 }
                 if (py::isinstance<py::str>(pyObj)) {
-                    std::string utf16_str = pyObj.attr("encode")("utf-16-le").cast<py::bytes>();
+                    std::string utf16_str;
+                    try {
+                        utf16_str = pyObj.attr("encode")("utf-16-le").cast<py::bytes>();
+                    } catch (const std::exception& e) {
+                        ThrowStdException("Error encoding string to UTF-16: " + std::string(e.what()));
+                    }
                     const char* dataPtr = utf16_str.data();
                     SQLLEN totalBytes = static_cast<SQLLEN>(utf16_str.size());
-
-                    const size_t chunkSize = 8192;
+                    const size_t chunkSize = DAE_CHUNK_SIZE;
                     for (size_t offset = 0; offset < totalBytes; offset += chunkSize) {
                         size_t len = std::min(chunkSize, totalBytes - offset);
                         rc = SQLPutData_ptr(hStmt, (SQLPOINTER)(dataPtr + offset), static_cast<SQLLEN>(len));
@@ -1033,14 +1031,12 @@ SQLRETURN SQLExecute_wrap(const SqlHandlePtr statementHandle,
                     ThrowStdException("DAE only supported for str or bytes");
                 }
             }
-
             if (!SQL_SUCCEEDED(rc)) {
                 LOG("SQLParamData final rc: {}", rc);
                 return rc;
             }
             LOG("DAE complete, SQLExecute resumed internally.");
         }
-
         if (!SQL_SUCCEEDED(rc) && rc != SQL_NO_DATA) {
             LOG("DDBCSQLExecute: Error during execution of the statement");
             return rc;

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -1017,7 +1017,7 @@ SQLRETURN SQLExecute_wrap(const SqlHandlePtr statementHandle,
                         ThrowStdException("Error encoding string to UTF-16: " + std::string(e.what()));
                     }
                     const char* dataPtr = utf16_str.data();
-                    SQLLEN totalBytes = static_cast<SQLLEN>(utf16_str.size());
+                    size_t totalBytes = utf16_str.size();
                     const size_t chunkSize = DAE_CHUNK_SIZE;
                     for (size_t offset = 0; offset < totalBytes; offset += chunkSize) {
                         size_t len = std::min(chunkSize, totalBytes - offset);

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -118,6 +118,9 @@ typedef SQLRETURN (SQL_API* SQLFreeStmtFunc)(SQLHSTMT, SQLUSMALLINT);
 typedef SQLRETURN (SQL_API* SQLGetDiagRecFunc)(SQLSMALLINT, SQLHANDLE, SQLSMALLINT, SQLWCHAR*, SQLINTEGER*,
                                        SQLWCHAR*, SQLSMALLINT, SQLSMALLINT*);
 
+// DAE APIs
+typedef SQLRETURN (SQL_API* SQLParamDataFunc)(SQLHSTMT, SQLPOINTER*);
+typedef SQLRETURN (SQL_API* SQLPutDataFunc)(SQLHSTMT, SQLPOINTER, SQLLEN);
 //-------------------------------------------------------------------------------------------------
 // Extern function pointer declarations (defined in ddbc_bindings.cpp)
 //-------------------------------------------------------------------------------------------------
@@ -159,6 +162,10 @@ extern SQLFreeStmtFunc SQLFreeStmt_ptr;
 
 // Diagnostic APIs
 extern SQLGetDiagRecFunc SQLGetDiagRec_ptr;
+
+// DAE APIs
+extern SQLParamDataFunc SQLParamData_ptr;
+extern SQLPutDataFunc SQLPutData_ptr;
 
 // Logging utility
 template <typename... Args>


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below (e.g. AB#37452)
For external contributors: Insert Github Issue number below (e.g. #149)
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> AB#<WORK_ITEM_ID>

<!-- External contributors: GitHub Issue -->
> GitHub Issue: #<ISSUE_NUMBER>

-------------------------------------------------------------------
### Summary   
<!-- Insert your summary of changes below. Minimum 10 characters required. -->  
This pull request introduces significant improvements to the handling of large NVARCHAR and binary parameters in the MSSQL Python driver, adds comprehensive test cases for various string and binary scenarios, and makes several adjustments to type mapping and build configuration. The main focus is on enabling and validating the "Data-at-Execution" (DAE) streaming path for large data, ensuring robust round-trip data integrity, and improving parameter type handling.

**Enhancements to parameter handling and DAE support:**

* Updated `_map_sql_type` in `mssql_python/cursor.py` to return an additional `is_dae` flag, indicating when parameters should be sent using the Data-at-Execution (DAE) streaming path (for large strings and binaries). This enables correct handling of large NVARCHAR and VARBINARY data. [[1]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R227-R231) [[2]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R240-R263) [[3]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R272) [[4]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R284) [[5]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R298) [[6]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R311) [[7]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R320) [[8]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R329-R366) [[9]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R376-R383) [[10]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R393-R400) [[11]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R409) [[12]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R418) [[13]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R427-R435)
* Modified `_create_parameter_types_list` to set the new `isDAE` flag and configure parameters for streaming with ODBC when necessary.
* Added DAE-related ODBC API function pointer types and externs in `mssql_python/pybind/ddbc_bindings.h` to support streaming large parameter data at execution time. [[1]](diffhunk://#diff-85167a2d59779df18704284ab7ce46220c3619408fbf22c631ffdf29f794d635R121-R123) [[2]](diffhunk://#diff-85167a2d59779df18704284ab7ce46220c3619408fbf22c631ffdf29f794d635R166-R169)

**Testing and validation improvements:**

* Expanded `main.py` with new test functions: `test_small_nvarchar`, `test_large_nvarchar`, and `test_fetch_modes`, which comprehensively validate small and large NVARCHAR round-trips, mixed fetch modes, and correct handling of streamed data.

**Type mapping and correctness:**

* Improved Unicode string length calculation for NVARCHAR parameters by using UTF-16 code unit length instead of Python string length, ensuring correct sizing for ODBC.
* Ensured all relevant type mappings now return the new `is_dae` flag, providing a consistent interface for parameter handling. [[1]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R227-R231) [[2]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R240-R263) [[3]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R272) [[4]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R284) [[5]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R298) [[6]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R311) [[7]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R320) [[8]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R329-R366) [[9]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R376-R383) [[10]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R393-R400) [[11]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R409) [[12]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R418) [[13]](diffhunk://#diff-deceea46ae01082ce8400e14fa02f4b7585afb7b5ed9885338b66494f5f38280R427-R435)

**Build configuration:**

* Disabled the `/WX` (treat warnings as errors) flag for MSVC builds in `mssql_python/pybind/CMakeLists.txt` to allow for more flexible compilation.

<!-- 
### PR Title Guide

> For feature requests
FEAT: (short-description)

> For non-feature requests like test case updates, config updates , dependency updates etc
CHORE: (short-description) 

> For Fix requests
FIX: (short-description)

> For doc update requests 
DOC: (short-description)

> For Formatting, indentation, or styling update
STYLE: (short-description)

> For Refactor, without any feature changes
REFACTOR: (short-description)

> For release related changes, without any feature changes
RELEASE: #<RELEASE_VERSION> (short-description) 

### Contribution Guidelines

External contributors:
- Create a GitHub issue first: https://github.com/microsoft/mssql-python/issues/new
- Link the GitHub issue in the "GitHub Issue" section above
- Follow the PR title format and provide a meaningful summary

mssql-python maintainers:
- Create an ADO Work Item following internal processes
- Link the ADO Work Item in the "ADO Work Item" section above  
- Follow the PR title format and provide a meaningful summary
-->