### PR TITLE
FEAT : uniqueidentifier support in executemany() 

### DIFF
--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -958,8 +958,6 @@ class Cursor:
 
         if parameters:
             for i, param in enumerate(parameters):
-                if isinstance(param, uuid.UUID):
-                    parameters[i] = param.bytes
                 paraminfo = self._create_parameter_types_list(
                     param, param_info, parameters, i
                 )

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -441,6 +441,15 @@ class Cursor:
                     0,
                     False
                 )
+        
+        if isinstance(param, uuid.UUID):
+            return (
+                ddbc_sql_const.SQL_GUID.value,
+                ddbc_sql_const.SQL_C_GUID.value,
+                16,
+                0,
+                False,
+            )
 
         if isinstance(param, datetime.datetime):
             return (
@@ -949,6 +958,8 @@ class Cursor:
 
         if parameters:
             for i, param in enumerate(parameters):
+                if isinstance(param, uuid.UUID):
+                    parameters[i] = param.bytes
                 paraminfo = self._create_parameter_types_list(
                     param, param_info, parameters, i
                 )

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -1908,6 +1908,82 @@ SQLRETURN BindParameterArray(SQLHANDLE hStmt,
                     bufferLength = sizeof(SQL_NUMERIC_STRUCT);
                     break;
                 }
+//                 case SQL_C_GUID: {
+//     SQLGUID* guidArray = AllocateParamBufferArray<SQLGUID>(tempBuffers, paramSetSize);
+//     strLenOrIndArray = AllocateParamBufferArray<SQLLEN>(tempBuffers, paramSetSize);
+
+//     for (size_t i = 0; i < paramSetSize; ++i) {
+//         if (columnValues[i].is_none()) {
+//             std::memset(&guidArray[i], 0, sizeof(SQLGUID));
+//             strLenOrIndArray[i] = SQL_NULL_DATA;
+//         } else {
+//             if (!py::isinstance<py::bytes>(columnValues[i])) {
+//                 ThrowStdException(MakeParamMismatchErrorStr(info.paramCType, paramIndex));
+//             }
+//             py::bytes uuid_bytes = columnValues[i].cast<py::bytes>();
+//             const unsigned char* uuid_data = reinterpret_cast<const unsigned char*>(PyBytes_AS_STRING(uuid_bytes.ptr()));
+//             if (PyBytes_GET_SIZE(uuid_bytes.ptr()) != 16) {
+//                 ThrowStdException("UUID binary data must be exactly 16 bytes long.");
+//             }
+
+//             // Map bytes to SQLGUID fields
+//             guidArray[i].Data1 = (static_cast<uint32_t>(uuid_data[3]) << 24) |
+//                                  (static_cast<uint32_t>(uuid_data[2]) << 16) |
+//                                  (static_cast<uint32_t>(uuid_data[1]) << 8)  |
+//                                  (static_cast<uint32_t>(uuid_data[0]));
+//             guidArray[i].Data2 = (static_cast<uint16_t>(uuid_data[5]) << 8) |
+//                                  (static_cast<uint16_t>(uuid_data[4]));
+//             guidArray[i].Data3 = (static_cast<uint16_t>(uuid_data[7]) << 8) |
+//                                  (static_cast<uint16_t>(uuid_data[6]));
+//             std::memcpy(guidArray[i].Data4, &uuid_data[8], 8);
+
+//             strLenOrIndArray[i] = sizeof(SQLGUID);
+//         }
+//     }
+
+//     dataPtr = guidArray;
+//     bufferLength = sizeof(SQLGUID);
+//     break;
+// }
+case SQL_C_GUID: {
+    SQLGUID* guidArray = AllocateParamBufferArray<SQLGUID>(tempBuffers, paramSetSize);
+    strLenOrIndArray = AllocateParamBufferArray<SQLLEN>(tempBuffers, paramSetSize);
+
+    py::object uuid_type = py::module_::import("uuid").attr("UUID");
+
+    for (size_t i = 0; i < paramSetSize; ++i) {
+        if (columnValues[i].is_none()) {
+            std::memset(&guidArray[i], 0, sizeof(SQLGUID));
+            strLenOrIndArray[i] = SQL_NULL_DATA;
+        } else if (py::isinstance(columnValues[i], uuid_type)) {
+            py::bytes uuid_bytes = columnValues[i].attr("bytes");
+            const unsigned char* uuid_data = reinterpret_cast<const unsigned char*>(PyBytes_AS_STRING(uuid_bytes.ptr()));
+
+            if (PyBytes_GET_SIZE(uuid_bytes.ptr()) != 16) {
+                ThrowStdException("UUID binary data must be exactly 16 bytes long.");
+            }
+
+            guidArray[i].Data1 = (static_cast<uint32_t>(uuid_data[3]) << 24) |
+                                 (static_cast<uint32_t>(uuid_data[2]) << 16) |
+                                 (static_cast<uint32_t>(uuid_data[1]) << 8)  |
+                                 (static_cast<uint32_t>(uuid_data[0]));
+            guidArray[i].Data2 = (static_cast<uint16_t>(uuid_data[5]) << 8) |
+                                 (static_cast<uint16_t>(uuid_data[4]));
+            guidArray[i].Data3 = (static_cast<uint16_t>(uuid_data[7]) << 8) |
+                                 (static_cast<uint16_t>(uuid_data[6]));
+            std::memcpy(guidArray[i].Data4, &uuid_data[8], 8);
+
+            strLenOrIndArray[i] = sizeof(SQLGUID);
+        } else {
+            ThrowStdException(MakeParamMismatchErrorStr(info.paramCType, paramIndex));
+        }
+    }
+
+    dataPtr = guidArray;
+    bufferLength = sizeof(SQLGUID);
+    break;
+}
+
                 default: {
                     ThrowStdException("BindParameterArray: Unsupported C type: " + std::to_string(info.paramCType));
                 }

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -2992,9 +2992,6 @@ SQLRETURN FetchBatchData(SQLHSTMT hStmt, ColumnBuffers& buffers, py::list& colum
                 }
                 case SQL_GUID: {
                     SQLGUID* guidValue = &buffers.guidBuffers[col - 1][i];
-                    // We already have the raw bytes from SQL Server in the SQLGUID struct.
-                    // We do not need to perform any additional reordering here, as the C++
-                    // SQLGUID struct is already laid out in the non-standard SQL Server byte order.
                     std::vector<char> guid_bytes(16);
                     std::memcpy(guid_bytes.data(), guidValue, sizeof(SQLGUID));
 

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -504,7 +504,34 @@ SQLRETURN BindParameters(SQLHANDLE hStmt, const py::list& params,
                 break;
             }
             case SQL_C_GUID: {
-                // TODO
+                if (!py::isinstance<py::bytes>(param)) {
+                    ThrowStdException(MakeParamMismatchErrorStr(paramInfo.paramCType, paramIndex));
+                }
+                py::bytes uuid_bytes = param.cast<py::bytes>();
+                const unsigned char* uuid_data = reinterpret_cast<const unsigned char*>(PyBytes_AS_STRING(uuid_bytes.ptr()));
+                if (PyBytes_GET_SIZE(uuid_bytes.ptr()) != 16) {
+                    ThrowStdException("UUID binary data must be exactly 16 bytes long.");
+                }
+                SQLGUID* guid_data_ptr = AllocateParamBuffer<SQLGUID>(paramBuffers);
+
+                guid_data_ptr->Data1 = 
+                    (static_cast<uint32_t>(uuid_data[3]) << 24) | 
+                    (static_cast<uint32_t>(uuid_data[2]) << 16) | 
+                    (static_cast<uint32_t>(uuid_data[1]) << 8)  | 
+                    (static_cast<uint32_t>(uuid_data[0]));
+                guid_data_ptr->Data2 = 
+                    (static_cast<uint16_t>(uuid_data[5]) << 8) | 
+                    (static_cast<uint16_t>(uuid_data[4]));
+                guid_data_ptr->Data3 = 
+                    (static_cast<uint16_t>(uuid_data[7]) << 8) | 
+                    (static_cast<uint16_t>(uuid_data[6]));
+
+                std::memcpy(guid_data_ptr->Data4, &uuid_data[8], 8);
+                dataPtr = static_cast<void*>(guid_data_ptr);
+                bufferLength = sizeof(SQLGUID);
+                strLenOrIndPtr = AllocateParamBuffer<SQLLEN>(paramBuffers);
+                *strLenOrIndPtr = sizeof(SQLGUID);
+                break;
             }
             default: {
                 std::ostringstream errorString;
@@ -2553,20 +2580,27 @@ SQLRETURN SQLGetData_wrap(SqlHandlePtr StatementHandle, SQLUSMALLINT colCount, p
 #if (ODBCVER >= 0x0350)
             case SQL_GUID: {
                 SQLGUID guidValue;
-                ret = SQLGetData_ptr(hStmt, i, SQL_C_GUID, &guidValue, sizeof(guidValue), NULL);
-                if (SQL_SUCCEEDED(ret)) {
-                    std::ostringstream oss;
-                    oss << std::hex << std::setfill('0') << std::setw(8) << guidValue.Data1 << '-'
-                        << std::setw(4) << guidValue.Data2 << '-' << std::setw(4) << guidValue.Data3
-                        << '-' << std::setw(2) << static_cast<int>(guidValue.Data4[0])
-                        << std::setw(2) << static_cast<int>(guidValue.Data4[1]) << '-' << std::hex
-                        << std::setw(2) << static_cast<int>(guidValue.Data4[2]) << std::setw(2)
-                        << static_cast<int>(guidValue.Data4[3]) << std::setw(2)
-                        << static_cast<int>(guidValue.Data4[4]) << std::setw(2)
-                        << static_cast<int>(guidValue.Data4[5]) << std::setw(2)
-                        << static_cast<int>(guidValue.Data4[6]) << std::setw(2)
-                        << static_cast<int>(guidValue.Data4[7]);
-                    row.append(oss.str());  // Append GUID as a string
+                SQLLEN indicator;
+                ret = SQLGetData_ptr(hStmt, i, SQL_C_GUID, &guidValue, sizeof(guidValue), &indicator);
+
+                if (SQL_SUCCEEDED(ret) && indicator != SQL_NULL_DATA) {
+                    std::vector<char> guid_bytes(16);
+                    guid_bytes[0] = ((char*)&guidValue.Data1)[3];
+                    guid_bytes[1] = ((char*)&guidValue.Data1)[2];
+                    guid_bytes[2] = ((char*)&guidValue.Data1)[1];
+                    guid_bytes[3] = ((char*)&guidValue.Data1)[0];
+                    guid_bytes[4] = ((char*)&guidValue.Data2)[1];
+                    guid_bytes[5] = ((char*)&guidValue.Data2)[0];
+                    guid_bytes[6] = ((char*)&guidValue.Data3)[1];
+                    guid_bytes[7] = ((char*)&guidValue.Data3)[0];
+                    std::memcpy(&guid_bytes[8], guidValue.Data4, sizeof(guidValue.Data4));
+
+                    py::bytes py_guid_bytes(guid_bytes.data(), guid_bytes.size());
+                    py::object uuid_module = py::module_::import("uuid");
+                    py::object uuid_obj = uuid_module.attr("UUID")(py_guid_bytes);
+                    row.append(uuid_obj);
+                } else if (indicator == SQL_NULL_DATA) {
+                    row.append(py::none());
                 } else {
                     LOG("Error retrieving data for column - {}, data type - {}, SQLGetData return "
                         "code - {}. Returning NULL value instead",
@@ -2575,7 +2609,7 @@ SQLRETURN SQLGetData_wrap(SqlHandlePtr StatementHandle, SQLUSMALLINT colCount, p
                 }
                 break;
             }
-#endif
+        #endif
             default:
                 std::ostringstream errorString;
                 errorString << "Unsupported data type for column - " << columnName << ", Type - "
@@ -2957,9 +2991,19 @@ SQLRETURN FetchBatchData(SQLHSTMT hStmt, ColumnBuffers& buffers, py::list& colum
                     break;
                 }
                 case SQL_GUID: {
-                    row.append(
-                        py::bytes(reinterpret_cast<const char*>(&buffers.guidBuffers[col - 1][i]),
-                                  sizeof(SQLGUID)));
+                    SQLGUID* guidValue = &buffers.guidBuffers[col - 1][i];
+                    // We already have the raw bytes from SQL Server in the SQLGUID struct.
+                    // We do not need to perform any additional reordering here, as the C++
+                    // SQLGUID struct is already laid out in the non-standard SQL Server byte order.
+                    std::vector<char> guid_bytes(16);
+                    std::memcpy(guid_bytes.data(), guidValue, sizeof(SQLGUID));
+
+                    // Convert the raw C++ byte vector to a Python bytes object
+                    py::bytes py_guid_bytes(guid_bytes.data(), guid_bytes.size());
+                    py::dict kwargs;
+                    kwargs["bytes"] = py_guid_bytes;
+                    py::object uuid_obj = py::module_::import("uuid").attr("UUID")(**kwargs);
+                    row.append(uuid_obj);
                     break;
                 }
                 case SQL_BINARY:

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -1908,82 +1908,44 @@ SQLRETURN BindParameterArray(SQLHANDLE hStmt,
                     bufferLength = sizeof(SQL_NUMERIC_STRUCT);
                     break;
                 }
-//                 case SQL_C_GUID: {
-//     SQLGUID* guidArray = AllocateParamBufferArray<SQLGUID>(tempBuffers, paramSetSize);
-//     strLenOrIndArray = AllocateParamBufferArray<SQLLEN>(tempBuffers, paramSetSize);
+                case SQL_C_GUID: {
+                    SQLGUID* guidArray = AllocateParamBufferArray<SQLGUID>(tempBuffers, paramSetSize);
+                    strLenOrIndArray = AllocateParamBufferArray<SQLLEN>(tempBuffers, paramSetSize);
 
-//     for (size_t i = 0; i < paramSetSize; ++i) {
-//         if (columnValues[i].is_none()) {
-//             std::memset(&guidArray[i], 0, sizeof(SQLGUID));
-//             strLenOrIndArray[i] = SQL_NULL_DATA;
-//         } else {
-//             if (!py::isinstance<py::bytes>(columnValues[i])) {
-//                 ThrowStdException(MakeParamMismatchErrorStr(info.paramCType, paramIndex));
-//             }
-//             py::bytes uuid_bytes = columnValues[i].cast<py::bytes>();
-//             const unsigned char* uuid_data = reinterpret_cast<const unsigned char*>(PyBytes_AS_STRING(uuid_bytes.ptr()));
-//             if (PyBytes_GET_SIZE(uuid_bytes.ptr()) != 16) {
-//                 ThrowStdException("UUID binary data must be exactly 16 bytes long.");
-//             }
+                    py::object uuid_type = py::module_::import("uuid").attr("UUID");
 
-//             // Map bytes to SQLGUID fields
-//             guidArray[i].Data1 = (static_cast<uint32_t>(uuid_data[3]) << 24) |
-//                                  (static_cast<uint32_t>(uuid_data[2]) << 16) |
-//                                  (static_cast<uint32_t>(uuid_data[1]) << 8)  |
-//                                  (static_cast<uint32_t>(uuid_data[0]));
-//             guidArray[i].Data2 = (static_cast<uint16_t>(uuid_data[5]) << 8) |
-//                                  (static_cast<uint16_t>(uuid_data[4]));
-//             guidArray[i].Data3 = (static_cast<uint16_t>(uuid_data[7]) << 8) |
-//                                  (static_cast<uint16_t>(uuid_data[6]));
-//             std::memcpy(guidArray[i].Data4, &uuid_data[8], 8);
+                    for (size_t i = 0; i < paramSetSize; ++i) {
+                        if (columnValues[i].is_none()) {
+                            std::memset(&guidArray[i], 0, sizeof(SQLGUID));
+                            strLenOrIndArray[i] = SQL_NULL_DATA;
+                        } else if (py::isinstance(columnValues[i], uuid_type)) {
+                            py::bytes uuid_bytes = columnValues[i].attr("bytes");
+                            const unsigned char* uuid_data = reinterpret_cast<const unsigned char*>(PyBytes_AS_STRING(uuid_bytes.ptr()));
 
-//             strLenOrIndArray[i] = sizeof(SQLGUID);
-//         }
-//     }
+                            if (PyBytes_GET_SIZE(uuid_bytes.ptr()) != 16) {
+                                ThrowStdException("UUID binary data must be exactly 16 bytes long.");
+                            }
 
-//     dataPtr = guidArray;
-//     bufferLength = sizeof(SQLGUID);
-//     break;
-// }
-case SQL_C_GUID: {
-    SQLGUID* guidArray = AllocateParamBufferArray<SQLGUID>(tempBuffers, paramSetSize);
-    strLenOrIndArray = AllocateParamBufferArray<SQLLEN>(tempBuffers, paramSetSize);
+                            guidArray[i].Data1 = (static_cast<uint32_t>(uuid_data[3]) << 24) |
+                                                (static_cast<uint32_t>(uuid_data[2]) << 16) |
+                                                (static_cast<uint32_t>(uuid_data[1]) << 8)  |
+                                                (static_cast<uint32_t>(uuid_data[0]));
+                            guidArray[i].Data2 = (static_cast<uint16_t>(uuid_data[5]) << 8) |
+                                                (static_cast<uint16_t>(uuid_data[4]));
+                            guidArray[i].Data3 = (static_cast<uint16_t>(uuid_data[7]) << 8) |
+                                                (static_cast<uint16_t>(uuid_data[6]));
+                            std::memcpy(guidArray[i].Data4, &uuid_data[8], 8);
 
-    py::object uuid_type = py::module_::import("uuid").attr("UUID");
+                            strLenOrIndArray[i] = sizeof(SQLGUID);
+                        } else {
+                            ThrowStdException(MakeParamMismatchErrorStr(info.paramCType, paramIndex));
+                        }
+                    }
 
-    for (size_t i = 0; i < paramSetSize; ++i) {
-        if (columnValues[i].is_none()) {
-            std::memset(&guidArray[i], 0, sizeof(SQLGUID));
-            strLenOrIndArray[i] = SQL_NULL_DATA;
-        } else if (py::isinstance(columnValues[i], uuid_type)) {
-            py::bytes uuid_bytes = columnValues[i].attr("bytes");
-            const unsigned char* uuid_data = reinterpret_cast<const unsigned char*>(PyBytes_AS_STRING(uuid_bytes.ptr()));
-
-            if (PyBytes_GET_SIZE(uuid_bytes.ptr()) != 16) {
-                ThrowStdException("UUID binary data must be exactly 16 bytes long.");
-            }
-
-            guidArray[i].Data1 = (static_cast<uint32_t>(uuid_data[3]) << 24) |
-                                 (static_cast<uint32_t>(uuid_data[2]) << 16) |
-                                 (static_cast<uint32_t>(uuid_data[1]) << 8)  |
-                                 (static_cast<uint32_t>(uuid_data[0]));
-            guidArray[i].Data2 = (static_cast<uint16_t>(uuid_data[5]) << 8) |
-                                 (static_cast<uint16_t>(uuid_data[4]));
-            guidArray[i].Data3 = (static_cast<uint16_t>(uuid_data[7]) << 8) |
-                                 (static_cast<uint16_t>(uuid_data[6]));
-            std::memcpy(guidArray[i].Data4, &uuid_data[8], 8);
-
-            strLenOrIndArray[i] = sizeof(SQLGUID);
-        } else {
-            ThrowStdException(MakeParamMismatchErrorStr(info.paramCType, paramIndex));
-        }
-    }
-
-    dataPtr = guidArray;
-    bufferLength = sizeof(SQLGUID);
-    break;
-}
-
+                    dataPtr = guidArray;
+                    bufferLength = sizeof(SQLGUID);
+                    break;
+                }
                 default: {
                     ThrowStdException("BindParameterArray: Unsupported C type: " + std::to_string(info.paramCType));
                 }

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -10267,7 +10267,7 @@ def test_insert_multiple_uuids(cursor, db_connection):
         db_connection.commit()
 
 def test_uuid_insert_with_none(cursor, db_connection):
-    """Test that inserting None into a UUID column raises an error (or is handled)."""
+    """Test that inserting None into a UUID column results in a NULL value and is handled correctly."""
     table_name = "#pytest_uuid_none"
     try:
         cursor.execute(f"DROP TABLE IF EXISTS {table_name}")

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -10292,6 +10292,52 @@ def test_uuid_insert_with_none(cursor, db_connection):
         cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
         db_connection.commit()
 
+def test_executemany_with_uuids(cursor, db_connection):
+    """Test inserting multiple rows with UUIDs and None using executemany."""
+    table_name = "#pytest_uuid_batch"
+    try:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        cursor.execute(f"""
+            CREATE TABLE {table_name} (
+                id UNIQUEIDENTIFIER,
+                description NVARCHAR(50)
+            )
+        """)
+        db_connection.commit()
+
+        # Prepare test data: mix of UUIDs and None
+        test_data = [
+            [uuid.uuid4(), "Item 1"],
+            [uuid.uuid4(), "Item 2"],
+            [None, "Item 3"],
+            [uuid.uuid4(), "Item 4"],
+            [None, "Item 5"]
+        ]
+
+        # Execute batch insert
+        cursor.executemany(f"INSERT INTO {table_name} (id, description) VALUES (?, ?)", test_data)
+        cursor.connection.commit()
+
+        # Fetch and verify
+        cursor.execute(f"SELECT id, description FROM {table_name}")
+        rows = cursor.fetchall()
+
+        assert len(rows) == len(test_data), "Number of fetched rows does not match inserted rows."
+
+        for row in rows:
+            retrieved_uuid, retrieved_desc = row
+            for original_uuid, original_desc in test_data:
+                if original_desc == retrieved_desc:
+                    if original_uuid is None:
+                        assert retrieved_uuid is None, f"Expected None for '{retrieved_desc}', got {retrieved_uuid}"
+                    else:
+                        assert isinstance(retrieved_uuid, uuid.UUID), f"Expected UUID, got {type(retrieved_uuid)}"
+                        assert retrieved_uuid == original_uuid, f"UUID mismatch for '{retrieved_desc}'"
+                    break
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        db_connection.commit()
+
 def test_close(db_connection):
     """Test closing the cursor"""
     try:

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -14,6 +14,7 @@ import time as time_module
 import decimal
 from contextlib import closing
 import mssql_python
+import uuid
 
 # Setup test table
 TEST_TABLE = """
@@ -10193,6 +10194,158 @@ def test_decimal_separator_calculations(cursor, db_connection):
         
         # Cleanup
         cursor.execute("DROP TABLE IF EXISTS #pytest_decimal_calc_test")
+
+def test_uuid_insert_and_select_none(cursor, db_connection):
+    """Test inserting and retrieving None in a nullable UUID column."""
+    table_name = "#pytest_uuid_nullable"
+    try:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        cursor.execute(f"""
+            CREATE TABLE {table_name} (
+                id UNIQUEIDENTIFIER,
+                name NVARCHAR(50)
+            )
+        """)
+        db_connection.commit()
+
+        # Insert a row with None for the UUID
+        cursor.execute(f"INSERT INTO {table_name} (id, name) VALUES (?, ?)", [None, "Bob"])
+        db_connection.commit()
+
+        # Fetch the row
+        cursor.execute(f"SELECT id, name FROM {table_name}")
+        row = cursor.fetchone()
+        retrieved_uuid, retrieved_name = row
+
+        # Assert that the retrieved UUID is None
+        assert retrieved_uuid is None, f"Expected None, got {type(retrieved_uuid)}"
+
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        db_connection.commit()
+
+def test_insert_multiple_uuids(cursor, db_connection):
+    """Test inserting multiple UUIDs and verifying retrieval."""
+    table_name = "#pytest_uuid_multiple"
+    try:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        cursor.execute(f"""
+            CREATE TABLE {table_name} (
+                id UNIQUEIDENTIFIER PRIMARY KEY,
+                description NVARCHAR(50)
+            )
+        """)
+        db_connection.commit()
+
+        uuids_to_insert = {f"Item {i}": uuid.uuid4() for i in range(5)}
+        
+        # Insert UUIDs and descriptions
+        for desc, uid in uuids_to_insert.items():
+            cursor.execute(f"INSERT INTO {table_name} (id, description) VALUES (?, ?)", [uid, desc])
+        db_connection.commit()
+
+        # Fetch all data
+        cursor.execute(f"SELECT id, description FROM {table_name}")
+        rows = cursor.fetchall()
+        
+        # Verify each fetched row against the original data
+        assert len(rows) == len(uuids_to_insert), "Number of fetched rows does not match."
+        
+        for row in rows:
+            retrieved_uuid, retrieved_desc = row
+            
+            # Assert type is correct
+            assert isinstance(retrieved_uuid, uuid.UUID), f"Expected uuid.UUID, got {type(retrieved_uuid)}"
+            
+            # Use the description to look up the original UUID
+            expected_uuid = uuids_to_insert.get(retrieved_desc)
+            
+            assert expected_uuid is not None, f"Retrieved description '{retrieved_desc}' was not in the original data."
+            assert retrieved_uuid == expected_uuid, f"UUID mismatch for '{retrieved_desc}': expected {expected_uuid}, got {retrieved_uuid}"
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        db_connection.commit()
+
+def test_uuid_insert_with_none(cursor, db_connection):
+    """Test that inserting None into a UUID column raises an error (or is handled)."""
+    table_name = "#pytest_uuid_none"
+    try:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        cursor.execute(f"""
+            CREATE TABLE {table_name} (
+                id UNIQUEIDENTIFIER,
+                name NVARCHAR(50)
+            )
+        """)
+        db_connection.commit()
+
+        cursor.execute(f"INSERT INTO {table_name} (id, name) VALUES (?, ?)", [None, "Bob"])
+        db_connection.commit()
+
+        cursor.execute(f"SELECT id, name FROM {table_name}")
+        row = cursor.fetchone()
+        assert row[0] is None, f"Expected NULL UUID, got {row[0]}"
+        assert row[1] == "Bob"
+
+
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        db_connection.commit()
+
+def test_executemany_uuid_insert_and_select(cursor, db_connection):
+    """Test inserting multiple UUIDs using executemany and verifying retrieval."""
+    table_name = "#pytest_uuid_executemany"
+    
+    try:
+        # Drop and create a temporary table for the test
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        cursor.execute(f"""
+            CREATE TABLE {table_name} (
+                id UNIQUEIDENTIFIER PRIMARY KEY,
+                description NVARCHAR(50)
+            )
+        """)
+        db_connection.commit()
+
+        # Generate data for insertion
+        data_to_insert = []
+        uuids_to_check = {}
+        for i in range(5):
+            new_uuid = uuid.uuid4()
+            description = f"Item {i}"
+            data_to_insert.append((new_uuid, description))
+            uuids_to_check[description] = new_uuid
+
+        # Insert all data with a single call to executemany
+        sql = f"INSERT INTO {table_name} (id, description) VALUES (?, ?)"
+        cursor.executemany(sql, data_to_insert)
+        db_connection.commit()
+
+        # Verify the number of rows inserted
+        assert cursor.rowcount == 5, f"Expected 5 rows inserted, but got {cursor.rowcount}"
+
+        # Fetch all data from the table
+        cursor.execute(f"SELECT id, description FROM {table_name}")
+        rows = cursor.fetchall()
+        
+        # Verify the number of fetched rows
+        assert len(rows) == len(data_to_insert), "Number of fetched rows does not match."
+        
+        # Verify each fetched row's data and type
+        for row in rows:
+            retrieved_uuid, retrieved_desc = row
+            
+            # Assert the type is correct
+            assert isinstance(retrieved_uuid, uuid.UUID), f"Expected uuid.UUID, got {type(retrieved_uuid)}"
+            
+            # Assert the value matches the original data
+            expected_uuid = uuids_to_check.get(retrieved_desc)
+            assert expected_uuid is not None, f"Retrieved description '{retrieved_desc}' was not in the original data."
+            assert retrieved_uuid == expected_uuid, f"UUID mismatch for '{retrieved_desc}': expected {expected_uuid}, got {retrieved_uuid}"
+
+    finally:
+        # Clean up the temporary table
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
         db_connection.commit()
 
 def test_close(db_connection):

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -10292,62 +10292,6 @@ def test_uuid_insert_with_none(cursor, db_connection):
         cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
         db_connection.commit()
 
-def test_executemany_uuid_insert_and_select(cursor, db_connection):
-    """Test inserting multiple UUIDs using executemany and verifying retrieval."""
-    table_name = "#pytest_uuid_executemany"
-    
-    try:
-        # Drop and create a temporary table for the test
-        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
-        cursor.execute(f"""
-            CREATE TABLE {table_name} (
-                id UNIQUEIDENTIFIER PRIMARY KEY,
-                description NVARCHAR(50)
-            )
-        """)
-        db_connection.commit()
-
-        # Generate data for insertion
-        data_to_insert = []
-        uuids_to_check = {}
-        for i in range(5):
-            new_uuid = uuid.uuid4()
-            description = f"Item {i}"
-            data_to_insert.append((new_uuid, description))
-            uuids_to_check[description] = new_uuid
-
-        # Insert all data with a single call to executemany
-        sql = f"INSERT INTO {table_name} (id, description) VALUES (?, ?)"
-        cursor.executemany(sql, data_to_insert)
-        db_connection.commit()
-
-        # Verify the number of rows inserted
-        assert cursor.rowcount == 5, f"Expected 5 rows inserted, but got {cursor.rowcount}"
-
-        # Fetch all data from the table
-        cursor.execute(f"SELECT id, description FROM {table_name}")
-        rows = cursor.fetchall()
-        
-        # Verify the number of fetched rows
-        assert len(rows) == len(data_to_insert), "Number of fetched rows does not match."
-        
-        # Verify each fetched row's data and type
-        for row in rows:
-            retrieved_uuid, retrieved_desc = row
-            
-            # Assert the type is correct
-            assert isinstance(retrieved_uuid, uuid.UUID), f"Expected uuid.UUID, got {type(retrieved_uuid)}"
-            
-            # Assert the value matches the original data
-            expected_uuid = uuids_to_check.get(retrieved_desc)
-            assert expected_uuid is not None, f"Retrieved description '{retrieved_desc}' was not in the original data."
-            assert retrieved_uuid == expected_uuid, f"UUID mismatch for '{retrieved_desc}': expected {expected_uuid}, got {retrieved_uuid}"
-
-    finally:
-        # Clean up the temporary table
-        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
-        db_connection.commit()
-
 def test_close(db_connection):
     """Test closing the cursor"""
     try:


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below (e.g. AB#37452)
For external contributors: Insert Github Issue number below (e.g. #149)
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> AB#34945

<!-- External contributors: GitHub Issue -->
> GitHub Issue: #<ISSUE_NUMBER>

-------------------------------------------------------------------
### Summary   
<!-- Insert your summary of changes below. Minimum 10 characters required. -->  
This pull request adds full support for handling Python `uuid.UUID` objects with SQL Server's `UNIQUEIDENTIFIER` type in the `mssql_python` driver. It introduces robust conversion between Python UUIDs and SQL GUIDs for both single and batch operations, ensures correct retrieval as Python `uuid.UUID` objects, and adds comprehensive tests for these scenarios.

**UUID/GUID Support Improvements:**

* Added mapping for Python `uuid.UUID` to SQL `GUID` types in `_map_sql_type`, enabling seamless parameter binding for UUIDs.
* Implemented correct binding and conversion logic for UUIDs in both single (`BindParameters`) and batch (`BindParameterArray`) parameter bindings, including validation of binary length and error handling. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L507-R534) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R1911-R1948)
* Enhanced data retrieval to return UUID columns as Python `uuid.UUID` objects instead of strings or raw bytes, in both single-row (`SQLGetData_wrap`) and batch (`FetchBatchData`) fetches. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L2556-R2641) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1L2960-R3041)

**Testing Enhancements:**

* Added comprehensive tests for inserting, selecting, and batch operations involving UUIDs, including cases with `None` (NULL) values and mixed UUID/NULL batches.
* Updated test imports to include the `uuid` module for use in new test cases.

<!-- 
### PR Title Guide

> For feature requests
FEAT: (short-description)

> For non-feature requests like test case updates, config updates , dependency updates etc
CHORE: (short-description) 

> For Fix requests
FIX: (short-description)

> For doc update requests 
DOC: (short-description)

> For Formatting, indentation, or styling update
STYLE: (short-description)

> For Refactor, without any feature changes
REFACTOR: (short-description)

> For release related changes, without any feature changes
RELEASE: #<RELEASE_VERSION> (short-description) 

### Contribution Guidelines

External contributors:
- Create a GitHub issue first: https://github.com/microsoft/mssql-python/issues/new
- Link the GitHub issue in the "GitHub Issue" section above
- Follow the PR title format and provide a meaningful summary

mssql-python maintainers:
- Create an ADO Work Item following internal processes
- Link the ADO Work Item in the "ADO Work Item" section above  
- Follow the PR title format and provide a meaningful summary
-->