### PR TITLE
FIX: Update time handling in Arrow integration to include fractional seconds

### DIFF
--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -247,7 +247,7 @@ struct ArrowArrayPrivateData {
     std::unique_ptr<uint64_t[]> varVal;
     std::unique_ptr<int32_t[]> dateVal;
     std::unique_ptr<int64_t[]> tsMicroVal;
-    std::unique_ptr<int32_t[]> timeSecondVal;
+    std::unique_ptr<int64_t[]> timeNanoVal;
     std::unique_ptr<Int128_t[]> decimalVal;
 
     std::vector<uint8_t> varData;
@@ -4691,12 +4691,10 @@ SQLRETURN FetchArrowBatch_wrap(
                 arrowColumnProducer->dateVal = std::make_unique<int32_t[]>(arrowBatchSize);
                 arrowColumnProducer->ptrValueBuffer = arrowColumnProducer->dateVal.get();
                 break;
-            case SQL_TIME:
-            case SQL_TYPE_TIME:
             case SQL_SS_TIME2:
-                format = "tts";
-                arrowColumnProducer->timeSecondVal = std::make_unique<int32_t[]>(arrowBatchSize);
-                arrowColumnProducer->ptrValueBuffer = arrowColumnProducer->timeSecondVal.get();
+                format = "ttn";
+                arrowColumnProducer->timeNanoVal = std::make_unique<int64_t[]>(arrowBatchSize);
+                arrowColumnProducer->ptrValueBuffer = arrowColumnProducer->timeNanoVal.get();
                 break;
             case SQL_BIT:
                 format = "b";
@@ -4965,8 +4963,6 @@ SQLRETURN FetchArrowBatch_wrap(
                             }
                             break;
                         }
-                        case SQL_TIME:
-                        case SQL_TYPE_TIME:
                         case SQL_SS_TIME2: {
                             buffers.timeBuffers[idxCol].resize(1);
                             ret = SQLGetData_ptr(
@@ -5226,14 +5222,13 @@ SQLRETURN FetchArrowBatch_wrap(
                             buffers.dateBuffers[idxCol][idxRowSql].day
                         );
                         break;
-                    case SQL_TIME:
-                    case SQL_TYPE_TIME:
                     case SQL_SS_TIME2: {
                         const SQL_SS_TIME2_STRUCT& timeValue = buffers.timeBuffers[idxCol][idxRowSql];
-                        arrowColumnProducer->timeSecondVal[idxRowArrow] = 
-                            static_cast<int32_t>(timeValue.hour) * 3600 +
-                            static_cast<int32_t>(timeValue.minute) * 60 +
-                            static_cast<int32_t>(timeValue.second);
+                        arrowColumnProducer->timeNanoVal[idxRowArrow] = 
+                            static_cast<int64_t>(timeValue.hour) * 3600 * 1000000000 +
+                            static_cast<int64_t>(timeValue.minute) * 60 * 1000000000 +
+                            static_cast<int64_t>(timeValue.second) * 1000000000 +
+                            static_cast<int64_t>(timeValue.fraction);
                         break;
                     }
                     case SQL_BIT: {

--- a/tests/test_004_cursor_arrow.py
+++ b/tests/test_004_cursor_arrow.py
@@ -89,14 +89,19 @@ def get_arrow_test_data(include_lobs: bool, batch_length: int):
             ],
         ),
         (
-            pa.time32("s"),
+            pa.time64("ns"),
             "time(0)",
             [time(12, 0, 5, 0), None, time(23, 59, 59, 0), time(0, 0, 0, 0)],
         ),
         (
-            pa.time32("s"),
+            pa.time64("ns"),
             "time(7)",
             [time(12, 0, 5, 0), None, time(23, 59, 59, 0), time(0, 0, 0, 0)],
+        ),
+        (
+            pa.time64("ns"),
+            "time(7)",
+            [time(12, 0, 5, 123456), None, time(23, 59, 59, 123456), time(0, 0, 0, 0)],
         ),
         (
             pa.timestamp("us"),
@@ -187,14 +192,6 @@ def _test_arrow_test_data(cursor: mssql_python.Cursor, arrow_test_data, fetch_le
 
     # Validate that Parquet serialization/deserialization does not detect any issues
     tbl = pa.Table.from_batches([ret])
-    # for some reason parquet converts seconds to milliseconds in time32
-    for i_col, col in enumerate(tbl.columns):
-        if col.type == pa.time32("s"):
-            tbl = tbl.set_column(
-                i_col,
-                tbl.schema.field(i_col).name,
-                col.cast(pa.time32("ms")),
-            )
     buffer = io.BytesIO()
     pq.write_table(tbl, buffer)
     buffer.seek(0)


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below 
For external contributors: Insert Github Issue number below
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- External contributors: GitHub Issue -->
> GitHub Issue: #498

-------------------------------------------------------------------
### Summary   
<!-- Insert your summary of changes below. Minimum 10 characters required. -->  

Map SQL time types to the arrow nanosecond type and include the fraction part of SQL_SS_TIME2_STRUCT in the value calculation.

For consistency, also remove the unreachable SQL_TIME and SQL_TYPE_TIME branches.

<!-- 
### PR Title Guide

> For feature requests
FEAT: (short-description)

> For non-feature requests like test case updates, config updates , dependency updates etc
CHORE: (short-description) 

> For Fix requests
FIX: (short-description)

> For doc update requests 
DOC: (short-description)

> For Formatting, indentation, or styling update
STYLE: (short-description)

> For Refactor, without any feature changes
REFACTOR: (short-description)

> For release related changes, without any feature changes
RELEASE: #<RELEASE_VERSION> (short-description) 

### Contribution Guidelines

External contributors:
- Create a GitHub issue first: https://github.com/microsoft/mssql-python/issues/new
- Link the GitHub issue in the "GitHub Issue" section above
- Follow the PR title format and provide a meaningful summary

mssql-python maintainers:
- Create an ADO Work Item following internal processes
- Link the ADO Work Item in the "ADO Work Item" section above  
- Follow the PR title format and provide a meaningful summary
-->