### PR TITLE
FIX: SQLDescribeParam ordinal remapping for VARBINARY/BINARY NULL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **GH-627 behavioral change:** `NULL` parameters for `VARBINARY`/`BINARY`
   columns on physical tables now succeed silently (previously raised
   `ProgrammingError` when a non-NULL parameter was bound first). For temp
-  tables where `SQLDescribeParam` cannot determine column metadata, a
-  `UserWarning` is now emitted before the `ProgrammingError`, guiding users
-  to call `cursor.setinputsizes()`. Users running with `-W error` or
-  filtering on `UserWarning` may observe new warnings on temp-table paths.
+  tables where `SQLDescribeParam` cannot determine column metadata, the
+  fallback to `SQL_VARCHAR` still produces the same `ProgrammingError` as
+  before; users should call `cursor.setinputsizes()` to work around this.
 
 ### Fixed
 - Bug fix: Resolved issue with connection timeout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Improved error handling in the connection module.
+- **GH-627 behavioral change:** `NULL` parameters for `VARBINARY`/`BINARY`
+  columns on physical tables now succeed silently (previously raised
+  `ProgrammingError` when a non-NULL parameter was bound first). For temp
+  tables where `SQLDescribeParam` cannot determine column metadata, a
+  `UserWarning` is now emitted before the `ProgrammingError`, guiding users
+  to call `cursor.setinputsizes()`. Users running with `-W error` or
+  filtering on `UserWarning` may observe new warnings on temp-table paths.
 
 ### Fixed
 - Bug fix: Resolved issue with connection timeout.
+- **GH-627:** Fixed `SQLDescribeParam` ordinal remapping bug that caused
+  `VARBINARY`/`BINARY` `NULL` bindings to fail when a non-NULL parameter was
+  bound first. The driver now pre-resolves unknown NULL parameter types before
+  any `SQLBindParameter` calls, avoiding ODBC ordinal confusion.
 
 ## [1.0.0-alpha] - 2025-02-24
 

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -858,6 +858,18 @@ class Cursor:  # pylint: disable=too-many-instance-attributes,too-many-public-me
         cursor.setinputsizes([(SQL_WVARCHAR, 50, 0), (SQL_DECIMAL, 18, 4)])
         cursor.executemany(sql, params)
 
