### PR TITLE
FIX: Use imageOverride demand instead of vmImage for 1ES Windows pool selection

### DIFF
--- a/OneBranchPipelines/dummy-release-pipeline.yml
+++ b/OneBranchPipelines/dummy-release-pipeline.yml
@@ -97,7 +97,8 @@ extends:
               type: windows
               isCustom: true
               name: Django-1ES-pool
-              vmImage: WIN22-SQL22
+              demands:
+              - imageOverride -equals WIN22-SQL22
             
             variables:
               ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'

--- a/OneBranchPipelines/official-release-pipeline.yml
+++ b/OneBranchPipelines/official-release-pipeline.yml
@@ -100,7 +100,8 @@ extends:
               type: windows
               isCustom: true
               name: Django-1ES-pool
-              vmImage: WIN22-SQL22
+              demands:
+              - imageOverride -equals WIN22-SQL22
             
             variables:
               ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'

--- a/OneBranchPipelines/stages/build-windows-single-stage.yml
+++ b/OneBranchPipelines/stages/build-windows-single-stage.yml
@@ -39,7 +39,8 @@ stages:
           type: windows
           isCustom: true
           name: Django-1ES-pool
-          vmImage: WIN22-SQL22
+          demands:
+          - imageOverride -equals WIN22-SQL22
         # Extended timeout for downloads, builds, and testing
         timeoutInMinutes: 120
         


### PR DESCRIPTION
### Work Item / Issue Reference
[AB#42368](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/42368)
> N/A

-------------------------------------------------------------------

### Summary

Fix 1ES Pipeline Templates validation failure (`1ES PT Error: Using an image without 1es-pt-prerequisites artifact is not allowed`) on Windows build stages.

The `Django-1ES-pool` custom 1ES Hosted Pool was falling back to its default `MMS2016` (Windows Server 2019) image because `vmImage` doesn't properly select images from custom pools. Changed all three Windows pool configurations to use `demands` with `imageOverride` (matching the pattern already used by the Linux stage template) to correctly select the `WIN22-SQL22` image.

**Files changed:**
- `OneBranchPipelines/stages/build-windows-single-stage.yml`
- `OneBranchPipelines/official-release-pipeline.yml`
- `OneBranchPipelines/dummy-release-pipeline.yml`