### PR TITLE
FIX: Flaky tests in CI and mark stress tests

### DIFF
--- a/eng/pipelines/pr-validation-pipeline.yml
+++ b/eng/pipelines/pr-validation-pipeline.yml
@@ -621,6 +621,7 @@ jobs:
       python benchmarks/perf-benchmarking.py --baseline benchmark_baseline.json --json benchmark_results.json
     displayName: 'Run performance benchmarks on macOS $(sqlVersion)'
     condition: or(eq(variables['sqlVersion'], 'SQL2022'), eq(variables['sqlVersion'], 'SQL2025'))
+    timeoutInMinutes: 20
     continueOnError: true
     env:
       DB_CONNECTION_STRING: 'Server=tcp:127.0.0.1,1433;Database=AdventureWorks2022;Uid=SA;Pwd=$(DB_PASSWORD);TrustServerCertificate=yes'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,25 @@ from mssql_python import connect
 import time
 
 
+def is_qemu_emulated():
+    """Detect if running under QEMU user-mode emulation (e.g. ARM64 on x86_64 host).
+
+    QEMU reports CPU implementer 0x51 in /proc/cpuinfo. Native ARM64 hardware
+    uses vendor-specific IDs (0x41 ARM, 0x61 Apple, etc.).
+    """
+    try:
+        with open("/proc/cpuinfo") as f:
+            for line in f:
+                if line.startswith("CPU implementer") and "0x51" in line:
+                    return True
+    except (FileNotFoundError, PermissionError):
+        pass
+    return False
+
+
+QEMU = is_qemu_emulated()
+
+
 def is_azure_sql_connection(conn_str):
     """Helper function to detect if connection string is for Azure SQL Database"""
     if not conn_str:

--- a/tests/test_013_SqlHandle_free_shutdown.py
+++ b/tests/test_013_SqlHandle_free_shutdown.py
@@ -26,6 +26,7 @@ Test Strategy:
 """
 
 import os
+import platform
 import subprocess
 import sys
 import textwrap
@@ -33,6 +34,21 @@ import threading
 import time
 
 import pytest
+
+
+def _is_qemu_emulated():
+    """Detect if running under QEMU user-mode emulation (e.g. ARM64 on x86_64 host)."""
+    try:
+        with open("/proc/cpuinfo") as f:
+            for line in f:
+                if line.startswith("CPU implementer") and "0x51" in line:
+                    return True
+    except (FileNotFoundError, PermissionError):
+        pass
+    return False
+
+
+_QEMU = _is_qemu_emulated()
 
 
 class TestHandleFreeShutdown:
@@ -255,6 +271,7 @@ class TestHandleFreeShutdown:
         assert "Query result: [(1,)]" in result.stdout
         print(f"PASS: STMT handle (Type 3) cleanup during shutdown")
 
+    @pytest.mark.skipif(_QEMU, reason="SIGSEGV under QEMU user-mode emulation — not reproducible on native ARM64")
     def test_dbc_handle_cleanup_at_shutdown(self, conn_str):
         """
         Test DBC handle (Type 2) cleanup during Python shutdown.
@@ -510,6 +527,7 @@ class TestHandleFreeShutdown:
         assert "Exception test: Exiting after exception without cleanup" in result.stdout
         print(f"PASS: Exception during query with shutdown")
 
+    @pytest.mark.skipif(_QEMU, reason="SIGSEGV under QEMU user-mode emulation — not reproducible on native ARM64")
     def test_weakref_cleanup_at_shutdown(self, conn_str):
         """
         Test handle cleanup when using weakrefs during shutdown.
@@ -912,6 +930,7 @@ class TestHandleFreeShutdown:
             ),
         ],
     )
+    @pytest.mark.skipif(_QEMU, reason="Flaky under QEMU user-mode emulation")
     def test_cleanup_connections_scenarios(self, conn_str, scenario, test_code, expected_msg):
         """
         Test _cleanup_connections() with various scenarios.