+        Note:
+            When inserting NULL into BINARY/VARBINARY columns in temp tables (#table)
+            or table variables, SQLDescribeParam cannot resolve the column type and
+            falls back to SQL_VARCHAR. This causes an implicit conversion error from
+            SQL Server. Use setinputsizes to explicitly specify the binary type::
+
+                from mssql_python.constants import SQL_VARBINARY
+                cursor.setinputsizes([None, (SQL_VARBINARY, 100, 0)])
+                cursor.execute("INSERT INTO #t (id, data) VALUES (?, ?)", [1, None])
+
+            Use None in the sizes list to skip type override for a parameter.
+
         Args:
             sizes: A sequence of tuples, one for each parameter. Each tuple contains
                 (sql_type, size, decimal_digits) where size and decimal_digits are optional.

--- a/mssql_python/cursor.py
+++ b/mssql_python/cursor.py
@@ -862,13 +862,15 @@ class Cursor:  # pylint: disable=too-many-instance-attributes,too-many-public-me
             When inserting NULL into BINARY/VARBINARY columns in temp tables (#table)
             or table variables, SQLDescribeParam cannot resolve the column type and
             falls back to SQL_VARCHAR. This causes an implicit conversion error from
-            SQL Server. Use setinputsizes to explicitly specify the binary type::
+            SQL Server. Use setinputsizes to explicitly specify types for ALL
+            parameters::
 
-                from mssql_python.constants import SQL_VARBINARY
-                cursor.setinputsizes([None, (SQL_VARBINARY, 100, 0)])
+                from mssql_python.constants import ConstantsDDBC
+                cursor.setinputsizes([
+                    (ConstantsDDBC.SQL_INTEGER.value, 0, 0),
+                    (ConstantsDDBC.SQL_VARBINARY.value, 100, 0)
+                ])
                 cursor.execute("INSERT INTO #t (id, data) VALUES (?, ?)", [1, None])
-
-            Use None in the sizes list to skip type override for a parameter.
 
         Args:
             sizes: A sequence of tuples, one for each parameter. Each tuple contains

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -499,7 +499,7 @@ static DescribedParamInfo ResolveNullParamType(SqlHandle& handle, SQLHANDLE hStm
 
     DescribedParamInfo info;
     if (SQL_SUCCEEDED(rc)) {
-        info = {type, size, digits, false};
+        info = {type, size, digits};
         LOG("ResolveNullParamType: SQLDescribeParam succeeded for param[%d] "
             "-> sqlType=%d, columnSize=%lu, decimalDigits=%d",
             paramIndex, type, (unsigned long)size, digits);
@@ -515,7 +515,7 @@ static DescribedParamInfo ResolveNullParamType(SqlHandle& handle, SQLHANDLE hStm
         // Example:
         //   cursor.setinputsizes([None, (SQL_VARBINARY, 100, 0)])
         //   cursor.execute("INSERT INTO #t (id, data) VALUES (?, ?)", [1, None])
-        info = {SQL_VARCHAR, 1, 0, true};
+        info = {SQL_VARCHAR, 1, 0};
         LOG_WARNING("ResolveNullParamType: SQLDescribeParam failed for "
                     "param[%d] (rc=%d), falling back to SQL_VARCHAR",
                     paramIndex, rc);
@@ -549,6 +549,9 @@ static DescribedParamInfo ResolveNullParamType(SqlHandle& handle, SQLHANDLE hStm
 static void PreResolveUnknownNullTypes(SqlHandle& handle, SQLHANDLE hStmt,
                                        std::vector<ParamInfo>& paramInfos,
                                        const py::list* params = nullptr) {
+    if (paramInfos.empty())
+        return;
+
     // Quick scan: skip entirely if no unknown NULL params exist.
     bool hasUnknownNull = false;
     for (size_t i = 0; i < paramInfos.size(); ++i) {
@@ -560,7 +563,6 @@ static void PreResolveUnknownNullTypes(SqlHandle& handle, SQLHANDLE hStmt,
     }
     if (!hasUnknownNull)
         return;
-
     for (size_t paramIndex = 0; paramIndex < paramInfos.size(); ++paramIndex) {
         ParamInfo& paramInfo = paramInfos[paramIndex];
         if (paramInfo.paramCType != SQL_C_DEFAULT || paramInfo.paramSQLType != SQL_UNKNOWN_TYPE) {
@@ -590,7 +592,6 @@ SQLRETURN BindParameters(SqlHandle& handle, SQLHANDLE hStmt, const py::list& par
 
     // GH-627: resolve unknown NULL param SQL types before binding any param.
     PreResolveUnknownNullTypes(handle, hStmt, paramInfos, &params);
-
     for (int paramIndex = 0; paramIndex < params.size(); paramIndex++) {
         const auto& param = params[paramIndex];
         ParamInfo& paramInfo = paramInfos[paramIndex];
@@ -740,8 +741,7 @@ SQLRETURN BindParameters(SqlHandle& handle, SQLHANDLE hStmt, const py::list& par
                 if (!py::isinstance<py::none>(param)) {
                     ThrowStdException(MakeParamMismatchErrorStr(paramInfo.paramCType, paramIndex));
                 }
-                // GH-627: SQL type already resolved by PreResolveUnknownNullTypes.
-                dataPtr = nullptr;
+                dataPtr = nullptr;  // GH-627: type resolved by PreResolveUnknownNullTypes.
                 strLenOrIndPtr = AllocateParamBuffer<SQLLEN>(paramBuffers);
                 *strLenOrIndPtr = SQL_NULL_DATA;
                 bufferLength = 0;
@@ -2051,7 +2051,6 @@ SQLRETURN BindParameterArray(SqlHandle& handle, SQLHANDLE hStmt, const py::list&
     try {
         // GH-627: resolve unknown NULL array param SQL types before binding any param.
         PreResolveUnknownNullTypes(handle, hStmt, paramInfos);
-
         for (int paramIndex = 0; paramIndex < columnwise_params.size(); ++paramIndex) {
             const py::list& columnValues = columnwise_params[paramIndex].cast<py::list>();
             ParamInfo& info = paramInfos[paramIndex];

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -473,7 +473,8 @@ std::string DescribeChar(unsigned char ch) {
 // GH-610: Resolve SQL type for a NULL parameter using per-handle cache.
 // On cache miss, calls SQLDescribeParam and stores the result.
 static DescribedParamInfo ResolveNullParamType(SqlHandle& handle, SQLHANDLE hStmt, int paramIndex) {
-    // Check per-handle cache (no mutex — one handle per thread)
+    // Check per-handle cache. ODBC mandates one handle per thread, so no
+    // mutex is needed. Violating this contract causes undefined behavior.
     auto it = handle.describeCache.find(paramIndex);
     if (it != handle.describeCache.end()) {
         LOG("ResolveNullParamType: Cache HIT for hStmt=%p param[%d] "
@@ -512,31 +513,44 @@ static DescribedParamInfo ResolveNullParamType(SqlHandle& handle, SQLHANDLE hStm
         //
         // When this fallback causes an error, users should call
         // cursor.setinputsizes() to explicitly specify the parameter type.
-        // Example:
-        //   cursor.setinputsizes([None, (SQL_VARBINARY, 100, 0)])
+        //  Example:
+        //   cursor.setinputsizes([None, (ConstantsDDBC.SQL_VARBINARY.value, 100, 0)])
         //   cursor.execute("INSERT INTO #t (id, data) VALUES (?, ?)", [1, None])
         info = {SQL_VARCHAR, 1, 0};
         LOG_WARNING("ResolveNullParamType: SQLDescribeParam failed for "
                     "param[%d] (rc=%d), falling back to SQL_VARCHAR",
                     paramIndex, rc);
-        // Emit a Python warning so users get actionable guidance.
-        py::module_::import("warnings")
-            .attr("warn")(
-                "SQLDescribeParam failed for parameter index " + std::to_string(paramIndex) +
-                    " (0-based). Falling back to SQL_VARCHAR for NULL binding. "
-                    "This may cause 'Implicit conversion from data type varchar to varbinary "
-                    "is not allowed' errors for BINARY/VARBINARY columns. "
-                    "To fix, call cursor.setinputsizes() with explicit type info for every "
-                    "parameter. Example (2 params): cursor.setinputsizes("
-                    "[(SQL_INTEGER, 0, 0), (SQL_VARBINARY, column_size, 0)])",
-                py::module_::import("builtins").attr("UserWarning"));
     }
 
-    // Cache both successful and fallback results. For fallbacks, this avoids
-    // repeated SQLDescribeParam network calls on statement reuse (same_sql path).
-    // The cache is cleared on SQLPrepare, so if the user changes the SQL or
-    // recreates the table, the next execution will retry SQLDescribeParam.
+    // Cache both successful and fallback results BEFORE emitting warnings.
+    // For fallbacks, this avoids repeated SQLDescribeParam network calls on
+    // statement reuse (same_sql path). The cache is cleared on SQLPrepare,
+    // so if the user changes the SQL or recreates the table, the next
+    // execution will retry SQLDescribeParam.
     handle.describeCache[paramIndex] = info;
+
+    // Emit a Python warning on fallback so users get actionable guidance.
+    // Wrapped in try-catch: if warning emission fails (e.g. interpreter
+    // shutdown), we still return the cached fallback rather than aborting.
+    if (!SQL_SUCCEEDED(rc)) {
+        try {
+            auto builtins = py::module_::import("builtins");
+            py::module_::import("warnings")
+                .attr("warn")(
+                    "SQLDescribeParam failed for parameter index " + std::to_string(paramIndex) +
+                        " (0-based). Falling back to SQL_VARCHAR for NULL binding. "
+                        "This may cause 'Implicit conversion from data type varchar to varbinary "
+                        "is not allowed' errors for BINARY/VARBINARY columns. "
+                        "To fix, call cursor.setinputsizes() with explicit type info for every "
+                        "parameter. Example (2 params): cursor.setinputsizes("
+                        "[(ConstantsDDBC.SQL_INTEGER.value, 0, 0), "
+                        "(ConstantsDDBC.SQL_VARBINARY.value, column_size, 0)])",
+                    builtins.attr("UserWarning"));
+        } catch (const py::error_already_set& e) {
+            LOG_WARNING("ResolveNullParamType: Failed to emit Python warning: %s", e.what());
+        }
+    }
+
     return info;
 }
 
@@ -561,15 +575,16 @@ static void PreResolveUnknownNullTypes(SqlHandle& handle, SQLHANDLE hStmt,
             break;
         }
     }
-    if (!hasUnknownNull)
-        return;
+    if (!hasUnknownNull) return;
+
     for (size_t paramIndex = 0; paramIndex < paramInfos.size(); ++paramIndex) {
         ParamInfo& paramInfo = paramInfos[paramIndex];
         if (paramInfo.paramCType != SQL_C_DEFAULT || paramInfo.paramSQLType != SQL_UNKNOWN_TYPE) {
             continue;
         }
         // For execute(), verify the actual value is None (mixed columns possible).
-        if (params && !py::isinstance<py::none>((*params)[paramIndex])) {
+        if (params && paramIndex < params->size() &&
+            !py::isinstance<py::none>((*params)[paramIndex])) {
             continue;
         }
 

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -10,7 +10,6 @@
 #include "logger_bridge.hpp"
 #include "utf_utils.h"
 
-
 #include <algorithm>  // std::min
 #include <cctype>
 #include <cstdint>
@@ -19,7 +18,6 @@
 #include <iomanip>  // std::setw, std::setfill
 #include <iostream>
 #include <utility>  // std::forward
-
 
 //-------------------------------------------------------------------------------------------------
 // Macro definitions
@@ -474,13 +472,13 @@ std::string DescribeChar(unsigned char ch) {
 
 // GH-610: Resolve SQL type for a NULL parameter using per-handle cache.
 // On cache miss, calls SQLDescribeParam and stores the result.
-static DescribedParamInfo ResolveNullParamType(
-        SqlHandle& handle, SQLHANDLE hStmt, int paramIndex) {
+static DescribedParamInfo ResolveNullParamType(SqlHandle& handle, SQLHANDLE hStmt, int paramIndex) {
     // Check per-handle cache (no mutex — one handle per thread)
     auto it = handle.describeCache.find(paramIndex);
     if (it != handle.describeCache.end()) {
         LOG("ResolveNullParamType: Cache HIT for hStmt=%p param[%d] "
-            "-> sqlType=%d", (void*)hStmt, paramIndex, it->second.sqlType);
+            "-> sqlType=%d",
+            (void*)hStmt, paramIndex, it->second.sqlType);
         return it->second;
     }
 
@@ -488,27 +486,96 @@ static DescribedParamInfo ResolveNullParamType(
     SQLSMALLINT type, digits, nullable;
     SQLULEN size;
     LOG("ResolveNullParamType: Cache MISS for hStmt=%p param[%d], calling "
-        "SQLDescribeParam", (void*)hStmt, paramIndex);
-    RETCODE rc = SQLDescribeParam_ptr(
-        hStmt, static_cast<SQLUSMALLINT>(paramIndex + 1),
-        &type, &size, &digits, &nullable);
+        "SQLDescribeParam",
+        (void*)hStmt, paramIndex);
+    RETCODE rc;
+    {
+        // Release the GIL during the blocking SQLDescribeParam network call.
+        // The driver calls sp_describe_undeclared_parameters on the server.
+        py::gil_scoped_release release;
+        rc = SQLDescribeParam_ptr(hStmt, static_cast<SQLUSMALLINT>(paramIndex + 1), &type, &size,
+                                  &digits, &nullable);
+    }
 
     DescribedParamInfo info;
     if (SQL_SUCCEEDED(rc)) {
-        info = {type, size, digits};
+        info = {type, size, digits, false};
         LOG("ResolveNullParamType: SQLDescribeParam succeeded for param[%d] "
             "-> sqlType=%d, columnSize=%lu, decimalDigits=%d",
             paramIndex, type, (unsigned long)size, digits);
     } else {
-        info = {SQL_VARCHAR, 1, 0};
+        // SQLDescribeParam failed — typically happens with temp tables (#table),
+        // table variables, or complex CTEs where the driver cannot determine
+        // parameter metadata.  Fall back to SQL_VARCHAR which works for most
+        // column types but will fail for BINARY/VARBINARY columns due to SQL
+        // Server's implicit conversion rules.
+        //
+        // When this fallback causes an error, users should call
+        // cursor.setinputsizes() to explicitly specify the parameter type.
+        // Example:
+        //   cursor.setinputsizes([None, (SQL_VARBINARY, 100, 0)])
+        //   cursor.execute("INSERT INTO #t (id, data) VALUES (?, ?)", [1, None])
+        info = {SQL_VARCHAR, 1, 0, true};
         LOG_WARNING("ResolveNullParamType: SQLDescribeParam failed for "
                     "param[%d] (rc=%d), falling back to SQL_VARCHAR",
                     paramIndex, rc);
+        // Emit a Python warning so users get actionable guidance.
+        py::module_::import("warnings")
+            .attr("warn")("SQLDescribeParam failed for parameter index " +
+                              std::to_string(paramIndex) +
+                              ". Falling back to SQL_VARCHAR for NULL binding. "
+                              "This may cause 'Implicit conversion from data type varchar "
+                              "to varbinary is not allowed' errors for BINARY/VARBINARY columns. "
+                              "To fix, use cursor.setinputsizes() to specify the column type "
+                              "before executing. Example: cursor.setinputsizes([(SQL_VARBINARY, "
+                              "column_size, 0)])",
+                          py::module_::import("builtins").attr("UserWarning"));
     }
 
-    // Store in per-handle cache
+    // Cache both successful and fallback results. For fallbacks, this avoids
+    // repeated SQLDescribeParam network calls on statement reuse (same_sql path).
+    // The cache is cleared on SQLPrepare, so if the user changes the SQL or
+    // recreates the table, the next execution will retry SQLDescribeParam.
     handle.describeCache[paramIndex] = info;
     return info;
+}
+
+// GH-627: Resolve unknown NULL SQL types before any SQLBindParameter calls.
+// Some drivers remap parameter ordinals during describe when parameters have
+// already been bound, so interleaving describe+bind can fail for binary NULLs.
+// When `params` is provided (execute path), an additional py::none check is
+// performed; for executemany (array path), SQL_C_DEFAULT already guarantees
+// all values in that column are NULL, so no Python-level check is needed.
+static void PreResolveUnknownNullTypes(SqlHandle& handle, SQLHANDLE hStmt,
+                                       std::vector<ParamInfo>& paramInfos,
+                                       const py::list* params = nullptr) {
+    // Quick scan: skip entirely if no unknown NULL params exist.
+    bool hasUnknownNull = false;
+    for (size_t i = 0; i < paramInfos.size(); ++i) {
+        if (paramInfos[i].paramCType == SQL_C_DEFAULT &&
+            paramInfos[i].paramSQLType == SQL_UNKNOWN_TYPE) {
+            hasUnknownNull = true;
+            break;
+        }
+    }
+    if (!hasUnknownNull)
+        return;
+
+    for (size_t paramIndex = 0; paramIndex < paramInfos.size(); ++paramIndex) {
+        ParamInfo& paramInfo = paramInfos[paramIndex];
+        if (paramInfo.paramCType != SQL_C_DEFAULT || paramInfo.paramSQLType != SQL_UNKNOWN_TYPE) {
+            continue;
+        }
+        // For execute(), verify the actual value is None (mixed columns possible).
+        if (params && !py::isinstance<py::none>((*params)[paramIndex])) {
+            continue;
+        }
+
+        auto resolved = ResolveNullParamType(handle, hStmt, static_cast<int>(paramIndex));
+        paramInfo.paramSQLType = resolved.sqlType;
+        paramInfo.columnSize = resolved.columnSize;
+        paramInfo.decimalDigits = resolved.decimalDigits;
+    }
 }
 
 // Given a list of parameters and their ParamInfo, calls SQLBindParameter on
@@ -520,6 +587,10 @@ SQLRETURN BindParameters(SqlHandle& handle, SQLHANDLE hStmt, const py::list& par
     LOG("BindParameters: Starting parameter binding for statement handle %p "
         "with %zu parameters",
         (void*)hStmt, params.size());
+
+    // GH-627: resolve unknown NULL param SQL types before binding any param.
+    PreResolveUnknownNullTypes(handle, hStmt, paramInfos, &params);
+
     for (int paramIndex = 0; paramIndex < params.size(); paramIndex++) {
         const auto& param = params[paramIndex];
         ParamInfo& paramInfo = paramInfos[paramIndex];
@@ -669,23 +740,11 @@ SQLRETURN BindParameters(SqlHandle& handle, SQLHANDLE hStmt, const py::list& par
                 if (!py::isinstance<py::none>(param)) {
                     ThrowStdException(MakeParamMismatchErrorStr(paramInfo.paramCType, paramIndex));
                 }
-                // GH-610: Resolve SQL type for NULL params via per-handle cache.
-                SQLSMALLINT sqlType = paramInfo.paramSQLType;
-                SQLULEN columnSize = paramInfo.columnSize;
-                SQLSMALLINT decimalDigits = paramInfo.decimalDigits;
-                if (sqlType == SQL_UNKNOWN_TYPE) {
-                    auto resolved = ResolveNullParamType(handle, hStmt, paramIndex);
-                    sqlType = resolved.sqlType;
-                    columnSize = resolved.columnSize;
-                    decimalDigits = resolved.decimalDigits;
-                }
+                // GH-627: SQL type already resolved by PreResolveUnknownNullTypes.
                 dataPtr = nullptr;
                 strLenOrIndPtr = AllocateParamBuffer<SQLLEN>(paramBuffers);
                 *strLenOrIndPtr = SQL_NULL_DATA;
                 bufferLength = 0;
-                paramInfo.paramSQLType = sqlType;
-                paramInfo.columnSize = columnSize;
-                paramInfo.decimalDigits = decimalDigits;
                 break;
             }
             case SQL_C_STINYINT:
@@ -1830,7 +1889,8 @@ SQLRETURN SQLExecute_wrap(const SqlHandlePtr statementHandle, const std::u16stri
         }
 
         std::vector<std::shared_ptr<void>> paramBuffers;
-        rc = BindParameters(*statementHandle, hStmt, params, paramInfos, paramBuffers, charEncoding);
+        rc =
+            BindParameters(*statementHandle, hStmt, params, paramInfos, paramBuffers, charEncoding);
         if (!SQL_SUCCEEDED(rc)) {
             return rc;
         }
@@ -1989,6 +2049,9 @@ SQLRETURN BindParameterArray(SqlHandle& handle, SQLHANDLE hStmt, const py::list&
     std::vector<std::shared_ptr<void>> tempBuffers;
 
     try {
+        // GH-627: resolve unknown NULL array param SQL types before binding any param.
+        PreResolveUnknownNullTypes(handle, hStmt, paramInfos);
+
         for (int paramIndex = 0; paramIndex < columnwise_params.size(); ++paramIndex) {
             const py::list& columnValues = columnwise_params[paramIndex].cast<py::list>();
             ParamInfo& info = paramInfos[paramIndex];
@@ -2566,20 +2629,10 @@ SQLRETURN BindParameterArray(SqlHandle& handle, SQLHANDLE hStmt, const py::list&
                 }
                 case SQL_C_DEFAULT: {
                     // Handle NULL parameters - all values in this column should be NULL
+                    // GH-627: SQL type already resolved by PreResolveUnknownNullTypes.
                     LOG("BindParameterArray: Binding SQL_C_DEFAULT (NULL) array - param_index=%d, "
-                        "count=%zu",
-                        paramIndex, paramSetSize);
-
-                    // GH-610: Resolve SQL type for all-NULL columns via per-handle cache.
-                    SQLSMALLINT resolvedSqlType = info.paramSQLType;
-                    SQLULEN resolvedColSize = info.columnSize;
-                    SQLSMALLINT resolvedDecDigits = info.decimalDigits;
-                    if (resolvedSqlType == SQL_UNKNOWN_TYPE) {
-                        auto resolved = ResolveNullParamType(handle, hStmt, paramIndex);
-                        resolvedSqlType = resolved.sqlType;
-                        resolvedColSize = resolved.columnSize;
-                        resolvedDecDigits = resolved.decimalDigits;
-                    }
+                        "count=%zu, resolvedSqlType=%d",
+                        paramIndex, paramSetSize, info.paramSQLType);
 
                     char* nullBuffer = AllocateParamBufferArray<char>(tempBuffers, paramSetSize);
                     strLenOrIndArray = AllocateParamBufferArray<SQLLEN>(tempBuffers, paramSetSize);
@@ -2591,14 +2644,6 @@ SQLRETURN BindParameterArray(SqlHandle& handle, SQLHANDLE hStmt, const py::list&
 
                     dataPtr = nullBuffer;
                     bufferLength = 1;
-
-                    // Override info fields so SQLBindParameter below uses resolved type
-                    info.paramSQLType = resolvedSqlType;
-                    info.columnSize = resolvedColSize;
-                    info.decimalDigits = resolvedDecDigits;
-
-                    LOG("BindParameterArray: SQL_C_DEFAULT bound - param_index=%d, "
-                        "resolvedSqlType=%d", paramIndex, resolvedSqlType);
                     break;
                 }
                 default: {
@@ -2638,9 +2683,8 @@ SQLRETURN BindParameterArray(SqlHandle& handle, SQLHANDLE hStmt, const py::list&
 }
 
 SQLRETURN SQLExecuteMany_wrap(const SqlHandlePtr statementHandle, const std::u16string& query,
-                              const py::list& columnwise_params,
-                              std::vector<ParamInfo>& paramInfos, size_t paramSetSize,
-                              const py::dict& encodingSettings) {
+                              const py::list& columnwise_params, std::vector<ParamInfo>& paramInfos,
+                              size_t paramSetSize, const py::dict& encodingSettings) {
     LOG("SQLExecuteMany: Starting batch execution - param_count=%zu, "
         "param_set_size=%zu",
         columnwise_params.size(), paramSetSize);
@@ -2681,8 +2725,8 @@ SQLRETURN SQLExecuteMany_wrap(const SqlHandlePtr statementHandle, const std::u16
             "BindParameterArray with encoding '%s'",
             charEncoding.c_str());
         std::vector<std::shared_ptr<void>> paramBuffers;
-        rc = BindParameterArray(*statementHandle, hStmt, columnwise_params, paramInfos, paramSetSize, paramBuffers,
-                                charEncoding);
+        rc = BindParameterArray(*statementHandle, hStmt, columnwise_params, paramInfos,
+                                paramSetSize, paramBuffers, charEncoding);
         if (!SQL_SUCCEEDED(rc)) {
             LOG("SQLExecuteMany: BindParameterArray failed - rc=%d", rc);
             return rc;
@@ -2711,8 +2755,8 @@ SQLRETURN SQLExecuteMany_wrap(const SqlHandlePtr statementHandle, const std::u16
             py::list rowParams = columnwise_params[rowIndex];
 
             std::vector<std::shared_ptr<void>> paramBuffers;
-            rc = BindParameters(*statementHandle, hStmt, rowParams, paramInfos,
-                                paramBuffers, charEncoding);
+            rc = BindParameters(*statementHandle, hStmt, rowParams, paramInfos, paramBuffers,
+                                charEncoding);
             if (!SQL_SUCCEEDED(rc)) {
                 LOG("SQLExecuteMany: BindParameters failed for row %zu - rc=%d", rowIndex, rc);
                 return rc;
@@ -4627,8 +4671,7 @@ int32_t days_from_civil(int y, int m, int d) {
     return era * 146097 + static_cast<int>(doe) - 719468;
 }
 
-SQLRETURN FetchArrowBatch_wrap(SqlHandlePtr StatementHandle, py::list& capsules,
-                               int arrowBatchSize,
+SQLRETURN FetchArrowBatch_wrap(SqlHandlePtr StatementHandle, py::list& capsules, int arrowBatchSize,
                                int charCtype) {
     // Fetch narrow char data as SQL_C_CHAR if on Linux/macOS and configured by the user
     charCtype = EffectiveCharCtypeForFetch(charCtype, "utf-8");

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -10,6 +10,7 @@
 #include "logger_bridge.hpp"
 #include "utf_utils.h"
 
+
 #include <algorithm>  // std::min
 #include <cctype>
 #include <cstdint>
@@ -18,6 +19,7 @@
 #include <iomanip>  // std::setw, std::setfill
 #include <iostream>
 #include <utility>  // std::forward
+
 
 //-------------------------------------------------------------------------------------------------
 // Macro definitions

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -521,15 +521,15 @@ static DescribedParamInfo ResolveNullParamType(SqlHandle& handle, SQLHANDLE hStm
                     paramIndex, rc);
         // Emit a Python warning so users get actionable guidance.
         py::module_::import("warnings")
-            .attr("warn")("SQLDescribeParam failed for parameter index " +
-                              std::to_string(paramIndex) +
-                              ". Falling back to SQL_VARCHAR for NULL binding. "
-                              "This may cause 'Implicit conversion from data type varchar "
-                              "to varbinary is not allowed' errors for BINARY/VARBINARY columns. "
-                              "To fix, use cursor.setinputsizes() to specify the column type "
-                              "before executing. Example: cursor.setinputsizes([(SQL_VARBINARY, "
-                              "column_size, 0)])",
-                          py::module_::import("builtins").attr("UserWarning"));
+            .attr("warn")(
+                "SQLDescribeParam failed for parameter index " + std::to_string(paramIndex) +
+                    " (0-based). Falling back to SQL_VARCHAR for NULL binding. "
+                    "This may cause 'Implicit conversion from data type varchar to varbinary "
+                    "is not allowed' errors for BINARY/VARBINARY columns. "
+                    "To fix, call cursor.setinputsizes() with explicit type info for every "
+                    "parameter. Example (2 params): cursor.setinputsizes("
+                    "[(SQL_INTEGER, 0, 0), (SQL_VARBINARY, column_size, 0)])",
+                py::module_::import("builtins").attr("UserWarning"));
     }
 
     // Cache both successful and fallback results. For fallbacks, this avoids

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -2699,8 +2699,9 @@ SQLRETURN BindParameterArray(SqlHandle& handle, SQLHANDLE hStmt, const py::list&
 }
 
 SQLRETURN SQLExecuteMany_wrap(const SqlHandlePtr statementHandle, const std::u16string& query,
-                              const py::list& columnwise_params, std::vector<ParamInfo>& paramInfos,
-                              size_t paramSetSize, const py::dict& encodingSettings) {
+                              const py::list& columnwise_params,
+                              std::vector<ParamInfo>& paramInfos, size_t paramSetSize,
+                              const py::dict& encodingSettings) {
     LOG("SQLExecuteMany: Starting batch execution - param_count=%zu, "
         "param_set_size=%zu",
         columnwise_params.size(), paramSetSize);
@@ -2741,8 +2742,8 @@ SQLRETURN SQLExecuteMany_wrap(const SqlHandlePtr statementHandle, const std::u16
             "BindParameterArray with encoding '%s'",
             charEncoding.c_str());
         std::vector<std::shared_ptr<void>> paramBuffers;
-        rc = BindParameterArray(*statementHandle, hStmt, columnwise_params, paramInfos,
-                                paramSetSize, paramBuffers, charEncoding);
+        rc = BindParameterArray(*statementHandle, hStmt, columnwise_params, paramInfos, paramSetSize, paramBuffers,
+                                charEncoding);
         if (!SQL_SUCCEEDED(rc)) {
             LOG("SQLExecuteMany: BindParameterArray failed - rc=%d", rc);
             return rc;
@@ -2771,8 +2772,8 @@ SQLRETURN SQLExecuteMany_wrap(const SqlHandlePtr statementHandle, const std::u16
             py::list rowParams = columnwise_params[rowIndex];
 
             std::vector<std::shared_ptr<void>> paramBuffers;
-            rc = BindParameters(*statementHandle, hStmt, rowParams, paramInfos, paramBuffers,
-                                charEncoding);
+            rc = BindParameters(*statementHandle, hStmt, rowParams, paramInfos,
+                                paramBuffers, charEncoding);
             if (!SQL_SUCCEEDED(rc)) {
                 LOG("SQLExecuteMany: BindParameters failed for row %zu - rc=%d", rowIndex, rc);
                 return rc;
@@ -4687,7 +4688,8 @@ int32_t days_from_civil(int y, int m, int d) {
     return era * 146097 + static_cast<int>(doe) - 719468;
 }
 
-SQLRETURN FetchArrowBatch_wrap(SqlHandlePtr StatementHandle, py::list& capsules, int arrowBatchSize,
+SQLRETURN FetchArrowBatch_wrap(SqlHandlePtr StatementHandle, py::list& capsules,
+                               int arrowBatchSize,
                                int charCtype) {
     // Fetch narrow char data as SQL_C_CHAR if on Linux/macOS and configured by the user
     charCtype = EffectiveCharCtypeForFetch(charCtype, "utf-8");

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -1932,8 +1932,7 @@ SQLRETURN SQLExecute_wrap(const SqlHandlePtr statementHandle, const std::u16stri
         }
 
         std::vector<std::shared_ptr<void>> paramBuffers;
-        rc =
-            BindParameters(*statementHandle, hStmt, params, paramInfos, paramBuffers, charEncoding);
+        rc = BindParameters(*statementHandle, hStmt, params, paramInfos, paramBuffers, charEncoding);
         if (!SQL_SUCCEEDED(rc)) {
             return rc;
         }

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -514,10 +514,10 @@ static DescribedParamInfo ResolveNullParamType(SqlHandle& handle, SQLHANDLE hStm
         // column types but will fail for BINARY/VARBINARY columns due to SQL
         // Server's implicit conversion rules.
         //
-        // When this fallback causes an error, users should call
-        // cursor.setinputsizes() to explicitly specify the parameter type.
-        //  Example:
-        //   cursor.setinputsizes([None, (ConstantsDDBC.SQL_VARBINARY.value, 100, 0)])
+        // Workaround: cursor.setinputsizes() to explicitly specify types.
+        //   from mssql_python.constants import ConstantsDDBC
+        //   cursor.setinputsizes([(ConstantsDDBC.SQL_INTEGER.value, 10, 0),
+        //                         (ConstantsDDBC.SQL_VARBINARY.value, 0, 0)])
         //   cursor.execute("INSERT INTO #t (id, data) VALUES (?, ?)", [1, None])
         info = {SQL_VARCHAR, 1, 0};
         LOG_WARNING("ResolveNullParamType: SQLDescribeParam failed for "
@@ -525,35 +525,14 @@ static DescribedParamInfo ResolveNullParamType(SqlHandle& handle, SQLHANDLE hStm
                     paramIndex, rc);
     }
 
-    // Cache both successful and fallback results BEFORE emitting warnings.
-    // For fallbacks, this avoids repeated SQLDescribeParam network calls on
-    // statement reuse (same_sql path). The cache is cleared on SQLPrepare,
-    // so if the user changes the SQL or recreates the table, the next
-    // execution will retry SQLDescribeParam.
+    // Cache both successful and fallback results. For fallbacks, this avoids
+    // repeated SQLDescribeParam network calls on statement reuse. Note: on the
+    // same_sql path clearDescribeCache() is NOT called, so a transient describe
+    // failure is pinned as SQL_VARCHAR for the life of the prepared statement.
+    // This is intentional — retrying a failing describe on every execute would
+    // add latency with no benefit (temp-table metadata won't become resolvable
+    // mid-connection). The cache IS cleared on SQLPrepare (usePrepare path).
     handle.describeCache[paramIndex] = info;
-
-    // Emit a Python warning on fallback so users get actionable guidance.
-    // Wrapped in try-catch: if warning emission fails (e.g. interpreter
-    // shutdown), we still return the cached fallback rather than aborting.
-    if (!SQL_SUCCEEDED(rc)) {
-        try {
-            auto builtins = py::module_::import("builtins");
-            py::module_::import("warnings")
-                .attr("warn")(
-                    "SQLDescribeParam failed for parameter index " + std::to_string(paramIndex) +
-                        " (0-based). Falling back to SQL_VARCHAR for NULL binding. "
-                        "This may cause 'Implicit conversion from data type varchar to varbinary "
-                        "is not allowed' errors for BINARY/VARBINARY columns. "
-                        "To fix: from mssql_python.constants import ConstantsDDBC; then call "
-                        "cursor.setinputsizes() with explicit type info for every parameter. "
-                        "Example (2 params): cursor.setinputsizes("
-                        "[(ConstantsDDBC.SQL_INTEGER.value, 10, 0), "
-                        "(ConstantsDDBC.SQL_VARBINARY.value, column_size, 0)])",
-                    builtins.attr("UserWarning"));
-        } catch (const py::error_already_set& e) {
-            LOG_WARNING("ResolveNullParamType: Failed to emit Python warning: %s", e.what());
-        }
-    }
 
     return info;
 }
@@ -568,18 +547,6 @@ static void PreResolveUnknownNullTypes(SqlHandle& handle, SQLHANDLE hStmt,
                                        std::vector<ParamInfo>& paramInfos,
                                        const py::list* params = nullptr) {
     if (paramInfos.empty())
-        return;
-
-    // Quick scan: skip entirely if no unknown NULL params exist.
-    bool hasUnknownNull = false;
-    for (size_t i = 0; i < paramInfos.size(); ++i) {
-        if (paramInfos[i].paramCType == SQL_C_DEFAULT &&
-            paramInfos[i].paramSQLType == SQL_UNKNOWN_TYPE) {
-            hasUnknownNull = true;
-            break;
-        }
-    }
-    if (!hasUnknownNull)
         return;
 
     for (size_t paramIndex = 0; paramIndex < paramInfos.size(); ++paramIndex) {

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -541,9 +541,10 @@ static DescribedParamInfo ResolveNullParamType(SqlHandle& handle, SQLHANDLE hStm
                         " (0-based). Falling back to SQL_VARCHAR for NULL binding. "
                         "This may cause 'Implicit conversion from data type varchar to varbinary "
                         "is not allowed' errors for BINARY/VARBINARY columns. "
-                        "To fix, call cursor.setinputsizes() with explicit type info for every "
-                        "parameter. Example (2 params): cursor.setinputsizes("
-                        "[(ConstantsDDBC.SQL_INTEGER.value, 0, 0), "
+                        "To fix: from mssql_python.constants import ConstantsDDBC; then call "
+                        "cursor.setinputsizes() with explicit type info for every parameter. "
+                        "Example (2 params): cursor.setinputsizes("
+                        "[(ConstantsDDBC.SQL_INTEGER.value, 10, 0), "
                         "(ConstantsDDBC.SQL_VARBINARY.value, column_size, 0)])",
                     builtins.attr("UserWarning"));
         } catch (const py::error_already_set& e) {
@@ -575,7 +576,8 @@ static void PreResolveUnknownNullTypes(SqlHandle& handle, SQLHANDLE hStmt,
             break;
         }
     }
-    if (!hasUnknownNull) return;
+    if (!hasUnknownNull)
+        return;
 
     for (size_t paramIndex = 0; paramIndex < paramInfos.size(); ++paramIndex) {
         ParamInfo& paramInfo = paramInfos[paramIndex];

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -15,6 +15,7 @@
 #include <string>
 #include <vector>
 
+
 namespace py = pybind11;
 using py::literals::operator""_a;
 

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -15,7 +15,6 @@
 #include <string>
 #include <vector>
 
-
 namespace py = pybind11;
 using py::literals::operator""_a;
 
@@ -247,6 +246,7 @@ struct DescribedParamInfo {
     SQLSMALLINT sqlType;
     SQLULEN columnSize;
     SQLSMALLINT decimalDigits;
+    bool isFallback = false;  // true when SQLDescribeParam failed and SQL_VARCHAR was used
 };
 
 class SqlHandle {

--- a/mssql_python/pybind/ddbc_bindings.h
+++ b/mssql_python/pybind/ddbc_bindings.h
@@ -246,7 +246,6 @@ struct DescribedParamInfo {
     SQLSMALLINT sqlType;
     SQLULEN columnSize;
     SQLSMALLINT decimalDigits;
-    bool isFallback = false;  // true when SQLDescribeParam failed and SQL_VARCHAR was used
 };
 
 class SqlHandle {

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -914,6 +914,31 @@ def test_gh627_executemany_nonnull_before_null_varbinary(cursor, db_connection):
         db_connection.commit()
 
 
+def test_gh627_executemany_mixed_null_nonnull_varbinary(cursor, db_connection):
+    """GH-627: executemany with mixed NULL/non-NULL VARBINARY rows should work.
+    This exercises the non-all-NULL executemany path where individual rows
+    go through BindParameters with both NULL and non-NULL binary values."""
+    table_name = f"pytest_gh627_mixed_{uuid.uuid4().hex}"
+    try:
+        cursor.execute(f"CREATE TABLE {table_name} (id INT, data VARBINARY(32) NULL)")
+        db_connection.commit()
+
+        cursor.executemany(
+            f"INSERT INTO {table_name} (id, data) VALUES (?, ?)",
+            [(1, b"\x01\x02\x03"), (2, None), (3, b"\xaa\xbb\xcc")],
+        )
+        db_connection.commit()
+
+        cursor.execute(f"SELECT id, data FROM {table_name} ORDER BY id")
+        rows = cursor.fetchall()
+        assert rows[0] == [1, b"\x01\x02\x03"]
+        assert rows[1] == [2, None]
+        assert rows[2] == [3, b"\xaa\xbb\xcc"]
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        db_connection.commit()
+
+
 def test_gh627_null_then_nonnull_varbinary_reuse(cursor, db_connection):
     """GH-627: Re-executing same SQL with NULL then non-NULL VARBINARY must work
     (prepared statement + cache reuse path)."""

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -1076,9 +1076,9 @@ def test_gh627_executemany_temp_table_warns(cursor, db_connection):
                 [(1, None), (2, None)],
             )
 
-    assert any("SQLDescribeParam failed" in str(w.message) for w in caught), (
-        f"Expected SQLDescribeParam warning, got: {[str(w.message) for w in caught]}"
-    )
+    assert any(
+        "SQLDescribeParam failed" in str(w.message) for w in caught
+    ), f"Expected SQLDescribeParam warning, got: {[str(w.message) for w in caught]}"
 
     cursor.execute("DROP TABLE IF EXISTS #gh627_em_warn")
     db_connection.commit()

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -991,20 +991,113 @@ def test_gh627_execute_nonnull_before_null_binary(cursor, db_connection):
         db_connection.commit()
 
 
+def test_gh627_null_varbinary_as_first_param(cursor, db_connection):
+    """GH-627: NULL VARBINARY as first parameter (ordinal 1 resolution)."""
+    table_name = f"pytest_gh627_first_{uuid.uuid4().hex}"
+    try:
+        cursor.execute(f"CREATE TABLE {table_name} (data VARBINARY(32) NULL, id INT)")
+        db_connection.commit()
+
+        cursor.execute(
+            f"INSERT INTO {table_name} (data, id) VALUES (?, ?)",
+            [None, 1],
+        )
+        db_connection.commit()
+
+        cursor.execute(f"SELECT data, id FROM {table_name}")
+        row = cursor.fetchone()
+        assert row[0] is None
+        assert row[1] == 1
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        db_connection.commit()
+
+
+def test_gh627_multiple_null_varbinary_columns(cursor, db_connection):
+    """GH-627: Multiple NULL VARBINARY columns resolved in a single pre-resolve pass."""
+    table_name = f"pytest_gh627_multi_{uuid.uuid4().hex}"
+    try:
+        cursor.execute(
+            f"CREATE TABLE {table_name} (id INT, bin1 VARBINARY(32) NULL, bin2 VARBINARY(64) NULL)"
+        )
+        db_connection.commit()
+
+        cursor.execute(
+            f"INSERT INTO {table_name} (id, bin1, bin2) VALUES (?, ?, ?)",
+            [1, None, None],
+        )
+        db_connection.commit()
+
+        cursor.execute(f"SELECT id, bin1, bin2 FROM {table_name}")
+        row = cursor.fetchone()
+        assert row == [1, None, None]
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        db_connection.commit()
+
+
+def test_gh627_varbinary_max_null(cursor, db_connection):
+    """GH-627: NULL VARBINARY(MAX) column — MAX has special semantics in
+    sp_describe_undeclared_parameters."""
+    table_name = f"pytest_gh627_max_{uuid.uuid4().hex}"
+    try:
+        cursor.execute(f"CREATE TABLE {table_name} (id INT, data VARBINARY(MAX) NULL)")
+        db_connection.commit()
+
+        cursor.execute(
+            f"INSERT INTO {table_name} (id, data) VALUES (?, ?)",
+            [1, None],
+        )
+        db_connection.commit()
+
+        cursor.execute(f"SELECT id, data FROM {table_name}")
+        row = cursor.fetchone()
+        assert row == [1, None]
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        db_connection.commit()
+
+
+def test_gh627_executemany_temp_table_warns(cursor, db_connection):
+    """GH-627: executemany with temp table + all-NULL VARBINARY column should
+    emit UserWarning (most common real-world failure scenario)."""
+    import warnings
+
+    from mssql_python.exceptions import ProgrammingError
+
+    cursor.execute("CREATE TABLE #gh627_em_warn (id INT, data VARBINARY(50) NULL)")
+    db_connection.commit()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(ProgrammingError):
+            cursor.executemany(
+                "INSERT INTO #gh627_em_warn (id, data) VALUES (?, ?)",
+                [(1, None), (2, None)],
+            )
+
+    assert any("SQLDescribeParam failed" in str(w.message) for w in caught), (
+        f"Expected SQLDescribeParam warning, got: {[str(w.message) for w in caught]}"
+    )
+
+    cursor.execute("DROP TABLE IF EXISTS #gh627_em_warn")
+    db_connection.commit()
+
+
 def test_gh627_temp_table_null_varbinary_warns(cursor, db_connection):
     """GH-627: Inserting NULL into a temp table VARBINARY column should emit a
     UserWarning about SQLDescribeParam fallback and setinputsizes workaround."""
     import warnings
+
+    from mssql_python.exceptions import ProgrammingError
 
     cursor.execute("CREATE TABLE #gh627_warn (id INT, data VARBINARY(50) NULL)")
     db_connection.commit()
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        try:
+        with pytest.raises(ProgrammingError):
             cursor.execute("INSERT INTO #gh627_warn (id, data) VALUES (?, ?)", [1, None])
-        except Exception:
-            pass  # Expected: implicit conversion error
 
     # At least one warning should mention SQLDescribeParam and setinputsizes
     assert any(

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -1058,52 +1058,36 @@ def test_gh627_varbinary_max_null(cursor, db_connection):
         db_connection.commit()
 
 
-def test_gh627_executemany_temp_table_warns(cursor, db_connection):
-    """GH-627: executemany with temp table + all-NULL VARBINARY column should
-    emit UserWarning (most common real-world failure scenario)."""
-    import warnings
-
+def test_gh627_executemany_temp_table_raises(cursor, db_connection):
+    """GH-627: executemany with temp table + all-NULL VARBINARY column raises
+    ProgrammingError due to SQL_VARCHAR fallback (SQLDescribeParam can't resolve
+    temp table metadata). Users should use setinputsizes to work around this."""
     from mssql_python.exceptions import ProgrammingError
 
     cursor.execute("CREATE TABLE #gh627_em_warn (id INT, data VARBINARY(50) NULL)")
     db_connection.commit()
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        with pytest.raises(ProgrammingError):
-            cursor.executemany(
-                "INSERT INTO #gh627_em_warn (id, data) VALUES (?, ?)",
-                [(1, None), (2, None)],
-            )
-
-    assert any(
-        "SQLDescribeParam failed" in str(w.message) for w in caught
-    ), f"Expected SQLDescribeParam warning, got: {[str(w.message) for w in caught]}"
+    with pytest.raises(ProgrammingError):
+        cursor.executemany(
+            "INSERT INTO #gh627_em_warn (id, data) VALUES (?, ?)",
+            [(1, None), (2, None)],
+        )
 
     cursor.execute("DROP TABLE IF EXISTS #gh627_em_warn")
     db_connection.commit()
 
 
-def test_gh627_temp_table_null_varbinary_warns(cursor, db_connection):
-    """GH-627: Inserting NULL into a temp table VARBINARY column should emit a
-    UserWarning about SQLDescribeParam fallback and setinputsizes workaround."""
-    import warnings
-
+def test_gh627_temp_table_null_varbinary_raises(cursor, db_connection):
+    """GH-627: Inserting NULL into a temp table VARBINARY column raises
+    ProgrammingError because SQLDescribeParam falls back to SQL_VARCHAR
+    and SQL Server rejects implicit varchar->varbinary conversion."""
     from mssql_python.exceptions import ProgrammingError
 
     cursor.execute("CREATE TABLE #gh627_warn (id INT, data VARBINARY(50) NULL)")
     db_connection.commit()
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        with pytest.raises(ProgrammingError):
-            cursor.execute("INSERT INTO #gh627_warn (id, data) VALUES (?, ?)", [1, None])
-
-    # At least one warning should mention SQLDescribeParam and setinputsizes
-    assert any(
-        "SQLDescribeParam failed" in str(w.message) and "setinputsizes" in str(w.message)
-        for w in caught
-    ), f"Expected SQLDescribeParam warning, got: {[str(w.message) for w in caught]}"
+    with pytest.raises(ProgrammingError):
+        cursor.execute("INSERT INTO #gh627_warn (id, data) VALUES (?, ?)", [1, None])
 
     cursor.execute("DROP TABLE IF EXISTS #gh627_warn")
     db_connection.commit()
@@ -1133,34 +1117,22 @@ def test_gh627_temp_table_setinputsizes_workaround(cursor, db_connection):
     db_connection.commit()
 
 
-def test_gh627_physical_table_no_fallback_warning(cursor, db_connection):
-    """GH-627: Physical tables should resolve via SQLDescribeParam without
-    triggering the fallback warning (only temp tables/CTEs trigger it)."""
-    import warnings
-
+def test_gh627_physical_table_null_varbinary_succeeds(cursor, db_connection):
+    """GH-627: Physical tables should resolve via SQLDescribeParam and
+    successfully bind NULL VARBINARY without error."""
     table_name = f"pytest_gh627_nocache_{uuid.uuid4().hex}"
+    try:
+        cursor.execute(f"CREATE TABLE {table_name} (id INT, data VARBINARY(50) NULL)")
+        db_connection.commit()
 
-    # First: use a physical table where SQLDescribeParam succeeds
-    cursor.execute(f"CREATE TABLE {table_name} (id INT, data VARBINARY(50) NULL)")
-    db_connection.commit()
-
-    # This should succeed without warnings (SQLDescribeParam works for physical tables)
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
         cursor.execute(f"INSERT INTO {table_name} (id, data) VALUES (?, ?)", [1, None])
-    db_connection.commit()
+        db_connection.commit()
 
-    # No SQLDescribeParam warning for physical tables
-    describe_warnings = [w for w in caught if "SQLDescribeParam failed" in str(w.message)]
-    assert (
-        len(describe_warnings) == 0
-    ), f"Should not warn for physical tables, got: {[str(w.message) for w in describe_warnings]}"
-
-    cursor.execute(f"SELECT data FROM {table_name}")
-    assert cursor.fetchone()[0] is None
-
-    cursor.execute(f"DROP TABLE {table_name}")
-    db_connection.commit()
+        cursor.execute(f"SELECT data FROM {table_name}")
+        assert cursor.fetchone()[0] is None
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        db_connection.commit()
 
 
 def test_varbinary_max(cursor, db_connection):

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -987,6 +987,9 @@ def test_gh627_temp_table_null_varbinary_warns(cursor, db_connection):
         for w in caught
     ), f"Expected SQLDescribeParam warning, got: {[str(w.message) for w in caught]}"
 
+    cursor.execute("DROP TABLE IF EXISTS #gh627_warn")
+    db_connection.commit()
+
 
 def test_gh627_temp_table_setinputsizes_workaround(cursor, db_connection):
     """GH-627: setinputsizes should resolve NULL VARBINARY binding in temp tables
@@ -994,8 +997,12 @@ def test_gh627_temp_table_setinputsizes_workaround(cursor, db_connection):
     cursor.execute("CREATE TABLE #gh627_fix (id INT, data VARBINARY(100) NULL)")
     db_connection.commit()
 
-    # Use setinputsizes to explicitly declare VARBINARY type (SQL_VARBINARY = -3)
-    cursor.setinputsizes([(4, 10, 0), (-3, 100, 0)])
+    # Use setinputsizes to explicitly declare types for all parameters
+    from mssql_python.constants import ConstantsDDBC
+
+    cursor.setinputsizes(
+        [(ConstantsDDBC.SQL_INTEGER.value, 10, 0), (ConstantsDDBC.SQL_VARBINARY.value, 100, 0)]
+    )
     cursor.execute("INSERT INTO #gh627_fix (id, data) VALUES (?, ?)", [1, None])
     db_connection.commit()
 
@@ -1003,6 +1010,9 @@ def test_gh627_temp_table_setinputsizes_workaround(cursor, db_connection):
     row = cursor.fetchone()
     assert row[0] == 1
     assert row[1] is None
+
+    cursor.execute("DROP TABLE IF EXISTS #gh627_fix")
+    db_connection.commit()
 
 
 def test_gh627_physical_table_no_fallback_warning(cursor, db_connection):

--- a/tests/test_004_cursor.py
+++ b/tests/test_004_cursor.py
@@ -871,6 +871,170 @@ def test_execute_none_into_varbinary_column(cursor, db_connection):
         drop_table_if_exists(cursor, "#test_varbinary_null")
 
 
+def test_gh627_execute_nonnull_before_null_varbinary(cursor, db_connection):
+    """GH-627: NULL VARBINARY should bind correctly when earlier params are non-NULL."""
+    table_name = f"pytest_gh627_execute_{uuid.uuid4().hex}"
+    try:
+        cursor.execute(f"CREATE TABLE {table_name} (id INT, data VARBINARY(32) NULL)")
+        db_connection.commit()
+
+        cursor.execute(
+            f"INSERT INTO {table_name} (id, data) VALUES (?, ?)",
+            [1, None],
+        )
+        db_connection.commit()
+
+        cursor.execute(f"SELECT id, data FROM {table_name}")
+        row = cursor.fetchone()
+        assert row[0] == 1
+        assert row[1] is None
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        db_connection.commit()
+
+
+def test_gh627_executemany_nonnull_before_null_varbinary(cursor, db_connection):
+    """GH-627: executemany all-NULL VARBINARY column should bind after non-NULL column."""
+    table_name = f"pytest_gh627_executemany_{uuid.uuid4().hex}"
+    try:
+        cursor.execute(f"CREATE TABLE {table_name} (id INT, data VARBINARY(32) NULL)")
+        db_connection.commit()
+
+        cursor.executemany(
+            f"INSERT INTO {table_name} (id, data) VALUES (?, ?)",
+            [(1, None), (2, None), (3, None)],
+        )
+        db_connection.commit()
+
+        cursor.execute(f"SELECT id, data FROM {table_name} ORDER BY id")
+        rows = cursor.fetchall()
+        assert rows == [[1, None], [2, None], [3, None]]
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        db_connection.commit()
+
+
+def test_gh627_null_then_nonnull_varbinary_reuse(cursor, db_connection):
+    """GH-627: Re-executing same SQL with NULL then non-NULL VARBINARY must work
+    (prepared statement + cache reuse path)."""
+    table_name = f"pytest_gh627_reuse_{uuid.uuid4().hex}"
+    try:
+        cursor.execute(f"CREATE TABLE {table_name} (id INT, data VARBINARY(32) NULL)")
+        db_connection.commit()
+
+        # First call: NULL — triggers SQLDescribeParam and caches VARBINARY type
+        cursor.execute(
+            f"INSERT INTO {table_name} (id, data) VALUES (?, ?)",
+            [1, None],
+        )
+        # Second call: non-NULL — reuses prepared stmt, cache entry should not interfere
+        cursor.execute(
+            f"INSERT INTO {table_name} (id, data) VALUES (?, ?)",
+            [2, b"\xde\xad\xbe\xef"],
+        )
+        db_connection.commit()
+
+        cursor.execute(f"SELECT id, data FROM {table_name} ORDER BY id")
+        rows = cursor.fetchall()
+        assert rows[0] == [1, None]
+        assert rows[1][0] == 2
+        assert rows[1][1] == b"\xde\xad\xbe\xef"
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        db_connection.commit()
+
+
+def test_gh627_execute_nonnull_before_null_binary(cursor, db_connection):
+    """GH-627: NULL BINARY (fixed-length) should bind correctly when earlier params are non-NULL."""
+    table_name = f"pytest_gh627_binary_{uuid.uuid4().hex}"
+    try:
+        cursor.execute(f"CREATE TABLE {table_name} (id INT, data BINARY(16) NULL)")
+        db_connection.commit()
+
+        cursor.execute(
+            f"INSERT INTO {table_name} (id, data) VALUES (?, ?)",
+            [1, None],
+        )
+        db_connection.commit()
+
+        cursor.execute(f"SELECT id, data FROM {table_name}")
+        row = cursor.fetchone()
+        assert row[0] == 1
+        assert row[1] is None
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        db_connection.commit()
+
+
+def test_gh627_temp_table_null_varbinary_warns(cursor, db_connection):
+    """GH-627: Inserting NULL into a temp table VARBINARY column should emit a
+    UserWarning about SQLDescribeParam fallback and setinputsizes workaround."""
+    import warnings
+
+    cursor.execute("CREATE TABLE #gh627_warn (id INT, data VARBINARY(50) NULL)")
+    db_connection.commit()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            cursor.execute("INSERT INTO #gh627_warn (id, data) VALUES (?, ?)", [1, None])
+        except Exception:
+            pass  # Expected: implicit conversion error
+
+    # At least one warning should mention SQLDescribeParam and setinputsizes
+    assert any(
+        "SQLDescribeParam failed" in str(w.message) and "setinputsizes" in str(w.message)
+        for w in caught
+    ), f"Expected SQLDescribeParam warning, got: {[str(w.message) for w in caught]}"
+
+
+def test_gh627_temp_table_setinputsizes_workaround(cursor, db_connection):
+    """GH-627: setinputsizes should resolve NULL VARBINARY binding in temp tables
+    where SQLDescribeParam cannot determine the column type."""
+    cursor.execute("CREATE TABLE #gh627_fix (id INT, data VARBINARY(100) NULL)")
+    db_connection.commit()
+
+    # Use setinputsizes to explicitly declare VARBINARY type (SQL_VARBINARY = -3)
+    cursor.setinputsizes([(4, 10, 0), (-3, 100, 0)])
+    cursor.execute("INSERT INTO #gh627_fix (id, data) VALUES (?, ?)", [1, None])
+    db_connection.commit()
+
+    cursor.execute("SELECT id, data FROM #gh627_fix")
+    row = cursor.fetchone()
+    assert row[0] == 1
+    assert row[1] is None
+
+
+def test_gh627_physical_table_no_fallback_warning(cursor, db_connection):
+    """GH-627: Physical tables should resolve via SQLDescribeParam without
+    triggering the fallback warning (only temp tables/CTEs trigger it)."""
+    import warnings
+
+    table_name = f"pytest_gh627_nocache_{uuid.uuid4().hex}"
+
+    # First: use a physical table where SQLDescribeParam succeeds
+    cursor.execute(f"CREATE TABLE {table_name} (id INT, data VARBINARY(50) NULL)")
+    db_connection.commit()
+
+    # This should succeed without warnings (SQLDescribeParam works for physical tables)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cursor.execute(f"INSERT INTO {table_name} (id, data) VALUES (?, ?)", [1, None])
+    db_connection.commit()
+
+    # No SQLDescribeParam warning for physical tables
+    describe_warnings = [w for w in caught if "SQLDescribeParam failed" in str(w.message)]
+    assert (
+        len(describe_warnings) == 0
+    ), f"Should not warn for physical tables, got: {[str(w.message) for w in describe_warnings]}"
+
+    cursor.execute(f"SELECT data FROM {table_name}")
+    assert cursor.fetchone()[0] is None
+
+    cursor.execute(f"DROP TABLE {table_name}")
+    db_connection.commit()
+
+
 def test_varbinary_max(cursor, db_connection):
     """Test SQL_VARBINARY with MAX length"""
     try:


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below 
For external contributors: Insert Github Issue number below
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> [AB#45521](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/45521)

<!-- External contributors: GitHub Issue -->
> GitHub Issue: #627 

-------------------------------------------------------------------
### Summary   
This pull request significantly improves how the driver resolves SQL types for NULL parameters, especially when inserting into temp tables or table variables. It proactively resolves unknown NULL parameter types before binding, emits actionable Python warnings when automatic type resolution fails, and provides clear guidance on using `setinputsizes` to avoid SQL Server implicit conversion errors. Additionally, the code is refactored for clarity and efficiency, and minor formatting improvements are made.

**Improvements to NULL parameter type resolution:**
- Added a new `PreResolveUnknownNullTypes` function to proactively resolve unknown NULL SQL types for both single and batch execution paths, ensuring all types are determined before any parameters are bound. This prevents driver errors with binary NULLs and improves reliability. 
- When SQL type resolution falls back to `SQL_VARCHAR` (because `SQLDescribeParam` fails), the code now emits a Python warning with detailed guidance on how to use `cursor.setinputsizes()` to specify the correct type, preventing common SQL Server errors with BINARY/VARBINARY columns.

**Documentation and user guidance:**
- Expanded the `setinputsizes` docstring in `cursor.py` to document the temp table/NULL issue and provide a concrete usage example for binary columns.

**Code structure and clarity:**
- Refactored parameter binding code to avoid redundant type resolution during binding, since types are now resolved in advance. 
- Added a `bool isFallback` field to `DescribedParamInfo` to track when a fallback type is used.

**Minor improvements:**
- Made minor formatting and whitespace changes for improved readability.