### PR TITLE
RELEASE:1.10.0

### DIFF
--- a/PyPI_Description.md
+++ b/PyPI_Description.md
@@ -35,21 +35,16 @@ PyBind11 provides:
 - Memory-safe bindings
 - Clean and Pythonic API, while performance-critical logic remains in robust, maintainable C++.
  
-## What's new in v1.9.0
+## What's new in v1.10.0
 
 ### Enhancements
 
-- **Row Objects in Bulk Copy** - `bulkcopy` now accepts `Row` objects (and lists) directly, automatically converting each row to a tuple so data fetched from a query can be bulk-inserted without manual conversion (#615).
+- **Active Directory Service Principal for Bulk Copy** - `bulkcopy` now supports `Authentication=ActiveDirectoryServicePrincipal`, acquiring tokens mid-handshake via a registered callback so service principal credentials work for bulk inserts (#576).
 
 ### Bug Fixes
 
-- **macOS / Linux Import Failure** - simdutf is now always statically linked via FetchContent, embedding its symbols into the extension and fixing import failures on machines without simdutf installed at the CI build path (#608).
-- **Incorrect Type Fallback for NULL Parameters** - `SQLDescribeParam` results are now cached per statement when binding `NULL` parameters, fixing incorrect type fallbacks for all-NULL columns and VARBINARY types while also eliminating redundant server round-trips (#614).
-- **executemany Large Decimal Handling** - Fixed a `SQL_C_NUMERIC` type mismatch that caused runtime errors when inserting `Decimal` values outside the SQL Server `MONEY` range via `executemany` (#611).
-- **Exception Pickling** - All DB-API exception subclasses and `ConnectionStringParseError` now implement `__reduce__`, so they survive pickle/unpickle round-trips with all attributes preserved (#616).
-- **PRINT Messages in nextset()** - Diagnostic messages (e.g., SQL Server PRINT output) from subsequent result sets are now captured correctly when `SQL_SUCCESS_WITH_INFO` is returned during `nextset()` (#618).
-- **Row Objects in executemany DAE Path** - `executemany` now converts `Row` objects to tuples in the DAE fallback path, fixing failures when writing to `varchar(max)` columns (#630).
-- **Static Type-Checking of Fetch Methods** - `fetchone`, `fetchmany`, and `fetchall` are no longer reassigned as instance attributes, fixing type-checking failures under `ty` and other static type checkers (#631).
+- **Non-ASCII VARCHAR in Arrow Fetch** - The arrow fetch path now requests `SQL_CHAR` data as `SQL_C_WCHAR` (UTF-16LE), ensuring correct results regardless of encoding settings, locale, or operating system (#575).
+- **Bulk Load Connection Timeouts** - Fixed connection timeouts during bulk load operations (#641, via `mssql_py_core` 0.1.5).
 
 For more information, please visit the project link on Github: https://github.com/microsoft/mssql-python
  

--- a/mssql_python/__init__.py
+++ b/mssql_python/__init__.py
@@ -14,7 +14,7 @@ import weakref
 from .helpers import Settings, get_settings, _settings, _settings_lock
 
 # Driver version
-__version__ = "1.9.0"
+__version__ = "1.10.0"
 
 # Exceptions
 # https://www.python.org/dev/peps/pep-0249/#exceptions

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ package_data = {
 
 setup(
     name="mssql-python",
-    version="1.9.0",
+    version="1.10.0",
     description="A Python library for interacting with Microsoft SQL Server",
     long_description=open("PyPI_Description.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
[AB#45983](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/45983)

Release mssql-python v1.10.0.

This PR bumps the driver version from 1.9.0 to 1.10.0 across `mssql_python/__init__.py`, `setup.py`, and updates `PyPI_Description.md` with this release's customer-facing changes.

### Summary

**Enhancements**

- **Active Directory Service Principal support for Bulk Copy** ([#576](https://github.com/microsoft/mssql-python/pull/576)) - `bulkcopy` now supports `Authentication=ActiveDirectoryServicePrincipal`, registering a token-provider callback that resolves the tenant from the STS URL mid-handshake and returns a service-principal JWT.

**Bug Fixes**

- **Non-ASCII VARCHAR data in the Arrow fetch path** ([#575](https://github.com/microsoft/mssql-python/pull/575)) - The Arrow fetch path now requests `SQL_CHAR` data as `SQL_C_WCHAR` (UTF-16LE), ensuring correct decoding regardless of encoding settings, locale, or OS. Thanks @ffelixg for the contribution!
- **Bulk load connection timeouts** ([#641](https://github.com/microsoft/mssql-python/pull/641)) - Fixed connection timeouts during bulk load operations. Fix lands in the Rust core via bumping `mssql_py_core` from 0.1.4 to 0.1.5. *(via `mssql_py_core`)*

**Version bump**

- `mssql_python/__init__.py`: `__version__ = "1.10.0"`
- `setup.py`: `version="1.10.0"`
- `PyPI_Description.md`: updated `## What's new in v1.10.0` section