@@ -940,7 +959,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=3
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         assert result.returncode == 0, f"Test failed. stderr: {result.stderr}"
@@ -1126,7 +1145,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=3
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         assert result.returncode == 0, f"Test failed. stderr: {result.stderr}"
@@ -1136,6 +1155,7 @@ class TestHandleFreeShutdown:
         )
         print(f"PASS: Cleanup connections list copy isolation")
 
+    @pytest.mark.skipif(_QEMU, reason="Flaky under QEMU user-mode emulation")
     def test_cleanup_connections_weakset_modification_during_iteration(self, conn_str):
         """
         Test that list copy prevents RuntimeError when WeakSet is modified during iteration.
@@ -1216,7 +1236,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=3
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         assert result.returncode == 0, f"Test failed. stderr: {result.stderr}"

--- a/tests/test_013_SqlHandle_free_shutdown.py
+++ b/tests/test_013_SqlHandle_free_shutdown.py
@@ -257,7 +257,9 @@ class TestHandleFreeShutdown:
         assert "Query result: [(1,)]" in result.stdout
         print(f"PASS: STMT handle (Type 3) cleanup during shutdown")
 
-    @pytest.mark.skipif(QEMU, reason="SIGSEGV under QEMU user-mode emulation — not reproducible on native ARM64")
+    @pytest.mark.skipif(
+        QEMU, reason="SIGSEGV under QEMU user-mode emulation — not reproducible on native ARM64"
+    )
     def test_dbc_handle_cleanup_at_shutdown(self, conn_str):
         """
         Test DBC handle (Type 2) cleanup during Python shutdown.
@@ -513,7 +515,9 @@ class TestHandleFreeShutdown:
         assert "Exception test: Exiting after exception without cleanup" in result.stdout
         print(f"PASS: Exception during query with shutdown")
 
-    @pytest.mark.skipif(QEMU, reason="SIGSEGV under QEMU user-mode emulation — not reproducible on native ARM64")
+    @pytest.mark.skipif(
+        QEMU, reason="SIGSEGV under QEMU user-mode emulation — not reproducible on native ARM64"
+    )
     def test_weakref_cleanup_at_shutdown(self, conn_str):
         """
         Test handle cleanup when using weakrefs during shutdown.

--- a/tests/test_013_SqlHandle_free_shutdown.py
+++ b/tests/test_013_SqlHandle_free_shutdown.py
@@ -37,6 +37,10 @@ import pytest
 from conftest import QEMU
 
 
+@pytest.mark.skipif(
+    QEMU,
+    reason="Subprocess shutdown tests SIGSEGV under QEMU user-mode emulation — not reproducible on native ARM64",
+)
 class TestHandleFreeShutdown:
     """Test SqlHandle::free() behavior for all handle types during Python shutdown."""
 
@@ -257,9 +261,6 @@ class TestHandleFreeShutdown:
         assert "Query result: [(1,)]" in result.stdout
         print(f"PASS: STMT handle (Type 3) cleanup during shutdown")
 
-    @pytest.mark.skipif(
-        QEMU, reason="SIGSEGV under QEMU user-mode emulation — not reproducible on native ARM64"
-    )
     def test_dbc_handle_cleanup_at_shutdown(self, conn_str):
         """
         Test DBC handle (Type 2) cleanup during Python shutdown.
@@ -515,9 +516,6 @@ class TestHandleFreeShutdown:
         assert "Exception test: Exiting after exception without cleanup" in result.stdout
         print(f"PASS: Exception during query with shutdown")
 
-    @pytest.mark.skipif(
-        QEMU, reason="SIGSEGV under QEMU user-mode emulation — not reproducible on native ARM64"
-    )
     def test_weakref_cleanup_at_shutdown(self, conn_str):
         """
         Test handle cleanup when using weakrefs during shutdown.
@@ -920,7 +918,6 @@ class TestHandleFreeShutdown:
             ),
         ],
     )
-    @pytest.mark.skipif(QEMU, reason="Flaky under QEMU user-mode emulation")
     def test_cleanup_connections_scenarios(self, conn_str, scenario, test_code, expected_msg):
         """
         Test _cleanup_connections() with various scenarios.
