### PR TITLE
FEAT: Migrate Release (and dummy) Pipelines to use ReleaseJob

### DIFF
--- a/OneBranchPipelines/dummy-release-pipeline.yml
+++ b/OneBranchPipelines/dummy-release-pipeline.yml
@@ -90,8 +90,9 @@ extends:
         displayName: '[TEST] Dummy Release - Testing ESRP Workflow'
         
         jobs:
-          - job: DownloadAndTestRelease
-            displayName: '[TEST] Download Artifacts and Perform Dummy Release'
+          # Job 1: Download, validate, and stage artifacts (custom pool)
+          - job: PrepAndValidate
+            displayName: '[TEST] Download and Validate Artifacts'
             
             pool:
               type: windows
@@ -116,7 +117,7 @@ extends:
                   artifactName: 'drop_Consolidate_ConsolidateArtifacts'  # Consolidated artifact with dist/ and symbols/
                   targetPath: '$(Build.SourcesDirectory)/artifacts'
               
-              # Step 3: List downloaded artifacts for verification
+              # Step 2: List downloaded artifacts for verification
               - task: PowerShell@2
                 displayName: '[TEST] List Downloaded Wheel and Symbol Files'
                 inputs:
@@ -174,7 +175,7 @@ extends:
                     Write-Host "Symbols: $(if ($symbols) { $symbols.Count } else { 0 }) files"
                     Write-Host "====================================="
               
-              # Step 3.5: Validate mssql-py-core is a stable version (no dev/alpha/beta/rc)
+              # Step 3: Validate mssql-py-core is a stable version (no dev/alpha/beta/rc)
               - task: PowerShell@2
                 displayName: '[TEST] Validate mssql-py-core is a stable version'
                 inputs:
@@ -222,74 +223,7 @@ extends:
                     parameters:
                       SymbolsFolder: '$(Build.SourcesDirectory)/symbols'
               
-              # Step 6: Copy wheels to ob_outputDirectory for OneBranch artifact publishing
-              - task: CopyFiles@2
-                displayName: '[TEST] Stage Wheels for Dummy Release'
-                inputs:
-                  SourceFolder: '$(Build.SourcesDirectory)/dist'
-                  Contents: '*.whl'
-                  TargetFolder: '$(ob_outputDirectory)/release'
-                  flattenFolders: true
-              
-              # Step 7: ESRP Dummy Release Task (only if performDummyRelease is true)
-              # ⚠️ IMPORTANT: Uses Maven ContentType for testing - NOT PyPI!
-              - ${{ if eq(parameters.performDummyRelease, true) }}:
-                  - task: EsrpRelease@9
-                    displayName: '[TEST] ESRP Dummy Release (Maven - NOT PyPI)'
-                    inputs:
-                      connectedservicename: '$(ESRPConnectedServiceName)'
-                      usemanagedidentity: true
-                      keyvaultname: '$(AuthAKVName)'
-                      signcertname: '$(AuthSignCertName)'
-                      clientid: '$(EsrpClientId)'
-                      Intent: 'PackageDistribution'
-                      # ⚠️ CRITICAL: ContentType is Maven (NOT PyPI) for safe testing
-                      # This ensures no accidental production releases to PyPI
-                      ContentType: 'Maven'
-                      ContentSource: 'Folder'
-                      FolderLocation: '$(Build.SourcesDirectory)/dist'
-                      WaitForReleaseCompletion: true
-                      Owners: '$(owner)'
-                      Approvers: '$(approver)'
-                      ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
-                      MainPublisher: 'ESRPRELPACMAN'
-                      DomainTenantId: '$(DomainTenantId)'
-              
-              # Step 8: Show test release status
-              - ${{ if eq(parameters.performDummyRelease, true) }}:
-                  - task: PowerShell@2
-                    displayName: '[TEST] Dummy Release Summary'
-                    inputs:
-                      targetType: 'inline'
-                      script: |
-                        Write-Host "===================================="
-                        Write-Host "⚠️  TEST PIPELINE - DUMMY RELEASE COMPLETED  ⚠️"
-                        Write-Host "===================================="
-                        Write-Host "Package: mssql-python (TEST)"
-                        Write-Host "ContentType: Maven (NOT PyPI - Safe for Testing)"
-                        Write-Host "Owners: $(owner)"
-                        Write-Host "Approvers: $(approver)"
-                        Write-Host "Symbols Published: ${{ parameters.publishSymbols }}"
-                        Write-Host "====================================="
-                        Write-Host ""
-                        Write-Host "⚠️ IMPORTANT: This was a DUMMY release using Maven ContentType"
-                        Write-Host "   NO packages were released to PyPI"
-                        Write-Host ""
-                        Write-Host "What was tested:"
-                        Write-Host "✓ Artifact download from build pipeline"
-                        Write-Host "✓ Wheel integrity verification"
-                        if ("${{ parameters.publishSymbols }}" -eq "True") {
-                          Write-Host "✓ Symbol publishing to SqlClientDrivers org"
-                        }
-                        Write-Host "✓ ESRP release workflow (Maven ContentType)"
-                        Write-Host ""
-                        Write-Host "Next steps:"
-                        Write-Host "1. Verify dummy release in ESRP portal"
-                        Write-Host "2. Check ESRP approval workflow completion"
-                        Write-Host "3. Verify symbols in SqlClientDrivers org (if published)"
-                        Write-Host "4. For PRODUCTION release, use official-release-pipeline.yml"
-                        Write-Host "====================================="
-              
+              # Dry run summary (when release is disabled)
               - ${{ if eq(parameters.performDummyRelease, false) }}:
                   - task: PowerShell@2
                     displayName: '[TEST] Dry Run - Dummy Release Skipped'
