### PR TITLE
FIX: Release GIL around blocking SQLSetConnectAttr calls (#565)

### DIFF
--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -315,9 +315,13 @@ SQLRETURN Connection::setAttribute(SQLINTEGER attribute, py::object value) {
 
             SQLPOINTER ptr;
             SQLINTEGER length;
-            
-            ptr = reinterpretU16stringAsSqlWChar(this->wstrStringBuffer);
-            length = static_cast<SQLINTEGER>(this->wstrStringBuffer.length() * sizeof(SQLWCHAR));
+            // Copy to a stack-local buffer so that releasing the GIL below
+            // doesn't expose a race where another thread overwrites the
+            // member wstrStringBuffer (and reallocates) while the ODBC
+            // driver is still reading from ptr.
+            std::u16string localStrBuffer = this->wstrStringBuffer;
+            ptr = reinterpretU16stringAsSqlWChar(localStrBuffer);
+            length = static_cast<SQLINTEGER>(localStrBuffer.length() * sizeof(SQLWCHAR));
 
             SQLRETURN ret;
             {
@@ -336,11 +340,12 @@ SQLRETURN Connection::setAttribute(SQLINTEGER attribute, py::object value) {
         }
     } else if (py::isinstance<py::bytes>(value) || py::isinstance<py::bytearray>(value)) {
         try {
-            std::string binary_data = value.cast<std::string>();
-            this->strBytesBuffer.clear();
-            this->strBytesBuffer = std::move(binary_data);
-            SQLPOINTER ptr = const_cast<char*>(this->strBytesBuffer.c_str());
-            SQLINTEGER length = static_cast<SQLINTEGER>(this->strBytesBuffer.size());
+            // Copy to a stack-local buffer so that releasing the GIL
+            // doesn't expose a race where another thread overwrites the
+            // member strBytesBuffer while the driver reads from ptr.
+            std::string localBytesBuffer = value.cast<std::string>();
+            SQLPOINTER ptr = const_cast<char*>(localBytesBuffer.c_str());
+            SQLINTEGER length = static_cast<SQLINTEGER>(localBytesBuffer.size());
 
             SQLRETURN ret;
             {

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -211,9 +211,16 @@ void Connection::setAutocommit(bool enable) {
     }
     SQLINTEGER value = enable ? SQL_AUTOCOMMIT_ON : SQL_AUTOCOMMIT_OFF;
     LOG("Setting autocommit=%d", enable);
-    SQLRETURN ret =
-        SQLSetConnectAttr_ptr(_dbcHandle->get(), SQL_ATTR_AUTOCOMMIT,
-                              reinterpret_cast<SQLPOINTER>(static_cast<SQLULEN>(value)), 0);
+    SQLRETURN ret;
+    {
+        // Release the GIL during the blocking ODBC call. Holding the GIL
+        // here can deadlock when the network path goes through another
+        // Python thread (e.g. an in-process SSH tunnel via paramiko +
+        // sshtunnel), since that thread also needs the GIL to run.
+        py::gil_scoped_release release;
+        ret = SQLSetConnectAttr_ptr(_dbcHandle->get(), SQL_ATTR_AUTOCOMMIT,
+                                    reinterpret_cast<SQLPOINTER>(static_cast<SQLULEN>(value)), 0);
+    }
     checkError(ret);
     if (value == SQL_AUTOCOMMIT_ON) {
         LOG("Autocommit enabled");
@@ -286,9 +293,15 @@ SQLRETURN Connection::setAttribute(SQLINTEGER attribute, py::object value) {
         // Get the integer value
         int64_t longValue = value.cast<int64_t>();
 
-        SQLRETURN ret = SQLSetConnectAttr_ptr(
-            _dbcHandle->get(), attribute,
-            reinterpret_cast<SQLPOINTER>(static_cast<SQLULEN>(longValue)), SQL_IS_INTEGER);
+        SQLRETURN ret;
+        {
+            // Release the GIL around the ODBC call for consistency with the
+            // other connection-attribute paths; some attributes can block.
+            py::gil_scoped_release release;
+            ret = SQLSetConnectAttr_ptr(
+                _dbcHandle->get(), attribute,
+                reinterpret_cast<SQLPOINTER>(static_cast<SQLULEN>(longValue)), SQL_IS_INTEGER);
+        }
 
         if (!SQL_SUCCEEDED(ret)) {
             LOG("Failed to set integer attribute=%d, ret=%d", attribute, ret);
@@ -306,7 +319,11 @@ SQLRETURN Connection::setAttribute(SQLINTEGER attribute, py::object value) {
             ptr = reinterpretU16stringAsSqlWChar(this->wstrStringBuffer);
             length = static_cast<SQLINTEGER>(this->wstrStringBuffer.length() * sizeof(SQLWCHAR));
 
-            SQLRETURN ret = SQLSetConnectAttr_ptr(_dbcHandle->get(), attribute, ptr, length);
+            SQLRETURN ret;
+            {
+                py::gil_scoped_release release;
+                ret = SQLSetConnectAttr_ptr(_dbcHandle->get(), attribute, ptr, length);
+            }
             if (!SQL_SUCCEEDED(ret)) {
                 LOG("Failed to set string attribute=%d, ret=%d", attribute, ret);
             } else {
@@ -325,7 +342,11 @@ SQLRETURN Connection::setAttribute(SQLINTEGER attribute, py::object value) {
             SQLPOINTER ptr = const_cast<char*>(this->strBytesBuffer.c_str());
             SQLINTEGER length = static_cast<SQLINTEGER>(this->strBytesBuffer.size());
 
-            SQLRETURN ret = SQLSetConnectAttr_ptr(_dbcHandle->get(), attribute, ptr, length);
+            SQLRETURN ret;
+            {
+                py::gil_scoped_release release;
+                ret = SQLSetConnectAttr_ptr(_dbcHandle->get(), attribute, ptr, length);
+            }
             if (!SQL_SUCCEEDED(ret)) {
                 LOG("Failed to set binary attribute=%d, ret=%d", attribute, ret);
             } else {
@@ -376,8 +397,14 @@ bool Connection::reset() {
         ThrowStdException("Connection handle not allocated");
     }
     LOG("Resetting connection via SQL_ATTR_RESET_CONNECTION");
-    SQLRETURN ret = SQLSetConnectAttr_ptr(_dbcHandle->get(), SQL_ATTR_RESET_CONNECTION,
-                                          (SQLPOINTER)SQL_RESET_CONNECTION_YES, SQL_IS_INTEGER);
+    SQLRETURN ret;
+    {
+        // Release the GIL around the ODBC call for consistency with the
+        // other connection-attribute paths; some attributes can block.
+        py::gil_scoped_release release;
+        ret = SQLSetConnectAttr_ptr(_dbcHandle->get(), SQL_ATTR_RESET_CONNECTION,
+                                    (SQLPOINTER)SQL_RESET_CONNECTION_YES, SQL_IS_INTEGER);
+    }
     if (!SQL_SUCCEEDED(ret)) {
         LOG("Failed to reset connection (ret=%d). Marking as dead.", ret);
         return false;
@@ -387,8 +414,11 @@ bool Connection::reset() {
     // Explicitly reset it to the default (SQL_TXN_READ_COMMITTED) to prevent
     // isolation level settings from leaking between pooled connection usages.
     LOG("Resetting transaction isolation level to READ COMMITTED");
-    ret = SQLSetConnectAttr_ptr(_dbcHandle->get(), SQL_ATTR_TXN_ISOLATION,
-                                (SQLPOINTER)SQL_TXN_READ_COMMITTED, SQL_IS_INTEGER);
+    {
+        py::gil_scoped_release release;
+        ret = SQLSetConnectAttr_ptr(_dbcHandle->get(), SQL_ATTR_TXN_ISOLATION,
+                                    (SQLPOINTER)SQL_TXN_READ_COMMITTED, SQL_IS_INTEGER);
+    }
     if (!SQL_SUCCEEDED(ret)) {
         LOG("Failed to reset transaction isolation level (ret=%d). Marking as dead.", ret);
         return false;

--- a/mssql_python/pybind/connection/connection_pool.cpp
+++ b/mssql_python/pybind/connection/connection_pool.cpp
@@ -17,12 +17,13 @@ std::shared_ptr<Connection> ConnectionPool::acquire(const std::u16string& connSt
     std::vector<std::shared_ptr<Connection>> to_disconnect;
     std::shared_ptr<Connection> valid_conn = nullptr;
     bool needs_connect = false;
+
+    // Phase 1: Prune stale connections (under mutex — no ODBC calls).
     {
         std::lock_guard<std::mutex> lock(_mutex);
         auto now = std::chrono::steady_clock::now();
         size_t before = _pool.size();
 
-        // Phase 1: Remove stale connections, collect for later disconnect
         _pool.erase(std::remove_if(_pool.begin(), _pool.end(),
                                    [&](const std::shared_ptr<Connection>& conn) {
                                        auto idle_time =
@@ -39,39 +40,51 @@ std::shared_ptr<Connection> ConnectionPool::acquire(const std::u16string& connSt
 
         size_t pruned = before - _pool.size();
         _current_size = (_current_size >= pruned) ? (_current_size - pruned) : 0;
+    }
 
-        // Phase 2: Attempt to reuse healthy connections
-        while (!_pool.empty()) {
-            auto conn = _pool.front();
-            _pool.pop_front();
-            if (conn->isAlive()) {
-                if (!conn->reset()) {
-                    to_disconnect.push_back(conn);
-                    --_current_size;
-                    continue;
+    // Phase 2: Pop one candidate at a time and validate it outside the
+    // mutex.  isAlive() and reset() perform ODBC calls that release the
+    // GIL; calling them while holding the mutex would create a mutex/GIL
+    // lock-ordering deadlock when multiple threads acquire concurrently.
+    while (true) {
+        std::shared_ptr<Connection> candidate;
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_pool.empty()) {
+                // No more candidates — try to reserve a slot for a new connection.
+                if (_current_size < _max_size) {
+                    valid_conn = std::make_shared<Connection>(connStr, true);
+                    ++_current_size;
+                    needs_connect = true;
+                } else {
+                    throw std::runtime_error("ConnectionPool::acquire: pool size limit reached");
                 }
-                valid_conn = conn;
                 break;
-            } else {
-                to_disconnect.push_back(conn);
-                --_current_size;
             }
+            candidate = _pool.front();
+            _pool.pop_front();
         }
 
-        // Reserve a slot for a new connection if none reusable.
-        // The actual connect() call happens outside the mutex to avoid
-        // holding the mutex during the blocking ODBC call (which releases
-        // the GIL and could otherwise cause a mutex/GIL deadlock).
-        if (!valid_conn && _current_size < _max_size) {
-            valid_conn = std::make_shared<Connection>(connStr, true);
-            ++_current_size;
-            needs_connect = true;
-        } else if (!valid_conn) {
-            throw std::runtime_error("ConnectionPool::acquire: pool size limit reached");
+        // Validate the candidate outside the mutex.
+        try {
+            if (candidate->isAlive() && candidate->reset()) {
+                valid_conn = candidate;
+                break;
+            }
+        } catch (const std::exception& ex) {
+            LOG("Candidate connection validation failed: %s", ex.what());
+        }
+
+        // Candidate is dead or reset failed — mark for disconnect and
+        // decrement the pool size.
+        to_disconnect.push_back(candidate);
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_current_size > 0) --_current_size;
         }
     }
 
-    // Phase 2.5: Connect the new connection outside the mutex.
+    // Phase 3: Connect the new connection outside the mutex.
     if (needs_connect) {
         try {
             valid_conn->connect(attrs_before);
@@ -85,7 +98,7 @@ std::shared_ptr<Connection> ConnectionPool::acquire(const std::u16string& connSt
         }
     }
 
-    // Phase 3: Disconnect expired/bad connections outside lock
+    // Phase 4: Disconnect expired/bad connections outside lock.
     for (auto& conn : to_disconnect) {
         try {
             conn->disconnect();

--- a/mssql_python/pybind/connection/connection_pool.cpp
+++ b/mssql_python/pybind/connection/connection_pool.cpp
@@ -39,6 +39,10 @@ std::shared_ptr<Connection> ConnectionPool::acquire(const std::u16string& connSt
                     _pool.end());
 
         size_t pruned = before - _pool.size();
+        // Decrement _current_size eagerly so new slots can be reserved while
+        // stale connections are being disconnected (Phase 4).  This means
+        // _current_size tracks *reserved capacity* (pooled + checked-out +
+        // in-flight new), not necessarily live ODBC handles.
         _current_size = (_current_size >= pruned) ? (_current_size - pruned) : 0;
     }
 
@@ -57,6 +61,12 @@ std::shared_ptr<Connection> ConnectionPool::acquire(const std::u16string& connSt
                     ++_current_size;
                     needs_connect = true;
                 } else {
+                    // NOTE: Another thread may be validating a popped candidate
+                    // outside the mutex right now.  If that candidate fails, a
+                    // slot will open up — but we can't wait for it here without
+                    // adding a condition-variable retry loop.  This is an
+                    // acceptable trade-off: transient "pool full" errors under
+                    // heavy contention are rare and callers can retry.
                     throw std::runtime_error("ConnectionPool::acquire: pool size limit reached");
                 }
                 break;

--- a/tests/test_023_ssh_tunnel_gil_release.py
+++ b/tests/test_023_ssh_tunnel_gil_release.py
@@ -213,6 +213,10 @@ def test_connect_through_python_tcp_forwarder_does_not_deadlock():
     env = os.environ.copy()
     env["DB_CONNECTION_STRING"] = base_conn_str
     env["PYTHONUNBUFFERED"] = "1"
+    # Propagate sys.path so the subprocess can find mssql_python even when
+    # the package is only available via pytest's path manipulation or an
+    # editable install rooted in the workspace.
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
 
     proc = subprocess.Popen(
         [sys.executable, __file__],

--- a/tests/test_023_ssh_tunnel_gil_release.py
+++ b/tests/test_023_ssh_tunnel_gil_release.py
@@ -1,0 +1,250 @@
+"""
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+
+Functional regression test for issue #565
+("SSH tunneling fails using paramiko+sshtunnel").
+
+The bug: ``mssql_python.connect()`` hangs indefinitely when the SQL Server
+is reached through an in-process Python TCP forwarder (e.g. ``paramiko`` +
+``sshtunnel``). Right after ``SQLDriverConnect`` returns, the bindings
+call ``SQLSetConnectAttr(SQL_ATTR_AUTOCOMMIT, OFF)`` **while still
+holding the GIL**. That call performs a network round-trip; the
+in-process forwarder thread cannot run (it needs the GIL to call
+``sock.sendall``), so the driver waits forever for a reply that never
+arrives — deadlock.
+
+How this test works
+-------------------
+We can't probe for the deadlock from within the same Python interpreter:
+once the worker thread is stuck inside C code holding the GIL, the
+entire interpreter can no longer execute bytecode, so even an in-process
+watchdog thread is starved. We therefore re-execute *this same file* as
+a subprocess (its ``__main__`` block sets up the forwarder and runs the
+connect) and apply a hard external watchdog (``Popen.communicate(timeout=...)``).
+
+Without the fix the subprocess hangs forever inside
+``Connection.setautocommit`` and is killed by the watchdog. With the fix
+it completes in well under a second.
+
+Linux-only because the issue is specific to non-Windows builds, and to
+keep the functional suite deterministic across developer/CI machines.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import socket
+import subprocess
+import sys
+import threading
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Issue #565 repro is Linux-only in the functional suite",
+)
+
+
+# Generous upper bound: with the fix, connect()+SELECT through the
+# in-process forwarder completes in well under a second locally.
+# Without the fix the subprocess hangs forever, so any small watchdog
+# catches it; we use 30s to absorb slow CI jitter.
+WATCHDOG_SECONDS = 30
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by the test (parsing only) and the subprocess entry point.
+# ---------------------------------------------------------------------------
+
+
+def _parse_server(conn_str: str) -> tuple[str, int] | None:
+    """Extract (host, port) from the Server=... clause of an ODBC conn string."""
+    m = re.search(r"(?i)(?:^|;)\s*Server\s*=\s*([^;]+)", conn_str)
+    if not m:
+        return None
+    raw = m.group(1).strip()
+    if ":" in raw and raw.lower().startswith(("tcp:", "np:", "lpc:")):
+        raw = raw.split(":", 1)[1]
+    if "," in raw:
+        host, port = raw.split(",", 1)
+    elif ":" in raw and raw.count(":") == 1:
+        host, port = raw.split(":", 1)
+    else:
+        host, port = raw, "1433"
+    try:
+        return host.strip(), int(port.strip())
+    except ValueError:
+        return None
+
+
+def _replace_server(conn_str: str, host: str, port: int) -> str:
+    """Return ``conn_str`` with its Server=... clause rewritten to host,port."""
+    return re.sub(
+        r"(?i)(^|;)\s*Server\s*=\s*[^;]+",
+        rf"\1Server={host},{port}",
+        conn_str,
+        count=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Subprocess entry point: in-process Python TCP forwarder + mssql_python
+# connect()+SELECT through it. Only runs when this file is executed as a
+# script (e.g. by the test below). Pytest collection ignores this block.
+# ---------------------------------------------------------------------------
+
+
+def _pipe(src: socket.socket, dst: socket.socket) -> None:
+    """
+    Forward bytes from ``src`` to ``dst`` until EOF.
+
+    The ``dst.sendall(data)`` call below is a bound-method dispatch that
+    requires the GIL. If another thread holds the GIL across a blocking
+    ODBC network call, this loop never makes progress — that is the
+    deadlock condition from issue #565 with paramiko + sshtunnel.
+    """
+    try:
+        while True:
+            data = src.recv(8192)
+            if not data:
+                break
+            dst.sendall(data)
+    except OSError:
+        pass
+    finally:
+        for s in (src, dst):
+            try:
+                s.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                s.close()
+            except OSError:
+                pass
+
+
+def _start_forwarder(target: tuple[str, int]) -> tuple[str, int]:
+    """Start an in-process TCP forwarder; return (bind_host, bind_port)."""
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(8)
+    host, port = listener.getsockname()
+
+    def acceptor() -> None:
+        while True:
+            try:
+                client, _ = listener.accept()
+            except OSError:
+                return
+            try:
+                upstream = socket.create_connection(target, timeout=10)
+            except OSError:
+                client.close()
+                continue
+            threading.Thread(target=_pipe, args=(client, upstream), daemon=True).start()
+            threading.Thread(target=_pipe, args=(upstream, client), daemon=True).start()
+
+    threading.Thread(target=acceptor, daemon=True).start()
+    return host, port
+
+
+def _run_forwarded_connect_subprocess() -> int:
+    """Body of the subprocess: connect through the forwarder and SELECT 1."""
+    import mssql_python
+    from mssql_python import connect
+
+    base = os.environ["DB_CONNECTION_STRING"]
+    target = _parse_server(base)
+    if target is None:
+        print("ERR: could not parse Server=... clause", file=sys.stderr)
+        return 2
+
+    fwd_host, fwd_port = _start_forwarder(target)
+
+    # Disable client-side pooling so we always exercise a fresh
+    # SQLDriverConnect + SQLSetConnectAttr(AUTOCOMMIT) sequence — the
+    # latter is the call that hangs in the unfixed binary.
+    mssql_python.pooling(enabled=False)
+
+    tunneled = _replace_server(base, fwd_host, fwd_port)
+
+    conn = connect(tunneled)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT 1")
+            row = cur.fetchone()
+        finally:
+            cur.close()
+    finally:
+        conn.close()
+
+    print(f"OK {tuple(row) if row is not None else None}", flush=True)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# The actual pytest test.
+# ---------------------------------------------------------------------------
+
+
+def test_connect_through_python_tcp_forwarder_does_not_deadlock():
+    """
+    Regression test for issue #565.
+
+    Routes ``mssql_python.connect()`` through a pure-Python TCP forwarder
+    in a subprocess and applies a hard watchdog. Before the
+    connection-attribute GIL-release fix, the subprocess hangs forever
+    inside ``SQLSetConnectAttr(SQL_ATTR_AUTOCOMMIT, OFF)`` (called by
+    ``Connection.setautocommit`` immediately after ``SQLDriverConnect``
+    returns); with the fix it completes in well under a second.
+    """
+    base_conn_str = os.getenv("DB_CONNECTION_STRING")
+    if not base_conn_str:
+        pytest.skip("DB_CONNECTION_STRING environment variable not set")
+
+    if _parse_server(base_conn_str) is None:
+        pytest.skip("Could not parse Server=host,port from DB_CONNECTION_STRING")
+
+    env = os.environ.copy()
+    env["DB_CONNECTION_STRING"] = base_conn_str
+    env["PYTHONUNBUFFERED"] = "1"
+
+    proc = subprocess.Popen(
+        [sys.executable, __file__],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        out, err = proc.communicate(timeout=WATCHDOG_SECONDS)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.communicate()
+        pytest.fail(
+            f"connect()+SELECT through in-process Python TCP forwarder did "
+            f"not complete within {WATCHDOG_SECONDS}s — this is the issue "
+            f"#565 deadlock (GIL held across SQLSetConnectAttr_AUTOCOMMIT)."
+        )
+
+    assert proc.returncode == 0, (
+        f"Subprocess exited with {proc.returncode}.\n"
+        f"stdout:\n{out.decode(errors='replace')}\n"
+        f"stderr:\n{err.decode(errors='replace')}"
+    )
+    assert b"OK (1,)" in out, (
+        f"Unexpected subprocess output.\n"
+        f"stdout:\n{out.decode(errors='replace')}\n"
+        f"stderr:\n{err.decode(errors='replace')}"
+    )
+
+
+# Subprocess entry point: when this file is run as a script (by the test
+# above), execute the forwarded-connect body. Pytest collection ignores
+# this block.
+if __name__ == "__main__":
+    sys.exit(_run_forwarded_connect_subprocess())

--- a/tests/test_023_ssh_tunnel_gil_release.py
+++ b/tests/test_023_ssh_tunnel_gil_release.py
@@ -219,7 +219,7 @@ def test_connect_through_python_tcp_forwarder_does_not_deadlock():
     env["PYTHONPATH"] = os.pathsep.join(sys.path)
 
     proc = subprocess.Popen(
-        [sys.executable, __file__],
+        [sys.executable, os.path.abspath(__file__)],
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
### Work Item / Issue Reference

> GitHub Issue: #565

-------------------------------------------------------------------
### Summary

Fixes the indefinite hang of `mssql_python.connect()` when the target server is reached through an in-process SSH tunnel created with `paramiko` + `sshtunnel` (issue #565, originally reported as #491).

**Root cause**

PR #541 released the GIL around `SQLDriverConnect`, `SQLDisconnect`, and `SQLEndTran`, but a handful of `SQLSetConnectAttr` call sites in `mssql_python/pybind/connection/connection.cpp` were left holding the GIL:

- `Connection::setAutocommit` — `SQL_ATTR_AUTOCOMMIT`. This is the call that hangs in the issue's repro: it runs by default immediately after every `connect()`.
- `Connection::setAttribute` (int / wide-string / bytes paths) — user-facing `set_attr()`.
- `Connection::reset` — `SQL_ATTR_RESET_CONNECTION` and `SQL_ATTR_TXN_ISOLATION`, called by the connection pool on acquire.

When the GIL is held during a call that ends up doing blocking work, paramiko's transport thread cannot run and so cannot forward bytes through the SSH channel — the driver waits forever for a response that never comes. `pyodbc` does not exhibit this because it releases the GIL around its blocking ODBC calls.

**Fix**

Wrap each of these call sites in `py::gil_scoped_release`, matching the pattern PR #541 already established for `SQLDriverConnect` / `SQLEndTran`. Local-only attribute reads (`SQLGetConnectAttr` for `SQL_ATTR_CONNECTION_DEAD` / `SQL_ATTR_AUTOCOMMIT`, `SQLGetInfo`, `SQLAllocHandle`) are intentionally left alone.

**Additional fix: Connection pool mutex/GIL deadlock**

The initial GIL-release change in `Connection::reset()` introduced a secondary deadlock in `ConnectionPool::acquire()`. The pool's `acquire()` method called `conn->isAlive()` and `conn->reset()` **while holding the pool `_mutex`**. With `reset()` now releasing the GIL internally, this created a classic ABBA lock-ordering inversion:

| Thread A | Thread B |
|----------|----------|
| Holds `_mutex`, calls `reset()` | Holds GIL, waiting on `_mutex` |
| `reset()` releases GIL, ODBC call | Gets nothing (blocked on mutex) |
| ODBC returns, tries to reacquire GIL — **blocked** | Still blocked on `_mutex` |
| **Deadlock:** holds mutex, needs GIL | **Deadlock:** holds GIL, needs mutex |

The fix restructures `ConnectionPool::acquire()` to pop one candidate connection from the pool under the mutex, then validate it (`isAlive()` + `reset()`) **outside** the mutex. This follows the same pattern already established in the pool for `connect()` (Phase 2.5) and `disconnect()` (Phase 3/4), where blocking ODBC calls that release the GIL are performed without holding the pool lock.

**Why this is safe:**

1. **No data races on `_pool`:** The candidate is popped from the deque atomically under the mutex before any validation. No other thread can access the same connection object.
2. **`_current_size` stays accurate:** Stale connections are decremented during pruning (Phase 1). Failed candidates are decremented individually after validation. New connections increment the count under the mutex before `connect()` is called.
3. **Pool size limit is respected:** The "reserve a new slot" check (`_current_size < _max_size`) still happens under the mutex, after confirming no viable candidates remain.
4. **Exception safety:** If `isAlive()` or `reset()` throws, the connection is caught and treated as dead — it goes to the disconnect list and `_current_size` is decremented.
5. **Single-threaded behavior unchanged:** With one thread, the loop simply pops, validates, and returns — identical to the previous while-loop but without holding the mutex during ODBC calls.

**Verification**

- Reproduced #565 locally with an in-process Python TCP forwarder (simulating paramiko/sshtunnel). Before the GIL-release fix, `mssql_python.connect()` hung indefinitely; after the fix it completes in ~0.3s.
- The pool deadlock was reproduced by returning connections to the pool and having 2+ threads call `connect()` concurrently — this hung indefinitely before the pool fix and completes instantly after.
- Full test suite: **1707 passed, 64 skipped, 0 failures** (~2 minutes).

**Diff:** 2 files changed — `connection.cpp` (+42/-12 GIL release) and `connection_pool.cpp` (+39/-26 mutex restructure).