@@ -1145,7 +1142,6 @@ class TestHandleFreeShutdown:
         )
         print(f"PASS: Cleanup connections list copy isolation")
 
-    @pytest.mark.skipif(QEMU, reason="Flaky under QEMU user-mode emulation")
     def test_cleanup_connections_weakset_modification_during_iteration(self, conn_str):
         """
         Test that list copy prevents RuntimeError when WeakSet is modified during iteration.

--- a/tests/test_013_SqlHandle_free_shutdown.py
+++ b/tests/test_013_SqlHandle_free_shutdown.py
@@ -85,7 +85,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=5
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         # Check for segfault
@@ -141,7 +141,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=5
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         if result.returncode < 0:
@@ -205,7 +205,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=5
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         if result.returncode < 0:
@@ -247,7 +247,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=5
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         assert result.returncode == 0, f"Process crashed. stderr: {result.stderr}"
@@ -290,7 +290,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=5
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         assert result.returncode == 0, f"Process crashed. stderr: {result.stderr}"
@@ -338,7 +338,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=5
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         assert result.returncode == 0, f"Process crashed. stderr: {result.stderr}"
@@ -410,7 +410,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=5
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         assert result.returncode == 0, f"Process crashed. stderr: {result.stderr}"
@@ -463,7 +463,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=5
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         assert result.returncode == 0, f"Process crashed. stderr: {result.stderr}"
@@ -502,7 +502,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=5
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         assert result.returncode == 0, f"Process crashed. stderr: {result.stderr}"
@@ -555,7 +555,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=5
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         assert result.returncode == 0, f"Process crashed. stderr: {result.stderr}"
@@ -613,7 +613,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=5
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         assert result.returncode == 0, f"Process crashed. stderr: {result.stderr}"
@@ -685,7 +685,7 @@ class TestHandleFreeShutdown:
         """)
 
         result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=5
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=15
         )
 
         assert result.returncode == 0, f"Process crashed. stderr: {result.stderr}"

--- a/tests/test_013_SqlHandle_free_shutdown.py
+++ b/tests/test_013_SqlHandle_free_shutdown.py
@@ -26,7 +26,6 @@ Test Strategy:
 """
 
 import os
-import platform
 import subprocess
 import sys
 import textwrap
@@ -35,20 +34,7 @@ import time
 
 import pytest
 
-
-def _is_qemu_emulated():
-    """Detect if running under QEMU user-mode emulation (e.g. ARM64 on x86_64 host)."""
-    try:
-        with open("/proc/cpuinfo") as f:
-            for line in f:
-                if line.startswith("CPU implementer") and "0x51" in line:
-                    return True
-    except (FileNotFoundError, PermissionError):
-        pass
-    return False
-
-
-_QEMU = _is_qemu_emulated()
+from conftest import QEMU
 
 
 class TestHandleFreeShutdown:
@@ -271,7 +257,7 @@ class TestHandleFreeShutdown:
         assert "Query result: [(1,)]" in result.stdout
         print(f"PASS: STMT handle (Type 3) cleanup during shutdown")
 
-    @pytest.mark.skipif(_QEMU, reason="SIGSEGV under QEMU user-mode emulation — not reproducible on native ARM64")
+    @pytest.mark.skipif(QEMU, reason="SIGSEGV under QEMU user-mode emulation — not reproducible on native ARM64")
     def test_dbc_handle_cleanup_at_shutdown(self, conn_str):
         """
         Test DBC handle (Type 2) cleanup during Python shutdown.
@@ -527,7 +513,7 @@ class TestHandleFreeShutdown:
         assert "Exception test: Exiting after exception without cleanup" in result.stdout
         print(f"PASS: Exception during query with shutdown")
 
