### PR TITLE
FIX: Handle Row objects in executemany DAE fallback path (GH-629)

### DIFF
--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -2413,6 +2413,11 @@ class Cursor:  # pylint: disable=too-many-instance-attributes,too-many-public-me
                 "DAE parameters detected. Falling back to row-by-row execution with streaming.",
             )
             for row in seq_of_parameters:
+                # Convert Row objects to tuples for compatibility with execute()
+                # Row objects from fetch APIs must be converted since _map_sql_type
+                # only recognizes primitive types (str, int, etc.), not Row objects
+                if hasattr(row, "_values") and hasattr(row, "__iter__"):
+                    row = tuple(row)
                 self.execute(operation, row)
             return
 

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -1454,6 +1454,12 @@ class Cursor:  # pylint: disable=too-many-instance-attributes,too-many-public-me
             if isinstance(parameters, tuple) and len(parameters) == 1:
                 if isinstance(parameters[0], (tuple, list, dict)):
                     actual_params = parameters[0]
+                elif isinstance(parameters[0], Row):
+                    # A Row (e.g. from fetchone()) is a sequence of column values.
+                    # Normalize it to a tuple so the downstream binding logic, which
+                    # only handles tuple/list/dict, can unwrap it into individual
+                    # parameters instead of treating the whole Row as one value.
+                    actual_params = tuple(parameters[0])
                 else:
                     actual_params = parameters
             else:
@@ -2413,11 +2419,6 @@ class Cursor:  # pylint: disable=too-many-instance-attributes,too-many-public-me
                 "DAE parameters detected. Falling back to row-by-row execution with streaming.",
             )
             for row in seq_of_parameters:
-                # Convert Row objects to tuples so execute() can unwrap them as parameters.
-                # execute() only unwraps tuple/list/dict arguments, not Row objects,
-                # so passing a Row directly would treat it as a single scalar parameter.
-                if isinstance(row, Row):
-                    row = tuple(row)
                 self.execute(operation, row)
             return
 

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -2413,10 +2413,10 @@ class Cursor:  # pylint: disable=too-many-instance-attributes,too-many-public-me
                 "DAE parameters detected. Falling back to row-by-row execution with streaming.",
             )
             for row in seq_of_parameters:
-                # Convert Row objects to tuples for compatibility with execute()
-                # Row objects from fetch APIs must be converted since _map_sql_type
-                # only recognizes primitive types (str, int, etc.), not Row objects
-                if hasattr(row, "_values") and hasattr(row, "__iter__"):
+                # Convert Row objects to tuples so execute() can unwrap them as parameters.
+                # execute() only unwraps tuple/list/dict arguments, not Row objects,
+                # so passing a Row directly would treat it as a single scalar parameter.
+                if isinstance(row, Row):
                     row = tuple(row)
                 self.execute(operation, row)
             return

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -16597,19 +16597,7 @@ def test_executemany_multi_column_with_large_decimal(cursor, db_connection):
 
 
 def test_executemany_row_objects_with_varchar_max_dae(cursor, db_connection):
