### PR TITLE
CHORE: align connection string sanitizer with its documented key masking

### DIFF
--- a/mssql_python/connection_string_parser.py
+++ b/mssql_python/connection_string_parser.py
@@ -21,7 +21,7 @@ from mssql_python.constants import _ALLOWED_CONNECTION_STRING_PARAMS, _RESERVED_
 from mssql_python.helpers import sanitize_user_input
 from mssql_python.logging import logger
 
-_SENSITIVE_KEYS = frozenset({"pwd"})
+_SENSITIVE_KEYS = frozenset({"pwd", "password"})
 
 
 class _ConnectionStringParser:

--- a/tests/test_007_logging.py
+++ b/tests/test_007_logging.py
@@ -359,6 +359,39 @@ class TestPasswordSanitization:
             assert "PWD=***" in sanitized
             assert "secret" not in sanitized
 
+    def test_password_synonym_sanitization(self, cleanup_logger):
+        """The 'password' synonym for PWD should be masked, matching the docstring contract."""
+        from mssql_python.helpers import sanitize_connection_string
+
+        conn_str = "Server=localhost;password=secret123;Database=test"
+        sanitized = sanitize_connection_string(conn_str)
+
+        assert "secret123" not in sanitized
+
+    def test_password_synonym_case_insensitive(self, cleanup_logger):
+        """password/Password/PASSWORD should all be masked."""
+        from mssql_python.helpers import sanitize_connection_string
+
+        test_cases = [
+            "Server=localhost;password=secret;Database=test",
+            "Server=localhost;Password=secret;Database=test",
+            "Server=localhost;PASSWORD=secret;Database=test",
+        ]
+
+        for conn_str in test_cases:
+            sanitized = sanitize_connection_string(conn_str)
+            assert "secret" not in sanitized
+
+    def test_password_synonym_braced_value_with_semicolon(self, cleanup_logger):
+        """password with a braced value containing semicolons must be fully masked."""
+        from mssql_python.helpers import sanitize_connection_string
+
+        conn_str = "Server=localhost;Password={Top;Secret};Database=test"
+        sanitized = sanitize_connection_string(conn_str)
+
+        assert "Top" not in sanitized
+        assert "Secret" not in sanitized
+
     def test_pwd_braced_value_with_semicolon(self, cleanup_logger):
         """PWD with braced value containing semicolons must be fully masked."""
         from mssql_python.helpers import sanitize_connection_string

--- a/tests/test_007_logging.py
+++ b/tests/test_007_logging.py
@@ -366,7 +366,9 @@ class TestPasswordSanitization:
         conn_str = "Server=localhost;password=secret123;Database=test"
         sanitized = sanitize_connection_string(conn_str)
 
+        assert "password=***" in sanitized
         assert "secret123" not in sanitized
+        assert "redacted" not in sanitized.lower()
 
     def test_password_synonym_case_insensitive(self, cleanup_logger):
         """password/Password/PASSWORD should all be masked."""
@@ -380,7 +382,9 @@ class TestPasswordSanitization:
 
         for conn_str in test_cases:
             sanitized = sanitize_connection_string(conn_str)
+            assert "password=***" in sanitized
             assert "secret" not in sanitized
+            assert "redacted" not in sanitized.lower()
 
     def test_password_synonym_braced_value_with_semicolon(self, cleanup_logger):
         """password with a braced value containing semicolons must be fully masked."""
@@ -389,8 +393,10 @@ class TestPasswordSanitization:
         conn_str = "Server=localhost;Password={Top;Secret};Database=test"
         sanitized = sanitize_connection_string(conn_str)
 
+        assert "password=***" in sanitized
         assert "Top" not in sanitized
         assert "Secret" not in sanitized
+        assert "redacted" not in sanitized.lower()
 
     def test_pwd_braced_value_with_semicolon(self, cleanup_logger):
         """PWD with braced value containing semicolons must be fully masked."""


### PR DESCRIPTION
### Work Item / Issue Reference

> Fixed [AB#46030](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/46030)

-------------------------------------------------------------------
### Summary

sanitize_connection_string documents masking of the PWD and Password keys, but
_SENSITIVE_KEYS only listed pwd, so the Password synonym passed through unmasked.
this adds password to _SENSITIVE_KEYS so the implementation matches its documented
behavior, plus regression tests for password / Password / PASSWORD and a braced value.
