### PR TITLE
FIX: Removed aggressive datetime parsing

### DIFF
--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -362,7 +362,7 @@ class Cursor:
                     0,
                     False,
                 )
-            
+                
             try:
                 val = uuid.UUID(param)
                 parameters_list[i] = val.bytes_le

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -376,38 +376,6 @@ class Cursor:
             except ValueError:
                 pass
 
-
-            # Attempt to parse as date, datetime, datetime2, timestamp, smalldatetime or time
-            if self._parse_date(param):
-                parameters_list[i] = self._parse_date(
-                    param
-                )  # Replace the parameter with the date object
-                return (
-                    ddbc_sql_const.SQL_DATE.value,
-                    ddbc_sql_const.SQL_C_TYPE_DATE.value,
-                    10,
-                    0,
-                    False,
-                )
-            if self._parse_datetime(param):
-                parameters_list[i] = self._parse_datetime(param)
-                return (
-                    ddbc_sql_const.SQL_TIMESTAMP.value,
-                    ddbc_sql_const.SQL_C_TYPE_TIMESTAMP.value,
-                    26,
-                    6,
-                    False,
-                )
-            if self._parse_time(param):
-                parameters_list[i] = self._parse_time(param)
-                return (
-                    ddbc_sql_const.SQL_TIME.value,
-                    ddbc_sql_const.SQL_C_TYPE_TIME.value,
-                    8,
-                    0,
-                    False,
-                )
-
             # String mapping logic here
             is_unicode = self._is_unicode_string(param)
 

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -10661,6 +10661,89 @@ def test_decimal_separator_calculations(cursor, db_connection):
         # Cleanup
         cursor.execute("DROP TABLE IF EXISTS #pytest_decimal_calc_test")
 