@@ -318,3 +252,88 @@ extends:
                         Write-Host "1. Use official-release-pipeline.yml instead"
                         Write-Host "2. Official pipeline uses PyPI ContentType"
                         Write-Host "====================================="
+          
+          # Job 2: ESRP Release (releaseJob on 1ES hosted pool — required by OneBranch policy)
+          # EsrpRelease is not allowed in custom pools; must use templateContext.type: releaseJob
+          - ${{ if eq(parameters.performDummyRelease, true) }}:
+            - job: DummyRelease
+              displayName: '[TEST] ESRP Dummy Release (Maven - NOT PyPI)'
+              dependsOn: PrepAndValidate
+              
+              templateContext:
+                type: releaseJob
+              
+              pool:
+                type: windows
+              
+              variables:
+                ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+                WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
+              
+              steps:
+                # Download artifacts directly from build pipeline
+                - task: DownloadPipelineArtifact@2
+                  displayName: '[TEST] Download Artifacts from Build Pipeline'
+                  inputs:
+                    buildType: 'specific'
+                    project: '$(System.TeamProject)'
+                    definition: 2199
+                    buildVersionToDownload: 'specific'
+                    buildId: $(resources.pipeline.buildPipeline.runID)
+                    artifactName: 'drop_Consolidate_ConsolidateArtifacts'
+                    targetPath: '$(Build.SourcesDirectory)/artifacts'
+                
+                # ⚠️ IMPORTANT: Uses Maven ContentType for testing - NOT PyPI!
+                - task: EsrpRelease@9
+                  displayName: '[TEST] ESRP Dummy Release (Maven - NOT PyPI)'
+                  inputs:
+                    connectedservicename: '$(ESRPConnectedServiceName)'
+                    usemanagedidentity: true
+                    keyvaultname: '$(AuthAKVName)'
+                    signcertname: '$(AuthSignCertName)'
+                    clientid: '$(EsrpClientId)'
+                    Intent: 'PackageDistribution'
+                    # ⚠️ CRITICAL: ContentType is Maven (NOT PyPI) for safe testing
+                    # This ensures no accidental production releases to PyPI
+                    ContentType: 'Maven'
+                    ContentSource: 'Folder'
+                    FolderLocation: '$(Build.SourcesDirectory)/artifacts/dist'
+                    WaitForReleaseCompletion: true
+                    Owners: '$(owner)'
+                    Approvers: '$(approver)'
+                    ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+                    MainPublisher: 'ESRPRELPACMAN'
+                    DomainTenantId: '$(DomainTenantId)'
+                
+                - task: PowerShell@2
+                  displayName: '[TEST] Dummy Release Summary'
+                  inputs:
+                    targetType: 'inline'
+                    script: |
+                      Write-Host "===================================="
+                      Write-Host "⚠️  TEST PIPELINE - DUMMY RELEASE COMPLETED  ⚠️"
+                      Write-Host "===================================="
+                      Write-Host "Package: mssql-python (TEST)"
+                      Write-Host "ContentType: Maven (NOT PyPI - Safe for Testing)"
+                      Write-Host "Owners: $(owner)"
+                      Write-Host "Approvers: $(approver)"
+                      Write-Host "Symbols Published: ${{ parameters.publishSymbols }}"
+                      Write-Host "====================================="
+                      Write-Host ""
+                      Write-Host "⚠️ IMPORTANT: This was a DUMMY release using Maven ContentType"
+                      Write-Host "   NO packages were released to PyPI"
+                      Write-Host ""
+                      Write-Host "What was tested:"
+                      Write-Host "✓ Artifact download from build pipeline"
+                      Write-Host "✓ Wheel integrity verification"
+                      if ("${{ parameters.publishSymbols }}" -eq "True") {
+                        Write-Host "✓ Symbol publishing to SqlClientDrivers org"
+                      }
+                      Write-Host "✓ ESRP release workflow (Maven ContentType)"
+                      Write-Host ""
+                      Write-Host "Next steps:"
+                      Write-Host "1. Verify dummy release in ESRP portal"
+                      Write-Host "2. Check ESRP approval workflow completion"
+                      Write-Host "3. Verify symbols in SqlClientDrivers org (if published)"
+                      Write-Host "4. For PRODUCTION release, use official-release-pipeline.yml"
+                      Write-Host "====================================="