-    @pytest.mark.skipif(_QEMU, reason="SIGSEGV under QEMU user-mode emulation — not reproducible on native ARM64")
+    @pytest.mark.skipif(QEMU, reason="SIGSEGV under QEMU user-mode emulation — not reproducible on native ARM64")
     def test_weakref_cleanup_at_shutdown(self, conn_str):
         """
         Test handle cleanup when using weakrefs during shutdown.
@@ -930,7 +916,7 @@ class TestHandleFreeShutdown:
             ),
         ],
     )
-    @pytest.mark.skipif(_QEMU, reason="Flaky under QEMU user-mode emulation")
+    @pytest.mark.skipif(QEMU, reason="Flaky under QEMU user-mode emulation")
     def test_cleanup_connections_scenarios(self, conn_str, scenario, test_code, expected_msg):
         """
         Test _cleanup_connections() with various scenarios.
@@ -1155,7 +1141,7 @@ class TestHandleFreeShutdown:
         )
         print(f"PASS: Cleanup connections list copy isolation")
 
-    @pytest.mark.skipif(_QEMU, reason="Flaky under QEMU user-mode emulation")
+    @pytest.mark.skipif(QEMU, reason="Flaky under QEMU user-mode emulation")
     def test_cleanup_connections_weakset_modification_during_iteration(self, conn_str):
         """
         Test that list copy prevents RuntimeError when WeakSet is modified during iteration.

--- a/tests/test_022_concurrent_query_gil_release.py
+++ b/tests/test_022_concurrent_query_gil_release.py
@@ -7,8 +7,9 @@ release added in PR #541 (covering ``SQLExecute`` / ``SQLExecDirect`` /
 ``SQLFetch`` / ``SQLEndTran`` in ``mssql_python/pybind/ddbc_bindings.cpp``
 and ``mssql_python/pybind/connection/connection.cpp``).
 
-These tests assert a binary correctness property (the GIL must be released
-around blocking ODBC calls) using a heartbeat-tick threshold:
+These are **not** performance/stress tests — they assert a binary
+correctness property (the GIL must be released around blocking ODBC calls)
+using a conservative threshold that doesn't depend on hardware speed:
 
 * with the GIL released, a Python heartbeat thread keeps ticking while
   another thread sits in ``cursor.execute("WAITFOR DELAY '00:00:02'")``
@@ -16,11 +17,15 @@ around blocking ODBC calls) using a heartbeat-tick threshold:
 * same property holds across an explicit ``commit()`` (covers the
   ``SQLEndTran`` GIL-release path).
 
-Marked ``@pytest.mark.stress`` because the tick-count thresholds are
-sensitive to CI runner scheduling and ``time.sleep()`` precision — they
-flake on macOS (especially pre-release Python builds) while reliably
-passing on developer machines. The nightly stress-test-pipeline runs
-these; they are excluded from PR validation via ``pytest.ini`` addopts.
+The threshold is set at 15% of theoretical max ticks — low enough to
+survive CI runner CPU contention (worst observed: 30%) while still
+catching real GIL starvation (which yields 0-2 ticks vs threshold of 6).
+
+A wall-clock "N threads finish in ~one WAITFOR worth of time" assertion
+was deliberately *not* added here — it depends on the SQL Server
+scheduler/container CPU allocation and is too flaky for the functional
+suite. That style of test lives in ``test_021_concurrent_connection_perf.py``
+under ``@pytest.mark.stress``.
 """
 
 import os
@@ -65,7 +70,6 @@ def _run_waitfor(conn_str: str) -> float:
 # ============================================================================
 
 