-    """Test executemany with Row objects from fetchmany() and VARCHAR(MAX) DAE fallback (GH-629).
-
-    When executemany() detects DAE parameters (large strings >4000 chars for VARCHAR(MAX)),
-    it falls back to row-by-row execution. This fallback must handle Row objects returned
-    by fetch APIs (fetchone/fetchmany/fetchall) by converting them to tuples before
-    passing to execute().
-
-    Without the GH-629 fix, this scenario raises:
-        TypeError: Unsupported parameter type: The driver cannot safely convert it to a SQL type.
-
-    This regression test ensures Row objects from fetch APIs can be passed directly to
-    executemany() even when DAE fallback is triggered.
-    """
+    """Test executemany with Row objects and VARCHAR(MAX) DAE fallback (GH-629)."""
     try:
         # Create source table with VARCHAR(MAX) column
         cursor.execute("""

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -16645,3 +16645,65 @@ def test_executemany_row_objects_with_varchar_max_dae(cursor, db_connection):
         cursor.execute("DROP TABLE IF EXISTS #pytest_gh629_source")
         cursor.execute("DROP TABLE IF EXISTS #pytest_gh629_target")
         db_connection.commit()
+
+
+def test_execute_with_row_object_as_parameters(cursor, db_connection):
+    """Test execute(sql, row) directly with a Row object as parameters (GH-629).
+
+    The fix for GH-629 lives in execute()'s single-argument unwrap: a Row
+    (e.g. from fetchone()) must be unwrapped into individual parameters
+    instead of being treated as one scalar value. This guards that surface
+    directly so a future refactor of the unwrap logic can't silently re-break it.
+    """
+    try:
+        cursor.execute("""
+            CREATE TABLE #pytest_gh629_exec_source (
+                id INT,
+                name VARCHAR(50),
+                large_text VARCHAR(MAX)
+            )
+        """)
+        cursor.execute("""
+            CREATE TABLE #pytest_gh629_exec_target (
+                id INT,
+                name VARCHAR(50),
+                large_text VARCHAR(MAX)
+            )
+        """)
+
+        # Row 1 stays small (regular bind path); Row 2 has a >4000 char value (DAE path)
+        small_text = "hello"
+        large_text = "X" * 5000
+        cursor.execute(
+            "INSERT INTO #pytest_gh629_exec_source VALUES (?, ?, ?)", (1, "alice", small_text)
+        )
+        cursor.execute(
+            "INSERT INTO #pytest_gh629_exec_source VALUES (?, ?, ?)", (2, "bob", large_text)
+        )
+        db_connection.commit()
+
+        # Fetch as Row objects, then pass each Row directly to execute(sql, row)
+        cursor.execute("SELECT * FROM #pytest_gh629_exec_source ORDER BY id")
+        rows = cursor.fetchall()
+        assert isinstance(rows[0], mssql_python.Row)
+
+        for row in rows:
+            # Passing the Row directly (not tuple(row)) must work after the fix.
+            cursor.execute("INSERT INTO #pytest_gh629_exec_target VALUES (?, ?, ?)", row)
+        db_connection.commit()
+
+        # Verify the round-trip preserved every value
+        cursor.execute(
+            "SELECT id, name, LEN(large_text) FROM #pytest_gh629_exec_target ORDER BY id"
+        )
+        result_rows = cursor.fetchall()
+        assert result_rows[0][0] == 1
+        assert result_rows[0][1] == "alice"
+        assert result_rows[0][2] == len(small_text)
+        assert result_rows[1][0] == 2
+        assert result_rows[1][1] == "bob"
+        assert result_rows[1][2] == 5000
+    finally:
+        cursor.execute("DROP TABLE IF EXISTS #pytest_gh629_exec_source")
+        cursor.execute("DROP TABLE IF EXISTS #pytest_gh629_exec_target")
+        db_connection.commit()

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -16657,4 +16657,3 @@ def test_executemany_row_objects_with_varchar_max_dae(cursor, db_connection):
         cursor.execute("DROP TABLE IF EXISTS #pytest_gh629_source")
         cursor.execute("DROP TABLE IF EXISTS #pytest_gh629_target")
         db_connection.commit()
-

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -16594,3 +16594,67 @@ def test_executemany_multi_column_with_large_decimal(cursor, db_connection):
     finally:
         cursor.execute("DROP TABLE IF EXISTS #pytest_gh609_multi")
         db_connection.commit()
+
+
+def test_executemany_row_objects_with_varchar_max_dae(cursor, db_connection):
+    """Test executemany with Row objects from fetchmany() and VARCHAR(MAX) DAE fallback (GH-629).
+
+    When executemany() detects DAE parameters (large strings >4000 chars for VARCHAR(MAX)),
+    it falls back to row-by-row execution. This fallback must handle Row objects returned
+    by fetch APIs (fetchone/fetchmany/fetchall) by converting them to tuples before
+    passing to execute().
+
+    Without the GH-629 fix, this scenario raises:
+        TypeError: Unsupported parameter type: The driver cannot safely convert it to a SQL type.
+
+    This regression test ensures Row objects from fetch APIs can be passed directly to
+    executemany() even when DAE fallback is triggered.
+    """
+    try:
+        # Create source table with VARCHAR(MAX) column
+        cursor.execute("""
+            CREATE TABLE #pytest_gh629_source (
+                id INT,
+                large_text VARCHAR(MAX)
+            )
+        """)
+
+        # Insert data with large strings (>4000 chars triggers DAE)
+        large_text = "X" * 5000
+        cursor.execute("INSERT INTO #pytest_gh629_source VALUES (?, ?)", (1, large_text))
+        cursor.execute("INSERT INTO #pytest_gh629_source VALUES (?, ?)", (2, large_text))
+        db_connection.commit()
+
+        # Fetch rows as Row objects
+        cursor.execute("SELECT * FROM #pytest_gh629_source")
+        rows = cursor.fetchmany(10)  # Returns Row objects
+        assert len(rows) == 2
+        assert type(rows[0]).__name__ == "Row"
+
+        # Create target table
+        cursor.execute("""
+            CREATE TABLE #pytest_gh629_target (
+                id INT,
+                large_text VARCHAR(MAX)
+            )
+        """)
+
+        # executemany with Row objects should work (triggers DAE + row-by-row fallback)
+        cursor.executemany("INSERT INTO #pytest_gh629_target VALUES (?, ?)", rows)
+        db_connection.commit()
+
+        # Verify data was inserted correctly
+        cursor.execute("SELECT COUNT(*) FROM #pytest_gh629_target")
+        assert cursor.fetchone()[0] == 2
+
+        cursor.execute("SELECT id, LEN(large_text) FROM #pytest_gh629_target ORDER BY id")
+        result_rows = cursor.fetchall()
+        assert result_rows[0][0] == 1
+        assert result_rows[0][1] == 5000
+        assert result_rows[1][0] == 2
+        assert result_rows[1][1] == 5000
+    finally:
+        cursor.execute("DROP TABLE IF EXISTS #pytest_gh629_source")
+        cursor.execute("DROP TABLE IF EXISTS #pytest_gh629_target")
+        db_connection.commit()
+

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -16617,7 +16617,7 @@ def test_executemany_row_objects_with_varchar_max_dae(cursor, db_connection):
         cursor.execute("SELECT * FROM #pytest_gh629_source")
         rows = cursor.fetchmany(10)  # Returns Row objects
         assert len(rows) == 2
-        assert type(rows[0]).__name__ == "Row"
+        assert isinstance(rows[0], mssql_python.Row)
 
         # Create target table
         cursor.execute("""


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below 
For external contributors: Insert Github Issue number below
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> [AB#45679](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/45679)

<!-- External contributors: GitHub Issue -->
> GitHub Issue: #629 

-------------------------------------------------------------------
### Summary   
<!-- Insert your summary of changes below. Minimum 10 characters required. -->  
This pull request introduces a compatibility improvement to the `executemany` method in `mssql_python/cursor.py`. It ensures that when iterating through rows of parameters, any Row objects are converted to tuples before execution. This conversion is necessary because the internal `_map_sql_type` logic only recognizes primitive types, and not Row objects, which prevents potential type errors during execution.

Parameter compatibility improvement:

* Updated the `executemany` method to convert Row objects to tuples before passing them to `execute`, ensuring compatibility with the internal type mapping logic.

<!-- 
### PR Title Guide

> For feature requests
FEAT: (short-description)

> For non-feature requests like test case updates, config updates , dependency updates etc
CHORE: (short-description) 

> For Fix requests
FIX: (short-description)

> For doc update requests 
DOC: (short-description)

> For Formatting, indentation, or styling update
STYLE: (short-description)

> For Refactor, without any feature changes
REFACTOR: (short-description)

> For performance improvements
PERF: (short-description)

> For release related changes, without any feature changes
RELEASE: #<RELEASE_VERSION> (short-description) 

### Contribution Guidelines

External contributors:
- Create a GitHub issue first: https://github.com/microsoft/mssql-python/issues/new
- Link the GitHub issue in the "GitHub Issue" section above
- Follow the PR title format and provide a meaningful summary

mssql-python maintainers:
- Create an ADO Work Item following internal processes
- Link the ADO Work Item in the "ADO Work Item" section above  
- Follow the PR title format and provide a meaningful summary
-->