### PR TITLE
FEAT: Make _bulkcopy a public API

### DIFF
--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -2499,7 +2499,7 @@ class Cursor:  # pylint: disable=too-many-instance-attributes,too-many-public-me
         return True
 
     # ── Mapping from ODBC connection-string keywords (lowercase, as _parse returns)
-    def _bulkcopy(
+    def bulkcopy(
         self,
         table_name: str,
         data: Iterable[Union[Tuple, List]],
@@ -2579,8 +2579,8 @@ class Cursor:  # pylint: disable=too-many-instance-attributes,too-many-public-me
             import mssql_py_core
         except ImportError as exc:
             raise ImportError(
-                "Bulk copy requires the mssql_py_core library which is not installed. "
-                "To install, run: pip install mssql_py_core "
+                "Bulk copy requires the mssql_py_core library which is not available. "
+                "This is an unexpected error. "
             ) from exc
 
         # Validate inputs

--- a/tests/test_019_bulkcopy.py
+++ b/tests/test_019_bulkcopy.py
@@ -65,7 +65,7 @@ def test_bulkcopy_basic(cursor):
 
     # Perform bulkcopy with auto-mapping (no column_mappings specified)
     # Using explicit timeout parameter instead of kwargs
-    result = cursor._bulkcopy(table_name, data, timeout=60)
+    result = cursor.bulkcopy(table_name, data, timeout=60)
 
     # Verify result
     assert result is not None


### PR DESCRIPTION
…or missing mssql_py_core

### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below 
For external contributors: Insert Github Issue number below
Only one reference is required - either GitHub issue OR ADO Work Item.
-->


<!-- External contributors: GitHub Issue -->
> GitHub Issue: #448

-------------------------------------------------------------------
### Summary   
<!-- Insert your summary of changes below. Minimum 10 characters required. -->  
This change renames `_bulkcopy` to `bulkcopy` to make the feature available in the public API surface area. 

<!-- 
### PR Title Guide

> For feature requests
FEAT: Expose `bulkcopy` API

Change error message to reflect that the absence of mssql_py_core is an internal error