-@pytest.mark.stress
 def test_query_does_not_block_other_python_threads(conn_str):
     """
     While one thread executes a 2-second ``WAITFOR DELAY``, a second pure-Python
@@ -75,7 +79,9 @@ def test_query_does_not_block_other_python_threads(conn_str):
     mssql_python.pooling(enabled=False)
 
     heartbeat_interval = 0.05  # 50ms ticks
-    expected_min_ticks = int(WAITFOR_SECONDS / heartbeat_interval * 0.5)  # 50% of theoretical max
+    # 15% of theoretical max: low enough to survive CI CPU contention (worst
+    # observed was 12 ticks ≈ 30%) but well above real GIL starvation (0-2 ticks).
+    expected_min_ticks = int(WAITFOR_SECONDS / heartbeat_interval * 0.15)
 
     stop_event = threading.Event()
     tick_count = [0]
@@ -130,7 +136,6 @@ def test_query_does_not_block_other_python_threads(conn_str):
 # ============================================================================
 
 
-@pytest.mark.stress
 def test_commit_does_not_block_other_python_threads(conn_str):
     """
     Smoke test for the SQLEndTran GIL-release added to ``Connection::commit``
@@ -193,10 +198,9 @@ def test_commit_does_not_block_other_python_threads(conn_str):
     assert not txn_error, f"Transaction thread error: {txn_error}"
 
     ticks_during = ticks_after - ticks_before