--- a/OneBranchPipelines/official-release-pipeline.yml
+++ b/OneBranchPipelines/official-release-pipeline.yml
@@ -93,8 +93,9 @@ extends:
         displayName: 'Release Python Packages to PyPI'
         
         jobs:
-          - job: DownloadAndRelease
-            displayName: 'Download Artifacts and Release via ESRP'
+          # Job 1: Download, validate, and stage artifacts (custom pool)
+          - job: PrepAndValidate
+            displayName: 'Download and Validate Artifacts'
             
             pool:
               type: windows
@@ -119,7 +120,7 @@ extends:
                   artifactName: 'drop_Consolidate_ConsolidateArtifacts'  # Consolidated artifact with dist/ and symbols/
                   targetPath: '$(Build.SourcesDirectory)/artifacts'
               
-              # Step 3: List downloaded artifacts for verification
+              # Step 2: List downloaded artifacts for verification
               - task: PowerShell@2
                 displayName: 'List Downloaded Wheel and Symbol Files'
                 inputs:
@@ -139,11 +140,6 @@ extends:
                         $size = [math]::Round($wheel.Length / 1MB, 2)
                         Write-Host "  - $($wheel.Name) (${size} MB)"
                       }
-                      
-                      # Copy wheels to dist folder for ESRP
-                      Write-Host "`nCopying wheels to $(Build.SourcesDirectory)/dist..."
-                      New-Item -ItemType Directory -Force -Path "$(Build.SourcesDirectory)/dist" | Out-Null
-                      Copy-Item -Path "$wheelsPath/*.whl" -Destination "$(Build.SourcesDirectory)/dist/" -Force
                       
                     } else {
                       Write-Error "Wheel directory not found at: $wheelsPath"
@@ -177,7 +173,7 @@ extends:
                     Write-Host "Symbols: $(if ($symbols) { $symbols.Count } else { 0 }) files"
                     Write-Host "====================================="
               
-              # Step 3.5: Validate mssql-py-core is a stable version (no dev/alpha/beta/rc)
+              # Step 3: Validate mssql-py-core is a stable version (no dev/alpha/beta/rc)
               - task: PowerShell@2
                 displayName: 'Validate mssql-py-core is a stable version'
                 inputs:
@@ -193,7 +189,7 @@ extends:
                   script: |
                     Write-Host "Verifying wheel file integrity..."
                     
-                    $wheels = Get-ChildItem -Path "$(Build.SourcesDirectory)/dist" -Filter "*.whl"
+                    $wheels = Get-ChildItem -Path "$(Build.SourcesDirectory)/artifacts/dist" -Filter "*.whl"
                     $allValid = $true
                     
                     foreach ($wheel in $wheels) {
@@ -225,60 +221,7 @@ extends:
                     parameters:
                       SymbolsFolder: '$(Build.SourcesDirectory)/symbols'
               
-              # Step 6: Copy wheels to ob_outputDirectory for OneBranch artifact publishing
-              - task: CopyFiles@2
-                displayName: 'Stage Wheels for Release'
-                inputs:
-                  SourceFolder: '$(Build.SourcesDirectory)/dist'
-                  Contents: '*.whl'
-                  TargetFolder: '$(ob_outputDirectory)/release'
-                  flattenFolders: true
-              
-              # Step 7: ESRP Release Task (only if releaseToPyPI is true)
-              - ${{ if eq(parameters.releaseToPyPI, true) }}:
-                  - task: EsrpRelease@9
-                    displayName: 'ESRP Release to PyPI'
-                    inputs:
-                      connectedservicename: '$(ESRPConnectedServiceName)'
-                      usemanagedidentity: true
-                      keyvaultname: '$(AuthAKVName)'
-                      signcertname: '$(AuthSignCertName)'
-                      clientid: '$(EsrpClientId)'
-                      Intent: 'PackageDistribution'
-                      ContentType: 'PyPI'
-                      ContentSource: 'Folder'
-                      FolderLocation: '$(Build.SourcesDirectory)/dist'
-                      WaitForReleaseCompletion: true
-                      Owners: '$(owner)'
-                      Approvers: '$(approver)'
-                      ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
-                      MainPublisher: 'ESRPRELPACMAN'
-                      DomainTenantId: '$(DomainTenantId)'
-              
-              # Step 8: Show release status
-              - ${{ if eq(parameters.releaseToPyPI, true) }}:
-                  - task: PowerShell@2
-                    displayName: 'Release Summary'
-                    inputs:
-                      targetType: 'inline'
-                      script: |
-                        Write-Host "===================================="
-                        Write-Host "ESRP Release Completed"
-                        Write-Host "===================================="
-                        Write-Host "Package: mssql-python"
-                        Write-Host "Target: PyPI"
-                        Write-Host "Owners: $(owner)"
-                        Write-Host "Approvers: $(approver)"
-                        Write-Host "Symbols Published: ${{ parameters.publishSymbols }}"
-                        Write-Host "====================================="
-                        Write-Host ""
-                        Write-Host "Next steps:"
-                        Write-Host "1. Verify release in ESRP portal"
-                        Write-Host "2. Wait for approval workflow completion"
-                        Write-Host "3. Verify package on PyPI: https://pypi.org/project/mssql-python/"
-                        Write-Host "4. Verify symbols in SqlClientDrivers org (if published)"
-                        Write-Host "====================================="
-              
+              # Dry run summary (when release is disabled)
               - ${{ if eq(parameters.releaseToPyPI, false) }}:
                   - task: PowerShell@2
                     displayName: 'Dry Run - Release Skipped'
@@ -292,6 +235,7 @@ extends:
                         Write-Host ""
                         Write-Host "Actions performed:"
                         Write-Host "- Downloaded wheels from build pipeline"
+                        Write-Host "- Verified wheel integrity"
                         Write-Host "- Downloaded symbols from build pipeline"
                         if ("${{ parameters.publishSymbols }}" -eq "True") {
                           Write-Host "- Published symbols to SqlClientDrivers org"
@@ -301,3 +245,74 @@ extends:
                         Write-Host "1. Set 'releaseToPyPI' parameter to true"
                         Write-Host "2. Re-run pipeline"
                         Write-Host "====================================="
+          
+          # Job 2: ESRP Release (releaseJob on 1ES hosted pool — required by OneBranch policy)
+          # EsrpRelease is not allowed in custom pools; must use templateContext.type: releaseJob
+          - ${{ if eq(parameters.releaseToPyPI, true) }}:
+            - job: PyPIRelease
+              displayName: 'ESRP Release to PyPI'
+              dependsOn: PrepAndValidate
+              
+              templateContext:
+                type: releaseJob
+                isProduction: true
+              
+              pool:
+                type: windows
+              
+              variables:
+                ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+                WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
+              
+              steps:
+                - task: DownloadPipelineArtifact@2
+                  displayName: 'Download Artifacts from Build Pipeline'
+                  inputs:
+                    buildType: 'specific'
+                    project: '$(System.TeamProject)'
+                    definition: 2199
+                    buildVersionToDownload: 'specific'
+                    buildId: $(resources.pipeline.buildPipeline.runID)
+                    artifactName: 'drop_Consolidate_ConsolidateArtifacts'
+                    targetPath: '$(Build.SourcesDirectory)/artifacts'
+                
+                - task: EsrpRelease@9
+                  displayName: 'ESRP Release to PyPI'
+                  inputs:
+                    connectedservicename: '$(ESRPConnectedServiceName)'
+                    usemanagedidentity: true
+                    keyvaultname: '$(AuthAKVName)'
+                    signcertname: '$(AuthSignCertName)'
+                    clientid: '$(EsrpClientId)'
+                    Intent: 'PackageDistribution'
+                    ContentType: 'PyPI'
+                    ContentSource: 'Folder'
+                    FolderLocation: '$(Build.SourcesDirectory)/artifacts/dist'
+                    WaitForReleaseCompletion: true
+                    Owners: '$(owner)'
+                    Approvers: '$(approver)'
+                    ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+                    MainPublisher: 'ESRPRELPACMAN'
+                    DomainTenantId: '$(DomainTenantId)'
+                
+                - task: PowerShell@2
+                  displayName: 'Release Summary'
+                  inputs:
+                    targetType: 'inline'
+                    script: |
+                      Write-Host "===================================="
+                      Write-Host "ESRP Release Completed"
+                      Write-Host "===================================="
+                      Write-Host "Package: mssql-python"
+                      Write-Host "Target: PyPI"
+                      Write-Host "Owners: $(owner)"
+                      Write-Host "Approvers: $(approver)"
+                      Write-Host "Symbols Published: ${{ parameters.publishSymbols }}"
+                      Write-Host "====================================="
+                      Write-Host ""
+                      Write-Host "Next steps:"
+                      Write-Host "1. Verify release in ESRP portal"
+                      Write-Host "2. Wait for approval workflow completion"
+                      Write-Host "3. Verify package on PyPI: https://pypi.org/project/mssql-python/"
+                      Write-Host "4. Verify symbols in SqlClientDrivers org (if published)"
+                      Write-Host "====================================="


### PR DESCRIPTION


### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below 
For external contributors: Insert Github Issue number below
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> [AB#43946](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/43946)

<!-- External contributors: GitHub Issue -->
> GitHub Issue: #<ISSUE_NUMBER>

-------------------------------------------------------------------
### Summary   
<!-- Insert your summary of changes below. Minimum 10 characters required. -->  

This pull request restructures both the dummy and official release pipelines to improve clarity, enforce OneBranch policy requirements, and streamline artifact handling. The main changes include splitting the pipelines into explicit preparation/validation and release jobs, ensuring ESRP release steps run on the correct pool, updating artifact paths, and enhancing dry run handling.

**Pipeline Restructuring and Policy Compliance:**

* Split the pipelines into two explicit jobs: `PrepAndValidate` (for downloading, validating, and staging artifacts using a custom pool) and a release job (`DummyRelease` or `PyPIRelease`) that runs on a 1ES hosted pool as required by OneBranch policy. ESRP release steps are now only in the release job, which depends on the preparation job. (`OneBranchPipelines/dummy-release-pipeline.yml`, `OneBranchPipelines/official-release-pipeline.yml`) [[1]](diffhunk://#diff-f33e687de954b798773c221fa2242934d5ec593abda31b787cdb10d590c1cb76L93-R95) [[2]](diffhunk://#diff-27a96a9aa4f8678027cc712c73505b5351a98bcd22501bbf5f0ed9617a7a6bffL96-R98) [[3]](diffhunk://#diff-f33e687de954b798773c221fa2242934d5ec593abda31b787cdb10d590c1cb76L225-R286) [[4]](diffhunk://#diff-27a96a9aa4f8678027cc712c73505b5351a98bcd22501bbf5f0ed9617a7a6bffL228-R278)

* ESRP release jobs now use `templateContext.type: releaseJob` and ensure artifact download and publishing steps are run in the correct environment, preventing accidental production releases from test pipelines. (`OneBranchPipelines/dummy-release-pipeline.yml`, `OneBranchPipelines/official-release-pipeline.yml`) [[1]](diffhunk://#diff-f33e687de954b798773c221fa2242934d5ec593abda31b787cdb10d590c1cb76L225-R286) [[2]](diffhunk://#diff-27a96a9aa4f8678027cc712c73505b5351a98bcd22501bbf5f0ed9617a7a6bffL228-R278)

**Artifact Path and Handling Updates:**

* Changed artifact and wheel file paths throughout the pipelines to use the new consolidated artifact location (`$(Build.SourcesDirectory)/artifacts/dist`) instead of the previous `dist` folder. This affects validation, ESRP release, and summary steps. (`OneBranchPipelines/dummy-release-pipeline.yml`, `OneBranchPipelines/official-release-pipeline.yml`) [[1]](diffhunk://#diff-f33e687de954b798773c221fa2242934d5ec593abda31b787cdb10d590c1cb76L250-L259) [[2]](diffhunk://#diff-27a96a9aa4f8678027cc712c73505b5351a98bcd22501bbf5f0ed9617a7a6bffL196-R192) [[3]](diffhunk://#diff-27a96a9aa4f8678027cc712c73505b5351a98bcd22501bbf5f0ed9617a7a6bffL250-L259)

* Removed unnecessary steps for copying wheels to a separate `dist` folder, as the new artifact structure makes this redundant. (`OneBranchPipelines/official-release-pipeline.yml`)

**Dry Run and Summary Improvements:**

* Enhanced dry run handling: when release parameters are disabled, a clear summary is shown and release steps are skipped. This logic is now more explicit and avoids accidental releases. (`OneBranchPipelines/dummy-release-pipeline.yml`, `OneBranchPipelines/official-release-pipeline.yml`) [[1]](diffhunk://#diff-f33e687de954b798773c221fa2242934d5ec593abda31b787cdb10d590c1cb76L225-R286) [[2]](diffhunk://#diff-27a96a9aa4f8678027cc712c73505b5351a98bcd22501bbf5f0ed9617a7a6bffL228-R278) [[3]](diffhunk://#diff-f33e687de954b798773c221fa2242934d5ec593abda31b787cdb10d590c1cb76L292-L320) [[4]](diffhunk://#diff-27a96a9aa4f8678027cc712c73505b5351a98bcd22501bbf5f0ed9617a7a6bffL281-L303)

**Step Renumbering and Minor Cleanups:**

* Updated step numbers and comments for clarity and consistency after restructuring, and removed obsolete or duplicate summary steps. (`OneBranchPipelines/dummy-release-pipeline.yml`, `OneBranchPipelines/official-release-pipeline.yml`) [[1]](diffhunk://#diff-f33e687de954b798773c221fa2242934d5ec593abda31b787cdb10d590c1cb76L119-R120) [[2]](diffhunk://#diff-f33e687de954b798773c221fa2242934d5ec593abda31b787cdb10d590c1cb76L177-R178) [[3]](diffhunk://#diff-27a96a9aa4f8678027cc712c73505b5351a98bcd22501bbf5f0ed9617a7a6bffL122-R123) [[4]](diffhunk://#diff-27a96a9aa4f8678027cc712c73505b5351a98bcd22501bbf5f0ed9617a7a6bffL180-R176)

These changes make the pipelines more robust, easier to understand, and compliant with internal release policies.
<!-- 
### PR Title Guide

> For feature requests
FEAT: (short-description)

> For non-feature requests like test case updates, config updates , dependency updates etc
CHORE: (short-description) 

> For Fix requests
FIX: (short-description)

> For doc update requests 
DOC: (short-description)

> For Formatting, indentation, or styling update
STYLE: (short-description)

> For Refactor, without any feature changes
REFACTOR: (short-description)

> For release related changes, without any feature changes
RELEASE: #<RELEASE_VERSION> (short-description) 

### Contribution Guidelines

External contributors:
- Create a GitHub issue first: https://github.com/microsoft/mssql-python/issues/new
- Link the GitHub issue in the "GitHub Issue" section above
- Follow the PR title format and provide a meaningful summary

mssql-python maintainers:
- Create an ADO Work Item following internal processes
- Link the ADO Work Item in the "ADO Work Item" section above  
- Follow the PR title format and provide a meaningful summary
-->