### PR TITLE
FIX: GH-Issue (#532) - Login failures are raised as RuntimeError instead of a mssql_python exception

### DIFF
--- a/mssql_python/connection.py
+++ b/mssql_python/connection.py
@@ -38,6 +38,7 @@ from mssql_python.exceptions import (
     InternalError,
     ProgrammingError,
     NotSupportedError,
+    sqlstate_to_exception,
 )
 from mssql_python.auth import extract_auth_type, process_connection_string
 from mssql_python.constants import ConstantsDDBC, GetInfoConstants
@@ -56,6 +57,35 @@ INFO_TYPE_STRING_THRESHOLD: int = 10000
 # UTF-16 encoding variants that should use SQL_WCHAR by default
 # Note: "utf-16" with BOM is NOT included as it's problematic for SQL_WCHAR
 UTF16_ENCODINGS: frozenset[str] = frozenset(["utf-16le", "utf-16be"])
+
+_SQLSTATE_RE = re.compile(r"^SQLSTATE:([A-Z0-9]{5}):(.*)", re.DOTALL)
+
+
+def _raise_connection_error(e: RuntimeError) -> None:
+    """Map a RuntimeError from the C++ pybind layer to the correct DB-API 2.0 exception.
+
+    Connection::checkError() throws "SQLSTATE:XXXXX:<odbc_message>" so the SQLSTATE
+    can be mapped via sqlstate_to_exception(), consistent with cursor-level error handling.
+    """
+    error_msg = str(e)
+    match = _SQLSTATE_RE.match(error_msg)
+    if match:
+        sqlstate, ddbc_error = match.group(1), match.group(2)
+        exc = sqlstate_to_exception(sqlstate, ddbc_error)
+        if exc is None:
+            logger.error("Unknown SQLSTATE %s, raising DatabaseError", sqlstate)
+            raise DatabaseError(
+                driver_error=f"An error occurred with SQLSTATE code: {sqlstate}",
+                ddbc_error=ddbc_error,
+            ) from None
+        logger.error("Connection error (SQLSTATE %s): %s", sqlstate, ddbc_error)
+        raise exc from None
+    # Fallback: no SQLSTATE prefix — e.g. "Connection handle not allocated"
+    logger.error("Connection error: %s", error_msg)
+    raise OperationalError(
+        driver_error="Connection operation failed",
+        ddbc_error=error_msg,
+    ) from None
 
 
 def _validate_utf16_wchar_compatibility(
@@ -333,9 +363,12 @@ class Connection:
         if not PoolingManager.is_initialized():
             PoolingManager.enable()
         self._pooling = PoolingManager.is_enabled()
-        self._conn = ddbc_bindings.Connection(
-            self.connection_str, self._pooling, self._attrs_before
-        )
+        try:
+            self._conn = ddbc_bindings.Connection(
+                self.connection_str, self._pooling, self._attrs_before
+            )
+        except RuntimeError as e:
+            _raise_connection_error(e)
         self.setautocommit(autocommit)
 
         # Register this connection for cleanup before Python shutdown
@@ -496,7 +529,10 @@ class Connection:
         Raises:
             DatabaseError: If there is an error while setting the autocommit mode.
         """
-        self._conn.set_autocommit(value)
+        try:
+            self._conn.set_autocommit(value)
+        except RuntimeError as e:
+            _raise_connection_error(e)
 
     def setencoding(self, encoding: Optional[str] = None, ctype: Optional[int] = None) -> None:
         """
@@ -1491,7 +1527,10 @@ class Connection:
             )
 
         # Commit the current transaction
-        self._conn.commit()
+        try:
+            self._conn.commit()
+        except RuntimeError as e:
+            _raise_connection_error(e)
         logger.info("Transaction committed successfully.")
 
     def rollback(self) -> None:
@@ -1514,7 +1553,10 @@ class Connection:
             )
 
         # Roll back the current transaction
-        self._conn.rollback()
+        try:
+            self._conn.rollback()
+        except RuntimeError as e:
+            _raise_connection_error(e)
         logger.info("Transaction rolled back successfully.")
 
     def close(self) -> None:

--- a/mssql_python/connection.py
+++ b/mssql_python/connection.py
@@ -931,9 +931,6 @@ class Connection:
             self._conn.set_attr(attribute, value)
             logger.info(f"Connection attribute {sanitized_attr} set successfully")
 
-        except RuntimeError as e:
-            # Handle C++ layer RuntimeError with proper DB-API exception mapping
-            _raise_connection_error(e)
         except Exception as e:
             error_msg = f"Failed to set connection attribute {sanitized_attr}: {str(e)}"
 
@@ -1314,9 +1311,6 @@ class Connection:
         # Get the raw result from the C++ layer
         try:
             raw_result = self._conn.get_info(info_type)
-        except RuntimeError as e:
-            # Handle C++ layer RuntimeError with proper DB-API exception mapping
-            _raise_connection_error(e)
         except Exception as e:  # pylint: disable=broad-exception-caught
             # Log the error and return None for invalid info types
             logger.warning(f"getinfo({info_type}) failed: {e}")

--- a/mssql_python/connection.py
+++ b/mssql_python/connection.py
@@ -496,7 +496,10 @@ class Connection:
         Returns:
             bool: True if autocommit is enabled, False otherwise.
         """
-        return self._conn.get_autocommit()
+        try:
+            return self._conn.get_autocommit()
+        except RuntimeError as e:
+            _raise_connection_error(e)
 
     @autocommit.setter
     def autocommit(self, value: bool) -> None:
@@ -928,6 +931,9 @@ class Connection:
             self._conn.set_attr(attribute, value)
             logger.info(f"Connection attribute {sanitized_attr} set successfully")
 
+        except RuntimeError as e:
+            # Handle C++ layer RuntimeError with proper DB-API exception mapping
+            _raise_connection_error(e)
         except Exception as e:
             error_msg = f"Failed to set connection attribute {sanitized_attr}: {str(e)}"
 
@@ -1308,6 +1314,9 @@ class Connection:
         # Get the raw result from the C++ layer
         try:
             raw_result = self._conn.get_info(info_type)
+        except RuntimeError as e:
+            # Handle C++ layer RuntimeError with proper DB-API exception mapping
+            _raise_connection_error(e)
         except Exception as e:  # pylint: disable=broad-exception-caught
             # Log the error and return None for invalid info types
             logger.warning(f"getinfo({info_type}) failed: {e}")
@@ -1619,7 +1628,11 @@ class Connection:
                     # For autocommit True, this is not necessary as each statement is
                     # committed immediately
                     logger.debug("Rolling back uncommitted changes before closing connection.")
-                    self._conn.rollback()
+                    try:
+                        self._conn.rollback()
+                    except RuntimeError as e:
+                        # Handle C++ layer RuntimeError with proper DB-API exception mapping
+                        _raise_connection_error(e)
                 # TODO: Check potential race conditions in case of multithreaded scenarios
                 # Close the connection
                 self._conn.close()

--- a/mssql_python/connection.py
+++ b/mssql_python/connection.py
@@ -58,7 +58,7 @@ INFO_TYPE_STRING_THRESHOLD: int = 10000
 # Note: "utf-16" with BOM is NOT included as it's problematic for SQL_WCHAR
 UTF16_ENCODINGS: frozenset[str] = frozenset(["utf-16le", "utf-16be"])
 
-_SQLSTATE_RE = re.compile(r"^SQLSTATE:([A-Z0-9]{5}):(.*)", re.DOTALL)
+_SQLSTATE_RE = re.compile(r"^SQLSTATE:([A-Z0-9]{0,5}):(.*)", re.DOTALL)
 
 
 def _raise_connection_error(e: RuntimeError) -> None:
@@ -71,6 +71,13 @@ def _raise_connection_error(e: RuntimeError) -> None:
     match = _SQLSTATE_RE.match(error_msg)
     if match:
         sqlstate, ddbc_error = match.group(1), match.group(2)
+        # Handle malformed SQLSTATE prefix (empty or invalid code)
+        if not sqlstate or len(sqlstate) != 5:
+            logger.error("Connection error (malformed SQLSTATE): %s", ddbc_error)
+            raise OperationalError(
+                driver_error="Connection operation failed",
+                ddbc_error=ddbc_error,
+            ) from None
         exc = sqlstate_to_exception(sqlstate, ddbc_error)
         if exc is None:
             logger.error("Unknown SQLSTATE %s, raising DatabaseError", sqlstate)

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -170,8 +170,11 @@ void Connection::disconnect() {
 // DB spec compliant
 void Connection::checkError(SQLRETURN ret) const {
     if (!SQL_SUCCEEDED(ret)) {
+        // Format: "SQLSTATE:XXXXX:<odbc_error_message>" — parsed by _raise_connection_error()
         ErrorInfo err = SQLCheckError_Wrap(SQL_HANDLE_DBC, _dbcHandle, ret);
-        ThrowStdException(err.ddbcErrorMsg);
+        std::string sqlState = WideToUTF8(err.sqlState);
+        std::string errorMsg = WideToUTF8(err.ddbcErrorMsg);
+        ThrowStdException("SQLSTATE:" + sqlState + ":" + errorMsg);
     }
 }
 

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -174,7 +174,13 @@ void Connection::checkError(SQLRETURN ret) const {
         ErrorInfo err = SQLCheckError_Wrap(SQL_HANDLE_DBC, _dbcHandle, ret);
         std::string sqlState = WideToUTF8(err.sqlState);
         std::string errorMsg = WideToUTF8(err.ddbcErrorMsg);
-        ThrowStdException("SQLSTATE:" + sqlState + ":" + errorMsg);
+        // Only add SQLSTATE prefix if we have a valid 5-character code
+        if (sqlState.length() == 5) {
+            ThrowStdException("SQLSTATE:" + sqlState + ":" + errorMsg);
+        } else {
+            // No valid SQLSTATE (e.g., SQL_INVALID_HANDLE) — throw clean error message
+            ThrowStdException(errorMsg);
+        }
     }
 }
 

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -172,8 +172,8 @@ void Connection::checkError(SQLRETURN ret) const {
     if (!SQL_SUCCEEDED(ret)) {
         // Format: "SQLSTATE:XXXXX:<odbc_error_message>" — parsed by _raise_connection_error()
         ErrorInfo err = SQLCheckError_Wrap(SQL_HANDLE_DBC, _dbcHandle, ret);
-        std::string sqlState = WideToUTF8(err.sqlState);
-        std::string errorMsg = WideToUTF8(err.ddbcErrorMsg);
+        std::string sqlState = err.sqlState;
+        std::string errorMsg = err.ddbcErrorMsg;
         // Only add SQLSTATE prefix if we have a valid 5-character code
         if (sqlState.length() == 5) {
             ThrowStdException("SQLSTATE:" + sqlState + ":" + errorMsg);

--- a/tests/test_006_exceptions.py
+++ b/tests/test_006_exceptions.py
@@ -190,6 +190,71 @@ def test_connection_error():
     assert "Incomplete specification" in str(excinfo.value) or "has no value" in str(excinfo.value)
 
 
+def test_connect_runtime_error_mapped_to_correct_dbapi_exception():
+    """Regression test for https://github.com/microsoft/mssql-python/issues/532.
+
+    Connection failures from the C++ pybind layer (RuntimeError) must be mapped
+    to the correct DB-API 2.0 exception via the embedded SQLSTATE code.
+    This covers connect(), commit(), and rollback() — all of which go through
+    Connection::checkError() in the C++ layer.
+    """
+    from unittest.mock import MagicMock, patch
+
+    # SQLSTATE 28000 = login failed -> OperationalError
+    with patch(
+        "mssql_python.connection.ddbc_bindings.Connection",
+        side_effect=RuntimeError("SQLSTATE:28000:Login failed for user 'baduser'."),
+    ):
+        with pytest.raises(OperationalError) as exc_info:
+            connect("Server=localhost;Database=mydb;UID=baduser;PWD=wrongpassword;")
+    assert "Login failed for user" in exc_info.value.ddbc_error
+    assert not isinstance(exc_info.value, RuntimeError)
+
+    # SQLSTATE IM002 = driver not found -> OperationalError (per SQLSTATE mapping)
+    with patch(
+        "mssql_python.connection.ddbc_bindings.Connection",
+        side_effect=RuntimeError(
+            "SQLSTATE:IM002:Data source name not found and no default driver specified"
+        ),
+    ):
+        with pytest.raises(OperationalError) as exc_info:
+            connect("Server=localhost;Database=mydb;UID=u;PWD=p;")
+    assert "no default driver" in exc_info.value.ddbc_error
+    assert not isinstance(exc_info.value, RuntimeError)
+
+    # No SQLSTATE prefix -> fallback OperationalError
+    with patch(
+        "mssql_python.connection.ddbc_bindings.Connection",
+        side_effect=RuntimeError("Connection handle not allocated"),
+    ):
+        with pytest.raises(OperationalError) as exc_info:
+            connect("Server=localhost;Database=mydb;UID=u;PWD=p;")
+    assert "Connection handle not allocated" in exc_info.value.ddbc_error
+    assert not isinstance(exc_info.value, RuntimeError)
+
+    # commit() failure -> OperationalError via same _raise_connection_error path
+    mock_conn = MagicMock()
+    mock_conn.commit.side_effect = RuntimeError("SQLSTATE:08S01:Communication link failure")
+    mock_conn.get_autocommit.return_value = False
+    with patch("mssql_python.connection.ddbc_bindings.Connection", return_value=mock_conn):
+        conn = connect("Server=localhost;Database=mydb;UID=u;PWD=p;")
+    with pytest.raises(OperationalError) as exc_info:
+        conn.commit()
+    assert "Communication link failure" in exc_info.value.ddbc_error
+    assert not isinstance(exc_info.value, RuntimeError)
+
+    # rollback() failure -> OperationalError via same _raise_connection_error path
+    mock_conn2 = MagicMock()
+    mock_conn2.rollback.side_effect = RuntimeError("SQLSTATE:08S01:Communication link failure")
+    mock_conn2.get_autocommit.return_value = False
+    with patch("mssql_python.connection.ddbc_bindings.Connection", return_value=mock_conn2):
+        conn2 = connect("Server=localhost;Database=mydb;UID=u;PWD=p;")
+    with pytest.raises(OperationalError) as exc_info:
+        conn2.rollback()
+    assert "Communication link failure" in exc_info.value.ddbc_error
+    assert not isinstance(exc_info.value, RuntimeError)
+
+
 def test_truncate_error_message_successful_cases():
     """Test truncate_error_message with valid Microsoft messages for comparison."""
 

--- a/tests/test_006_exceptions.py
+++ b/tests/test_006_exceptions.py
@@ -206,7 +206,7 @@ def test_connect_runtime_error_mapped_to_correct_dbapi_exception():
         side_effect=RuntimeError("SQLSTATE:28000:Login failed for user 'baduser'."),
     ):
         with pytest.raises(OperationalError) as exc_info:
-            connect("Server=localhost;Database=mydb;UID=baduser;PWD=wrongpassword;")
+            connect("Server=testserver;Database=mydb;UID=baduser;PWD=wrongpassword;")
     assert "Login failed for user" in exc_info.value.ddbc_error
     assert not isinstance(exc_info.value, RuntimeError)
 
@@ -218,7 +218,7 @@ def test_connect_runtime_error_mapped_to_correct_dbapi_exception():
         ),
     ):
         with pytest.raises(OperationalError) as exc_info:
-            connect("Server=localhost;Database=mydb;UID=u;PWD=p;")
+            connect("Server=testserver;Database=mydb;UID=u;PWD=p;")
     assert "no default driver" in exc_info.value.ddbc_error
     assert not isinstance(exc_info.value, RuntimeError)
 
@@ -228,7 +228,7 @@ def test_connect_runtime_error_mapped_to_correct_dbapi_exception():
         side_effect=RuntimeError("Connection handle not allocated"),
     ):
         with pytest.raises(OperationalError) as exc_info:
-            connect("Server=localhost;Database=mydb;UID=u;PWD=p;")
+            connect("Server=testserver;Database=mydb;UID=u;PWD=p;")
     assert "Connection handle not allocated" in exc_info.value.ddbc_error
     assert not isinstance(exc_info.value, RuntimeError)
 
@@ -238,7 +238,7 @@ def test_connect_runtime_error_mapped_to_correct_dbapi_exception():
         side_effect=RuntimeError("SQLSTATE:99999:Unknown error with unmapped code"),
     ):
         with pytest.raises(DatabaseError) as exc_info:
-            connect("Server=localhost;Database=mydb;UID=u;PWD=p;")
+            connect("Server=testserver;Database=mydb;UID=u;PWD=p;")
     assert "Unknown error with unmapped code" in exc_info.value.ddbc_error
     assert "SQLSTATE code: 99999" in exc_info.value.driver_error
     assert not isinstance(exc_info.value, RuntimeError)
@@ -249,7 +249,7 @@ def test_connect_runtime_error_mapped_to_correct_dbapi_exception():
         side_effect=RuntimeError("SQLSTATE::Invalid handle!"),
     ):
         with pytest.raises(OperationalError) as exc_info:
-            connect("Server=localhost;Database=mydb;UID=u;PWD=p;")
+            connect("Server=testserver;Database=mydb;UID=u;PWD=p;")
     assert "Invalid handle!" in exc_info.value.ddbc_error
     assert not isinstance(exc_info.value, RuntimeError)
 
@@ -258,7 +258,7 @@ def test_connect_runtime_error_mapped_to_correct_dbapi_exception():
     mock_conn.commit.side_effect = RuntimeError("SQLSTATE:08S01:Communication link failure")
     mock_conn.get_autocommit.return_value = False
     with patch("mssql_python.connection.ddbc_bindings.Connection", return_value=mock_conn):
-        conn = connect("Server=localhost;Database=mydb;UID=u;PWD=p;")
+        conn = connect("Server=testserver;Database=mydb;UID=u;PWD=p;")
     with pytest.raises(OperationalError) as exc_info:
         conn.commit()
     assert "Communication link failure" in exc_info.value.ddbc_error
@@ -269,7 +269,7 @@ def test_connect_runtime_error_mapped_to_correct_dbapi_exception():
     mock_conn2.rollback.side_effect = RuntimeError("SQLSTATE:08S01:Communication link failure")
     mock_conn2.get_autocommit.return_value = False
     with patch("mssql_python.connection.ddbc_bindings.Connection", return_value=mock_conn2):
-        conn2 = connect("Server=localhost;Database=mydb;UID=u;PWD=p;")
+        conn2 = connect("Server=testserver;Database=mydb;UID=u;PWD=p;")
     with pytest.raises(OperationalError) as exc_info:
         conn2.rollback()
     assert "Communication link failure" in exc_info.value.ddbc_error

--- a/tests/test_006_exceptions.py
+++ b/tests/test_006_exceptions.py
@@ -232,6 +232,27 @@ def test_connect_runtime_error_mapped_to_correct_dbapi_exception():
     assert "Connection handle not allocated" in exc_info.value.ddbc_error
     assert not isinstance(exc_info.value, RuntimeError)
 
+    # Unmapped SQLSTATE (sqlstate_to_exception returns None) -> DatabaseError
+    with patch(
+        "mssql_python.connection.ddbc_bindings.Connection",
+        side_effect=RuntimeError("SQLSTATE:99999:Unknown error with unmapped code"),
+    ):
+        with pytest.raises(DatabaseError) as exc_info:
+            connect("Server=localhost;Database=mydb;UID=u;PWD=p;")
+    assert "Unknown error with unmapped code" in exc_info.value.ddbc_error
+    assert "SQLSTATE code: 99999" in exc_info.value.driver_error
+    assert not isinstance(exc_info.value, RuntimeError)
+
+    # Malformed SQLSTATE (empty code) -> OperationalError
+    with patch(
+        "mssql_python.connection.ddbc_bindings.Connection",
+        side_effect=RuntimeError("SQLSTATE::Invalid handle!"),
+    ):
+        with pytest.raises(OperationalError) as exc_info:
+            connect("Server=localhost;Database=mydb;UID=u;PWD=p;")
+    assert "Invalid handle!" in exc_info.value.ddbc_error
+    assert not isinstance(exc_info.value, RuntimeError)
+
     # commit() failure -> OperationalError via same _raise_connection_error path
     mock_conn = MagicMock()
     mock_conn.commit.side_effect = RuntimeError("SQLSTATE:08S01:Communication link failure")


### PR DESCRIPTION

### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below 
For external contributors: Insert Github Issue number below
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> [AB#44632](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/44632)

<!-- External contributors: GitHub Issue -->
> GitHub Issue: #532 
-------------------------------------------------------------------
### Summary   
<!-- Insert your summary of changes below. Minimum 10 characters required. -->  
This pull request improves error handling in the `mssql_python` connection layer by ensuring that low-level runtime errors from the C++ pybind layer are consistently mapped to the correct DB-API 2.0 exceptions using SQLSTATE codes. This makes error reporting more robust and predictable, especially during connection, commit, and rollback operations. The changes also add comprehensive tests to verify this behavior.

**Error handling improvements:**

* Introduced the `_raise_connection_error` function in `connection.py` to parse `RuntimeError` messages from the C++ layer, extract SQLSTATE codes, and map them to appropriate DB-API exceptions using `sqlstate_to_exception`. If no SQLSTATE is found, a fallback `OperationalError` is raised. (`[mssql_python/connection.pyR61-R89](diffhunk://#diff-29bb94de45aae51c23a6426d40133c28e4161e68769e08d046059c7186264e90R61-R89)`)
* Updated the connection initialization, `setautocommit`, `commit`, and `rollback` methods in `connection.py` to wrap calls to the native layer in try/except blocks that utilize `_raise_connection_error`, ensuring consistent exception mapping throughout the connection lifecycle. (`[[1]](diffhunk://#diff-29bb94de45aae51c23a6426d40133c28e4161e68769e08d046059c7186264e90R362-R367)`, `[[2]](diffhunk://#diff-29bb94de45aae51c23a6426d40133c28e4161e68769e08d046059c7186264e90R528-R531)`, `[[3]](diffhunk://#diff-29bb94de45aae51c23a6426d40133c28e4161e68769e08d046059c7186264e90R1516-R1519)`, `[[4]](diffhunk://#diff-29bb94de45aae51c23a6426d40133c28e4161e68769e08d046059c7186264e90R1542-R1545)`)
* Modified the C++ `Connection::checkError` method to format error messages as `"SQLSTATE:XXXXX:<odbc_error_message>"`, enabling the Python layer to parse and handle errors correctly. (`[mssql_python/pybind/connection/connection.cppR182-R186](diffhunk://#diff-eca696c13d997f510e5f9b16288ed1deb0ad132768c283eda1518f78edf9b6ecR182-R186)`)

**Testing enhancements:**

* Added a regression test (`test_connect_runtime_error_mapped_to_correct_dbapi_exception`) to verify that connection, commit, and rollback errors from the C++ layer are mapped to the correct DB-API exceptions, including handling of unknown or missing SQLSTATE codes. (`[tests/test_006_exceptions.pyR193-R257](diffhunk://#diff-16f96f3facfc774c12b49a09116108763139a8a92ceef526fbb4f4f01600c6fdR193-R257)`)

**Dependency update:**

* Imported `sqlstate_to_exception` in `connection.py` to support the new error mapping logic. (`[mssql_python/connection.pyR41](diffhunk://#diff-29bb94de45aae51c23a6426d40133c28e4161e68769e08d046059c7186264e90R41)`)

<!-- 
### PR Title Guide

> For feature requests
FEAT: (short-description)

> For non-feature requests like test case updates, config updates , dependency updates etc
CHORE: (short-description) 

> For Fix requests
FIX: (short-description)

> For doc update requests 
DOC: (short-description)

> For Formatting, indentation, or styling update
STYLE: (short-description)

> For Refactor, without any feature changes
REFACTOR: (short-description)

> For performance improvements
PERF: (short-description)

> For release related changes, without any feature changes
RELEASE: #<RELEASE_VERSION> (short-description) 

### Contribution Guidelines

External contributors:
- Create a GitHub issue first: https://github.com/microsoft/mssql-python/issues/new
- Link the GitHub issue in the "GitHub Issue" section above
- Follow the PR title format and provide a meaningful summary

mssql-python maintainers:
- Create an ADO Work Item following internal processes
- Link the ADO Work Item in the "ADO Work Item" section above  
- Follow the PR title format and provide a meaningful summary
-->