-    # 40% of theoretical max gives margin against macOS CI scheduler noise
-    # (sleep(0.05) overshoot + GIL re-acquisition latency) while still
-    # catching real GIL starvation, which would yield <= ~2 ticks.
-    expected_min_ticks = int(WAITFOR_SECONDS / heartbeat_interval * 0.4)
+    # 15% of theoretical max: survives CI CPU contention while still catching
+    # real GIL starvation (which yields 0-2 ticks vs threshold of 6).
+    expected_min_ticks = int(WAITFOR_SECONDS / heartbeat_interval * 0.15)
     print(
         f"\n[HEARTBEAT] ticks during WAITFOR+commit: {ticks_during} "
         f"(expected >= {expected_min_ticks})"

--- a/tests/test_022_concurrent_query_gil_release.py
+++ b/tests/test_022_concurrent_query_gil_release.py
@@ -17,15 +17,15 @@ using a conservative threshold that doesn't depend on hardware speed:
 * same property holds across an explicit ``commit()`` (covers the
   ``SQLEndTran`` GIL-release path).
 
-The threshold is set at 15% of theoretical max ticks — low enough to
-survive CI runner CPU contention (worst observed: 30%) while still
-catching real GIL starvation (which yields 0-2 ticks vs threshold of 6).
-
 A wall-clock "N threads finish in ~one WAITFOR worth of time" assertion
 was deliberately *not* added here — it depends on the SQL Server
 scheduler/container CPU allocation and is too flaky for the functional
 suite. That style of test lives in ``test_021_concurrent_connection_perf.py``
 under ``@pytest.mark.stress``.
+
+A 2-second server-side WAITFOR is short enough to keep these in the
+default functional suite (~5s total) while still producing an unambiguous
+signal that survives normal CI jitter.
 """
 
 import os
@@ -70,6 +70,7 @@ def _run_waitfor(conn_str: str) -> float:
 # ============================================================================
 
 
+@pytest.mark.stress  # Heartbeat tick counts flake under CI CPU contention (macOS Py3.14)
 def test_query_does_not_block_other_python_threads(conn_str):
     """
     While one thread executes a 2-second ``WAITFOR DELAY``, a second pure-Python
@@ -79,9 +80,7 @@ def test_query_does_not_block_other_python_threads(conn_str):
     mssql_python.pooling(enabled=False)
 
     heartbeat_interval = 0.05  # 50ms ticks
-    # 15% of theoretical max: low enough to survive CI CPU contention (worst
-    # observed was 12 ticks ≈ 30%) but well above real GIL starvation (0-2 ticks).
-    expected_min_ticks = int(WAITFOR_SECONDS / heartbeat_interval * 0.15)
+    expected_min_ticks = int(WAITFOR_SECONDS / heartbeat_interval * 0.5)  # 50% of theoretical max
 
     stop_event = threading.Event()
     tick_count = [0]
@@ -136,6 +135,7 @@ def test_query_does_not_block_other_python_threads(conn_str):
 # ============================================================================
 
 
+@pytest.mark.stress  # Heartbeat tick counts flake under CI CPU contention (macOS Py3.14)
 def test_commit_does_not_block_other_python_threads(conn_str):
     """
     Smoke test for the SQLEndTran GIL-release added to ``Connection::commit``
@@ -198,9 +198,10 @@ def test_commit_does_not_block_other_python_threads(conn_str):
     assert not txn_error, f"Transaction thread error: {txn_error}"
 
     ticks_during = ticks_after - ticks_before
-    # 15% of theoretical max: survives CI CPU contention while still catching
-    # real GIL starvation (which yields 0-2 ticks vs threshold of 6).
-    expected_min_ticks = int(WAITFOR_SECONDS / heartbeat_interval * 0.15)
+    # 40% of theoretical max gives margin against macOS CI scheduler noise
+    # (sleep(0.05) overshoot + GIL re-acquisition latency) while still
+    # catching real GIL starvation, which would yield <= ~2 ticks.
+    expected_min_ticks = int(WAITFOR_SECONDS / heartbeat_interval * 0.4)
     print(
         f"\n[HEARTBEAT] ticks during WAITFOR+commit: {ticks_during} "
         f"(expected >= {expected_min_ticks})"

--- a/tests/test_022_concurrent_query_gil_release.py
+++ b/tests/test_022_concurrent_query_gil_release.py
@@ -7,9 +7,8 @@ release added in PR #541 (covering ``SQLExecute`` / ``SQLExecDirect`` /
 ``SQLFetch`` / ``SQLEndTran`` in ``mssql_python/pybind/ddbc_bindings.cpp``
 and ``mssql_python/pybind/connection/connection.cpp``).
 
-These are **not** performance/stress tests — they assert a binary
-correctness property (the GIL must be released around blocking ODBC calls)
-using a conservative threshold that doesn't depend on hardware speed:
+These tests assert a binary correctness property (the GIL must be released
+around blocking ODBC calls) using a heartbeat-tick threshold:
 
 * with the GIL released, a Python heartbeat thread keeps ticking while
   another thread sits in ``cursor.execute("WAITFOR DELAY '00:00:02'")``
@@ -17,15 +16,11 @@ using a conservative threshold that doesn't depend on hardware speed:
 * same property holds across an explicit ``commit()`` (covers the
   ``SQLEndTran`` GIL-release path).
 
-A wall-clock "N threads finish in ~one WAITFOR worth of time" assertion
-was deliberately *not* added here — it depends on the SQL Server
-scheduler/container CPU allocation and is too flaky for the functional
-suite. That style of test lives in ``test_021_concurrent_connection_perf.py``
-under ``@pytest.mark.stress``.
-
-A 2-second server-side WAITFOR is short enough to keep these in the
-default functional suite (~5s total) while still producing an unambiguous
-signal that survives normal CI jitter.
+Marked ``@pytest.mark.stress`` because the tick-count thresholds are
+sensitive to CI runner scheduling and ``time.sleep()`` precision — they
+flake on macOS (especially pre-release Python builds) while reliably
+passing on developer machines. The nightly stress-test-pipeline runs
+these; they are excluded from PR validation via ``pytest.ini`` addopts.
 """
 
 import os
@@ -70,6 +65,7 @@ def _run_waitfor(conn_str: str) -> float:
 # ============================================================================
 
 
+@pytest.mark.stress
 def test_query_does_not_block_other_python_threads(conn_str):
     """
     While one thread executes a 2-second ``WAITFOR DELAY``, a second pure-Python
@@ -134,6 +130,7 @@ def test_query_does_not_block_other_python_threads(conn_str):
 # ============================================================================
 
 
+@pytest.mark.stress
 def test_commit_does_not_block_other_python_threads(conn_str):
     """
     Smoke test for the SQLEndTran GIL-release added to ``Connection::commit``


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below 
For external contributors: Insert Github Issue number below
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> [AB#45424](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/45424)

<!-- External contributors: GitHub Issue -->
> GitHub Issue: 

-------------------------------------------------------------------

### Summary

Fix all known flaky test failures in PR validation. Audited 30 recent builds — 12 had failures, all from 2 test files on macOS or ARM64 QEMU. Also cap macOS benchmark step to prevent job timeouts.

---

### Audit (30 PR validation builds)

#### test_022 — GIL heartbeat (8/30 builds, macOS only)

| Test | Hits | Cause |
|------|------|-------|
| `test_query_does_not_block_other_python_threads` | 5/30 | Heartbeat tick threshold too aggressive for CI CPU contention |
| `test_commit_does_not_block_other_python_threads` | 3/30 | Same |

#### test_013 — shutdown handle cleanup (7/30 builds, macOS + QEMU)

| Test | Hits | Cause |
|------|------|-------|
| `test_dbc_handle_cleanup_at_shutdown` | 2/30 | macOS timeout + QEMU SEGV |
| `test_force_gc_finalization_order_issue` | 2/30 | macOS timeout |
| `test_aggressive_dbc_segfault_reproduction` | 1/30 | macOS timeout |
| `test_cleanup_connections_weakset_modification_during_iteration` | 1/30 | macOS timeout |
| `test_weakref_cleanup_at_shutdown` | 1/30 | QEMU SEGV |
| `test_cleanup_connections_scenarios` | 1/30 | QEMU |
| `test_exception_during_query_with_shutdown` | 1/30 | QEMU SEGV (found during this PR) |

#### macOS benchmark timeout (2/30 builds)

Benchmark step had no timeout. On macOS, it takes 10–28 min (vs 3 min Linux, 5 min Windows). Slow runs eat the 60 min job budget and kill the entire job.

---

### Changes

#### `tests/test_022_concurrent_query_gil_release.py`

- Mark both heartbeat tests with `@pytest.mark.stress`
- Excluded from PR validation by `pytest.ini` addopts; runs in nightly stress pipeline

#### `tests/test_013_SqlHandle_free_shutdown.py`

- Bump subprocess timeout from 5s/3s to 15s on all ODBC shutdown tests (fixes macOS TimeoutExpired)
- Skip entire `TestHandleFreeShutdown` class on QEMU (verified 0/400 on native ARM64 — all subprocess shutdown tests can SEGV under QEMU user-mode emulation)

#### `tests/conftest.py`

- Add shared `is_qemu_emulated()` helper and `QEMU` flag for reuse across test files

#### `eng/pipelines/pr-validation-pipeline.yml`

- Add `timeoutInMinutes: 20` on macOS benchmark step with `continueOnError: true`
- Slow benchmarks are terminated gracefully without failing the build

---

### What this does NOT change

- No test logic or C++ changes
- All tests run on every native platform (Linux x86, Windows, macOS, native ARM64)
- Benchmark script unchanged — macOS benchmark variance (2.7x) is a separate investigation

---

### Benchmark duration analysis (13 builds)

| Platform | Range | Variance |
|----------|-------|----------|
| Linux Ubuntu | 3m06s – 3m24s | 1.1x |
| Windows | 4m35s – 6m12s | 1.3x |
| macOS | 10m28s – 28m39s | 2.7x |

---

### Additional findings (not in this PR)

- `is_python_finalizing()` in `ddbc_bindings.cpp` checks `sys._is_finalizing` which was renamed to `sys.is_finalizing` in Python 3.13+. Shutdown protection silently degrades on 3.13+, but `atexit` cleanup saves us. Separate fix needed.
- macOS benchmark variance needs deeper investigation (runner contention vs code issue).
