### PR TITLE
FEAT: Support for Native_UUID Attribute

### DIFF
--- a/mssql_python/__init__.py
+++ b/mssql_python/__init__.py
@@ -5,6 +5,7 @@ This module initializes the mssql_python package.
 """
 import threading
 import locale
+import sys
 
 # Exceptions
 # https://www.python.org/dev/peps/pep-0249/#exceptions
@@ -31,6 +32,7 @@ class Settings:
         self.lowercase = False
         # Use the pre-determined separator - no locale access here
         self.decimal_separator = _DEFAULT_DECIMAL_SEPARATOR
+        self.native_uuid = False  # Default to False for backwards compatibility
 
 # Global settings instance
 _settings = Settings()
@@ -40,9 +42,11 @@ def get_settings():
     """Return the global settings object"""
     with _settings_lock:
         _settings.lowercase = lowercase
+        _settings.native_uuid = native_uuid
         return _settings
 
 lowercase = _settings.lowercase  # Default is False
+native_uuid = _settings.native_uuid  # Default is False
 
 # Set the initial decimal separator in C++
 from .ddbc_bindings import DDBCSetDecimalSeparator
@@ -166,7 +170,6 @@ def pooling(max_size=100, idle_timeout=600, enabled=True):
     else:
         PoolingManager.enable(max_size, idle_timeout)
 
-import sys
 _original_module_setattr = sys.modules[__name__].__setattr__
 
 def _custom_setattr(name, value):

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -363,19 +363,6 @@ class Cursor:
                     False,
                 )
                 
-            try:
-                val = uuid.UUID(param)
-                parameters_list[i] = val.bytes_le
-                return (
-                    ddbc_sql_const.SQL_GUID.value,
-                    ddbc_sql_const.SQL_C_GUID.value,
-                    16,
-                    0,
-                    False
-                )
-            except ValueError:
-                pass
-
             # String mapping logic here
             is_unicode = self._is_unicode_string(param)
 


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below (e.g. AB#37452)
For external contributors: Insert Github Issue number below (e.g. #149)
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> AB#39059

-------------------------------------------------------------------
### Summary   
This pull request introduces a new global setting, `native_uuid`, to the `mssql_python` package, allowing users to control whether UUID values are returned as `uuid.UUID` objects or as strings. The implementation includes updates to the package initialization, row processing logic, and a comprehensive set of tests to verify the new behavior and ensure backward compatibility.

**UUID Handling Improvements:**

* Added a `native_uuid` setting to the global configuration in `mssql_python/__init__.py`, defaulting to `False` for backward compatibility. This setting controls whether UUIDs are returned as `uuid.UUID` objects or as strings. 
* Updated the `Row` class in `mssql_python/row.py` to check the `native_uuid` setting and convert UUID values to strings when `native_uuid` is `False`, ensuring consistent output based on configuration.

**Testing Enhancements:**

* Updated and extended tests in `tests/test_004_cursor.py` to verify correct UUID handling for both `native_uuid=True` and `native_uuid=False`, including new tests for the setting and resetting of the `native_uuid` option. 

**Internal Refactoring:**

* Removed unused UUID mapping logic in `mssql_python/cursor.py` that is now handled via the new setting and row processing logic.
* Minor import and code organization cleanups in affected modules for clarity and maintainability.

These changes provide greater flexibility and control over how UUIDs are handled in query results, improving the usability of the package in different application contexts.