### PR TITLE
RELEASE:1.11.0

### DIFF
--- a/PyPI_Description.md
+++ b/PyPI_Description.md
@@ -35,16 +35,15 @@ PyBind11 provides:
 - Memory-safe bindings
 - Clean and Pythonic API, while performance-critical logic remains in robust, maintainable C++.
  
-## What's new in v1.10.0
-
-### Enhancements
-
-- **Active Directory Service Principal for Bulk Copy** - `bulkcopy` now supports `Authentication=ActiveDirectoryServicePrincipal`, acquiring tokens mid-handshake via a registered callback so service principal credentials work for bulk inserts (#576).
+## What's new in v1.11.0
 
 ### Bug Fixes
 
-- **Non-ASCII VARCHAR in Arrow Fetch** - The arrow fetch path now requests `SQL_CHAR` data as `SQL_C_WCHAR` (UTF-16LE), ensuring correct results regardless of encoding settings, locale, or operating system (#575).
-- **Bulk Load Connection Timeouts** - Fixed connection timeouts during bulk load operations (#641, via `mssql_py_core` 0.1.5).
+- **SSH-Tunnel / In-Process Forwarder Deadlock** - The driver now releases the GIL around blocking ODBC teardown calls (`SQLFreeHandle`/`SQLFreeStmt`) and `SQLDescribeParam`, preventing deadlocks when the connection is routed through an in-process Python TCP forwarder (#604).
+- **BINARY/VARBINARY NULL Parameters in Temp Tables** - Unknown NULL parameter types are now pre-resolved before binding, with actionable `setinputsizes` guidance, fixing errors when inserting NULL binary values into temp tables or table variables (#654).
+- **Context Manager Transaction Semantics** - The `Connection` context manager now commits on clean exit and rolls back on exception (with `autocommit=False`), matching the documented behavior (#639).
+- **macOS Apple Silicon Import Failure** - Bundled macOS ODBC dylibs are now configured for all shipped architectures, so `import mssql_python` works on Apple Silicon without requiring a separate `brew install unixodbc` (#661).
+- **Service Principal Bulk Copy Freeze** - Fixed a GIL-deadlock that froze `bulkcopy` when authenticating with a service principal (#666, via `mssql_py_core` 0.1.6).
 
 For more information, please visit the project link on Github: https://github.com/microsoft/mssql-python
  

--- a/mssql_python/__init__.py
+++ b/mssql_python/__init__.py
@@ -14,7 +14,7 @@ import weakref
 from .helpers import Settings, get_settings, _settings, _settings_lock
 
 # Driver version
-__version__ = "1.10.0"
+__version__ = "1.11.0"
 
 # Exceptions
 # https://www.python.org/dev/peps/pep-0249/#exceptions

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ package_data = {
 
 setup(
     name="mssql-python",
-    version="1.10.0",
+    version="1.11.0",
     description="A Python library for interacting with Microsoft SQL Server",
     long_description=open("PyPI_Description.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Release mssql-python v1.11.0.

[AB#46332](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/46332)

### Summary

Version bump to 1.11.0. Updates `mssql_python/__init__.py`, `setup.py`, and `PyPI_Description.md`. Bundled `mssql_py_core` bumped from 0.1.5 to 0.1.6.

#### Bug Fixes

- **SSH-tunnel / in-process forwarder deadlock** — Release the GIL around blocking ODBC round-trips in the teardown path and `SQLDescribeParam`, so `close()` and parametrized queries with `None` values no longer deadlock in-process TCP forwarder setups (#604, issue #565).
- **BINARY/VARBINARY NULL parameters in temp tables and table variables** — Proactively resolve unknown NULL parameter types before binding and emit actionable `setinputsizes()` guidance on `SQL_VARCHAR` fallback (#654, issue #627).
- **Context manager transaction semantics** — `Connection.__exit__` now commits on clean exit and rolls back on exception when `autocommit=False`, instead of always rolling back (#639, issue #635).
- **macOS Apple Silicon import failure** — `configure_dylibs.sh` rewrites bundled ODBC dylib dependencies to `@loader_path` for every architecture in the universal2 wheel, fixing `import mssql_python` on clean Apple Silicon machines (#661, issue #656).
- **Service Principal bulk copy freeze** — Fixed a GIL-deadlock in the Rust core that froze bulk copy under `ActiveDirectoryServicePrincipal` auth; picked up via the `mssql_py_core` 0.1.6 bump (#666, issue #662).

#### Version Bump

- `mssql_python/__init__.py`: `__version__ = "1.11.0"`
- `setup.py`: `version="1.11.0"`
- `PyPI_Description.md`: `## What's new in v1.11.0` section refreshed.
