### PR TITLE
FIX: fix current cmake warnings in linux and add support to treat warnings as errors in linux 

### DIFF
--- a/mssql_python/pybind/CMakeLists.txt
+++ b/mssql_python/pybind/CMakeLists.txt
@@ -9,7 +9,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_VERBOSE_MAKEFILE ON CACHE BOOL "Verbose output" FORCE)
 
 # Treat CMake warnings as errors
-set(CMAKE_WARN_DEPRECATED_DEPRECATION FALSE)
 set(CMAKE_ERROR_DEPRECATED TRUE)
 set(CMAKE_WARN_DEPRECATED TRUE)
 
@@ -310,10 +309,16 @@ endif()
 # Add warning flags for GCC/Clang on Linux and macOS
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     target_compile_options(ddbc_bindings PRIVATE 
-        -Werror
-        -Wattributes
-        -Wint-to-pointer-cast
+        -Werror        # Treat warnings as errors
+        -Wattributes   # Enable attribute warnings (cross-compiler)
     )
+    
+    # GCC-specific warning flags
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_compile_options(ddbc_bindings PRIVATE 
+            -Wint-to-pointer-cast  # GCC-specific warning for integer-to-pointer casts
+        )
+    endif()
 endif()
 
 # Add macOS-specific string conversion fix

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -114,6 +114,9 @@ py::object get_uuid_class() {
 
 // Struct to hold parameter information for binding. Used by SQLBindParameter.
 // This struct is shared between C++ & Python code.
+// Suppress -Wattributes warning for ParamInfo struct
+// The warning is triggered because pybind11 handles visibility attributes automatically,
+// and having additional attributes on the struct can cause conflicts on Linux with GCC
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wattributes"
@@ -728,7 +731,7 @@ SQLRETURN BindParameters(SQLHANDLE hStmt, const py::list& params,
                 return rc;
             }
 
-            rc = SQLSetDescField_ptr(hDesc, 1, SQL_DESC_SCALE, reinterpret_cast<SQLPOINTER>(static_cast<uintptr_t>(numericPtr->scale)), 0);
+            rc = SQLSetDescField_ptr(hDesc, 1, SQL_DESC_SCALE, reinterpret_cast<SQLPOINTER>(static_cast<intptr_t>(numericPtr->scale)), 0);
             if (!SQL_SUCCEEDED(rc)) {
                 LOG("BindParameters: SQLSetDescField(SQL_DESC_SCALE) failed "
                     "for param[%d] - SQLRETURN=%d",


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below (e.g. AB#37452)
For external contributors: Insert Github Issue number below (e.g. #149)
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> [AB#37803](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/37803)

<!-- External contributors: GitHub Issue -->
> GitHub Issue: #<ISSUE_NUMBER>

-------------------------------------------------------------------
### Summary   
<!-- Insert your summary of changes below. Minimum 10 characters required. -->  

This pull request introduces improvements to the build configuration and code safety for the `mssql_python/pybind` module. The main changes focus on enforcing stricter warning and error handling in the build system, improving cross-platform compatibility, and ensuring safe type casting in parameter binding.

**Build system improvements:**

* Enforced treating CMake warnings and deprecated features as errors by setting `CMAKE_ERROR_DEPRECATED` and `CMAKE_WARN_DEPRECATED` to `TRUE` in `CMakeLists.txt`, ensuring deprecated usage is caught early.
* Added compiler warning flags for GCC and Clang (`-Werror`, `-Wattributes`, `-Wint-to-pointer-cast`) to treat warnings as errors and catch visibility and type casting issues in `CMakeLists.txt`.

**Code safety and compatibility:**

* Suppressed visibility attribute warnings for the `ParamInfo` struct on Linux using GCC diagnostic pragmas, while maintaining compatibility with Windows. [[1]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R117-R121) [[2]](diffhunk://#diff-dde2297345718ec449a14e7dff91b7bb2342b008ecc071f562233646d71144a1R132-R134)
* Updated type casting in the `BindParameters` function to use `reinterpret_cast` and `static_cast` for safe conversion of numeric precision and scale values to `SQLPOINTER`, preventing potential type safety issues.
<!-- 
### PR Title Guide

> For feature requests
FEAT: (short-description)

> For non-feature requests like test case updates, config updates , dependency updates etc
CHORE: (short-description) 

> For Fix requests
FIX: (short-description)

> For doc update requests 
DOC: (short-description)

> For Formatting, indentation, or styling update
STYLE: (short-description)

> For Refactor, without any feature changes
REFACTOR: (short-description)

> For release related changes, without any feature changes
RELEASE: #<RELEASE_VERSION> (short-description) 

### Contribution Guidelines

External contributors:
- Create a GitHub issue first: https://github.com/microsoft/mssql-python/issues/new
- Link the GitHub issue in the "GitHub Issue" section above
- Follow the PR title format and provide a meaningful summary

mssql-python maintainers:
- Create an ADO Work Item following internal processes
- Link the ADO Work Item in the "ADO Work Item" section above  
- Follow the PR title format and provide a meaningful summary
-->