+def test_date_string_parameter_binding(cursor, db_connection):
+    """Verify that date-like strings are treated as strings in parameter binding"""
+    table_name = "#pytest_date_string"
+    try:
+        drop_table_if_exists(cursor, table_name)
+        cursor.execute(f"""
+            CREATE TABLE {table_name} (
+                a_column VARCHAR(20)
+            )
+        """)
+        cursor.execute(f"INSERT INTO {table_name} (a_column) VALUES ('string1'), ('string2')")
+        db_connection.commit()
+
+        date_str = "2025-08-12"
+
+        # Should fail to match anything, since binding may treat it as DATE not VARCHAR
+        cursor.execute(f"SELECT a_column FROM {table_name} WHERE RIGHT(a_column, 10) = ?", (date_str,))
+        rows = cursor.fetchall()
+
+        assert rows == [], f"Expected no match for date-like string, got {rows}"
+
+    except Exception as e:
+        pytest.fail(f"Date string parameter binding test failed: {e}")
+    finally:
+        drop_table_if_exists(cursor, table_name)
+        db_connection.commit()
+
+def test_time_string_parameter_binding(cursor, db_connection):
+    """Verify that time-like strings are treated as strings in parameter binding"""
+    table_name = "#pytest_time_string"
+    try:
+        drop_table_if_exists(cursor, table_name)
+        cursor.execute(f"""
+            CREATE TABLE {table_name} (
+                time_col VARCHAR(22)
+            )
+        """)
+        cursor.execute(f"INSERT INTO {table_name} (time_col) VALUES ('prefix_14:30:45_suffix')")
+        db_connection.commit()
+
+        time_str = "14:30:45"
+
+        # This should fail because '14:30:45' gets converted to TIME type
+        # and SQL Server can't compare TIME against VARCHAR with prefix/suffix
+        cursor.execute(f"SELECT time_col FROM {table_name} WHERE time_col = ?", (time_str,))
+        rows = cursor.fetchall()
+
+        assert rows == [], f"Expected no match for time-like string, got {rows}"
+
+    except Exception as e:
+        pytest.fail(f"Time string parameter binding test failed: {e}")
+    finally:
+        drop_table_if_exists(cursor, table_name)
+        db_connection.commit()
+
+def test_datetime_string_parameter_binding(cursor, db_connection):
+    """Verify that datetime-like strings are treated as strings in parameter binding"""
+    table_name = "#pytest_datetime_string"
+    try:
+        drop_table_if_exists(cursor, table_name)
+        cursor.execute(f"""
+            CREATE TABLE {table_name} (
+                datetime_col VARCHAR(33)
+            )
+        """)
+        cursor.execute(f"INSERT INTO {table_name} (datetime_col) VALUES ('prefix_2025-08-12T14:30:45_suffix')")
+        db_connection.commit()
+
+        datetime_str = "2025-08-12T14:30:45"
+
+        # This should fail because '2025-08-12T14:30:45' gets converted to TIMESTAMP type
+        # and SQL Server can't compare TIMESTAMP against VARCHAR with prefix/suffix
+        cursor.execute(f"SELECT datetime_col FROM {table_name} WHERE datetime_col = ?", (datetime_str,))
+        rows = cursor.fetchall()
+
+        assert rows == [], f"Expected no match for datetime-like string, got {rows}"
+
+    except Exception as e:
+        pytest.fail(f"Datetime string parameter binding test failed: {e}")
+    finally:
+        drop_table_if_exists(cursor, table_name)
+        db_connection.commit()
+        
 def test_close(db_connection):
     """Test closing the cursor"""
     try:


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below (e.g. AB#37452)
For external contributors: Insert Github Issue number below (e.g. #149)
Only one reference is required - either GitHub issue OR ADO Work Item.
-->


<!-- External contributors: GitHub Issue -->
> GitHub Issue: https://github.com/microsoft/mssql-python/issues/234

-------------------------------------------------------------------
### Summary   
### Summary

This PR fixes a critical issue where string parameters were being automatically converted to datetime objects, causing failures in SQL queries that require string-to-string comparisons. The fix removes aggressive content-based datetime parsing from the `_map_sql_type()` method while preserving all existing functionality for actual datetime objects.

### Problem

The mssql-python driver was failing on queries like:
```python
cursor.execute("SELECT * FROM table WHERE RIGHT(column, 10) = ?", ('2025-08-12',))
```

This would throw datetime conversion errors because the driver was automatically trying to parse the string `'2025-08-12'` as a date object, even when it should remain a string for the RIGHT() function comparison.

### Problematic Code (Before Fix):
```python
if isinstance(param, str):
    # Attempt to parse as date, datetime, datetime2, timestamp, smalldatetime or time
    if self._parse_date(param):
        parameters_list[i] = self._parse_date(param)  # MUTATION!
        return (SQL_DATE, SQL_C_TYPE_DATE, 10, 0, False)
    if self._parse_datetime(param):
        parameters_list[i] = self._parse_datetime(param)  # MUTATION!
        return (SQL_TIMESTAMP, SQL_C_TYPE_TIMESTAMP, 26, 6, False)
    # ... more parsing attempts
```

### Why This Was Wrong:
1. **Violated separation of concerns**: Type mapping shouldn't do content parsing
2. **Unpredictable behavior**: Same string could be treated differently in different contexts
3. **Data mutation**: Modified user's parameter data without permission
4. **Against DB-API principles**: Parameter binding should be based on Python type, not content

### Solution

**Approach**: Follow PyMSSQL's proven type-based parameter mapping approach.

**Key Changes**:
1. **Removed automatic datetime parsing** from `_map_sql_type()` for string parameters
2. **Strings now always map to VARCHAR/NVARCHAR** based purely on Python type

**Files Modified**:
- `mssql_python/cursor.py`: Simplified string parameter handling in `_map_sql_type()`
- `tests/test_004_cursor.py`: Added test for string parameter behavior

### Before vs After

**Before** (Failed):
```python
date_str = '2025-08-12'
cursor.execute("SELECT * WHERE RIGHT(column, 10) = ?", (date_str,))  # DateTime conversion error
```

**After** (Works):
```python  
date_str = '2025-08-12'
cursor.execute("SELECT * WHERE RIGHT(column, 10) = ?", (date_str,))  # Works correctly
```
