### PR TITLE
FEAT: Added Security Compiler Options in CMake

### DIFF
--- a/mssql_python/pybind/CMakeLists.txt
+++ b/mssql_python/pybind/CMakeLists.txt
@@ -5,8 +5,13 @@ project(ddbc_bindings)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Enable verbose output to see actual compiler/linker commands
+set(CMAKE_VERBOSE_MAKEFILE ON CACHE BOOL "Verbose output" FORCE)
+
 if (MSVC)
     # Security compiler options for OneBranch compliance
+    message(STATUS "Applying MSVC security compiler options for OneBranch compliance")
+    
     add_compile_options(
         /GS          # Buffer security check - detects buffer overruns
         /guard:cf    # Control Flow Guard - protects against control flow hijacking
@@ -20,12 +25,17 @@ if (MSVC)
     
     # SAFESEH only for x86 (32-bit) builds
     if(CMAKE_SIZEOF_VOID_P EQUAL 4)  # 32-bit
+        message(STATUS "Applying /SAFESEH for 32-bit build")
         add_link_options(/SAFESEH)  # Safe Structured Exception Handling
+    else()
+        message(STATUS "Skipping /SAFESEH (not applicable for 64-bit builds)")
     endif()
     
     # Enable PDB generation for all target types
     add_compile_options("$<$<CONFIG:Release>:/Zi>")
     add_link_options("$<$<CONFIG:Release>:/DEBUG /OPT:REF /OPT:ICF>")
+    
+    message(STATUS "Security flags applied: /GS /guard:cf /DYNAMICBASE /NXCOMPAT /GUARD:CF")
 endif()
 
 # Detect platform


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below (e.g. AB#37452)
For external contributors: Insert Github Issue number below (e.g. #149)
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> [AB#40193](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/40193)

-------------------------------------------------------------------
### Summary   
<!-- Insert your summary of changes below. Minimum 10 characters required. -->  
This pull request improves the build configuration for the `mssql_python/pybind` project, focusing on security and diagnostics for MSVC builds. The main changes enhance security compliance and provide better visibility into the build process.

Build diagnostics:

* Enabled verbose output in CMake to show actual compiler and linker commands by setting `CMAKE_VERBOSE_MAKEFILE` to `ON`.

Security compliance improvements (MSVC builds):

* Added security-related compiler options: `/GS` for buffer security checks and `/guard:cf` for Control Flow Guard.
* Added security-related linker options: `/DYNAMICBASE` for ASLR, `/NXCOMPAT` for DEP, and `/GUARD:CF` for Control Flow Guard.
* Conditionally applied `/SAFESEH` linker option for 32-bit builds to enable Safe Structured Exception Handling; skipped for 64-bit builds.
* Added status messages to indicate when security flags are applied and which options are enabled or skipped.
