### PR TITLE
FIX: remove checks of string mapping to uuid

### DIFF
--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -363,19 +363,6 @@ class Cursor:
                     False,
                 )
                 
-            try:
-                val = uuid.UUID(param)
-                parameters_list[i] = val.bytes_le
-                return (
-                    ddbc_sql_const.SQL_GUID.value,
-                    ddbc_sql_const.SQL_C_GUID.value,
-                    16,
-                    0,
-                    False
-                )
-            except ValueError:
-                pass
-
             # String mapping logic here
             is_unicode = self._is_unicode_string(param)
 


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below (e.g. AB#37452)
For external contributors: Insert Github Issue number below (e.g. #149)
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> [AB#39185](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/39185)

<!-- External contributors: GitHub Issue -->
> GitHub Issue: #241 

-------------------------------------------------------------------
### Summary   
<!-- Insert your summary of changes below. Minimum 10 characters required. -->  
This pull request removes the logic for automatically mapping UUID string parameters to GUID types in the `_map_sql_type` method of `mssql_python/cursor.py`. As a result, UUID strings will no longer be converted to binary GUID representations when binding parameters.

Type mapping changes:

* Removed the code that attempted to parse parameters as UUIDs and map them to SQL GUID types, so UUID strings will now be handled as regular strings instead of being converted to `bytes_le` for GUID columns.

<!-- 
### PR Title Guide

> For feature requests
FEAT: (short-description)

> For non-feature requests like test case updates, config updates , dependency updates etc
CHORE: (short-description) 

> For Fix requests
FIX: (short-description)

> For doc update requests 
DOC: (short-description)

> For Formatting, indentation, or styling update
STYLE: (short-description)

> For Refactor, without any feature changes
REFACTOR: (short-description)

> For release related changes, without any feature changes
RELEASE: #<RELEASE_VERSION> (short-description) 

### Contribution Guidelines

External contributors:
- Create a GitHub issue first: https://github.com/microsoft/mssql-python/issues/new
- Link the GitHub issue in the "GitHub Issue" section above
- Follow the PR title format and provide a meaningful summary

mssql-python maintainers:
- Create an ADO Work Item following internal processes
- Link the ADO Work Item in the "ADO Work Item" section above  
- Follow the PR title format and provide a meaningful summary
-->