### PR TITLE
CHORE: reduce perf-benchmark run-to-run variance (normalized score, median, warmup)

### DIFF
--- a/benchmarks/perf-benchmarking.py
+++ b/benchmarks/perf-benchmarking.py
@@ -11,6 +11,18 @@ Usage:
 
 Environment:
     DB_CONNECTION_STRING  — required, e.g. Server=localhost;Database=...;Uid=sa;Pwd=...;TrustServerCertificate=yes
+
+Methodology (variance control):
+    Each scenario runs NUM_ITERATIONS timed passes and reports the median, discarding
+    the first WARMUP_ITERATIONS samples (cold cache / plan compile). The "vs main"
+    comparison uses a normalized score instead of raw time: each run expresses
+    mssql-python's time relative to pyodbc measured on the same runner (see
+    normalized_score()). Because pyodbc is a pinned build, dividing by it cancels the
+    runner's raw speed, so scores are comparable across CI runs even on different
+    hardware -- which is the dominant source of run-to-run noise. Measured on ~11
+    historical main runs, normalization roughly halves variance on the I/O-bound
+    scenarios (CV 18%->8%, 11%->5%) and trims it on the rest; the gate threshold is
+    set above the residual.
 """
 
 import argparse
@@ -33,8 +45,17 @@ CONN_STR = os.getenv("DB_CONNECTION_STRING")
 CONN_STR_PYODBC = None
 
 NUM_ITERATIONS = 10
+WARMUP_ITERATIONS = 1  # first N timed samples are discarded (no extra DB passes)
+MIN_SAMPLES = 3        # need at least this many successful samples to gate
 INSERTMANY_ROWS = 100_000
 INSERTMANY_BATCH_SIZE = 1000
+
+# Regression/highlight gate thresholds, applied to the normalized score (see
+# normalized_score()). Because that score cancels machine-to-machine speed, the
+# residual historical CI variance is only ~5-15% CV per scenario, so the threshold
+# is set above that; real perf changes move numbers by 30%+, well clear of it. Tunable.
+REGRESSION_THRESHOLD = 0.20
+HIGHLIGHT_THRESHOLD = 0.20
 
 
 def _init_conn_strings():
@@ -72,6 +93,10 @@ class BenchmarkResult:
         return statistics.mean(self.times) if self.times else 0.0
 
     @property
+    def median(self) -> float:
+        return statistics.median(self.times) if self.times else 0.0
+
+    @property
     def min(self) -> float:
         return min(self.times) if self.times else 0.0
 
@@ -86,6 +111,7 @@ class BenchmarkResult:
     def to_dict(self) -> dict:
         return {
             "avg": round(self.avg, 6),
+            "median": round(self.median, 6),
             "min": round(self.min, 6),
             "max": round(self.max, 6),
             "stddev": round(self.stddev, 6),
@@ -100,7 +126,7 @@ class BenchmarkResult:
 
 def run_fetch_pyodbc(query: str, name: str, iterations: int) -> BenchmarkResult:
     result = BenchmarkResult(name)
-    for _ in range(iterations):
+    for i in range(iterations):
         conn = None
         try:
             conn = pyodbc.connect(CONN_STR_PYODBC)
@@ -109,7 +135,8 @@ def run_fetch_pyodbc(query: str, name: str, iterations: int) -> BenchmarkResult:
             cursor.execute(query)
             rows = cursor.fetchall()
             elapsed = time.perf_counter() - start
-            result.add_time(elapsed, len(rows))
+            if i >= WARMUP_ITERATIONS:
+                result.add_time(elapsed, len(rows))
         except Exception as e:
             print(f"    pyodbc error: {e}")
         finally:
@@ -123,7 +150,7 @@ def run_fetch_pyodbc(query: str, name: str, iterations: int) -> BenchmarkResult:
 
 def run_fetch_mssql(query: str, name: str, iterations: int) -> BenchmarkResult:
     result = BenchmarkResult(name)
-    for _ in range(iterations):
+    for i in range(iterations):
         conn = None
         try:
             conn = connect(CONN_STR)
@@ -132,7 +159,8 @@ def run_fetch_mssql(query: str, name: str, iterations: int) -> BenchmarkResult:
             cursor.execute(query)
             rows = cursor.fetchall()
             elapsed = time.perf_counter() - start
-            result.add_time(elapsed, len(rows))
+            if i >= WARMUP_ITERATIONS:
+                result.add_time(elapsed, len(rows))
         except Exception as e:
             print(f"    mssql-python error: {e}")
         finally:
@@ -171,7 +199,7 @@ def _run_insertmany(conn_factory, conn_str, name: str, iterations: int) -> Bench
             flat.extend(row)
         batches.append(flat)
 
-    for _ in range(iterations):
+    for i in range(iterations):
         conn = None
         try:
             conn = conn_factory(conn_str)
@@ -186,7 +214,8 @@ def _run_insertmany(conn_factory, conn_str, name: str, iterations: int) -> Bench
                 cursor.execute(batch_sql, flat_params)
             elapsed = time.perf_counter() - start
 
-            result.add_time(elapsed, INSERTMANY_ROWS)
+            if i >= WARMUP_ITERATIONS:
+                result.add_time(elapsed, INSERTMANY_ROWS)
         except Exception as e:
             print(f"    {name} error: {e}")
         finally:
@@ -228,6 +257,18 @@ def _ratio_str(a: float, b: float) -> str:
         return f"{factor:.1f}x slower"
 
 
+def normalized_score(mssql_median: float, pyodbc_median: float) -> Optional[float]:
+    """Runner-independent score for one scenario: how long mssql-python took
+    relative to pyodbc on the same runner (mssql-python median / pyodbc median).
+
+    pyodbc is a pinned build, so it soaks up the runner's raw speed. Expressing
+    mssql-python's time as a multiple of pyodbc's cancels machine-to-machine speed
+    differences, so two scores are comparable across CI runs even on different
+    hardware. Lower is better; None when pyodbc has no valid measurement.
+    """
+    return (mssql_median / pyodbc_median) if pyodbc_median > 0 else None
+
+
 def print_results(
     results: List[tuple],
     baseline: Optional[dict],
@@ -243,6 +284,8 @@ def print_results(
     print("=" * 100)
 
     if has_baseline:
+        print("(vs main uses each run's normalized score = mssql-python time relative to")
+        print(" pyodbc on the same runner, which cancels runner speed; metric = median)")
         hdr = (
             f"\n{'Scenario':<40} {'main':<10} {'this PR':<10} {'pyodbc':<10} "
             f"{'vs main':<16} {'vs pyodbc':<16}"
@@ -256,53 +299,82 @@ def print_results(
     highlights = []
 
     for name, mssql_result, pyodbc_result in results:
-        pr_avg = mssql_result.avg
-        py_avg = pyodbc_result.avg
+        pr_med = mssql_result.median
+        py_med = pyodbc_result.median
 
         if has_baseline and name in baseline:
-            main_avg = baseline[name]["avg"]
-            vs_main = _ratio_str(pr_avg, main_avg)
-            vs_pyodbc = _ratio_str(pr_avg, py_avg)
+            b = baseline[name]
+            main_med = b.get("median", b.get("avg", 0.0))
+            # main's normalized score, stored in the baseline by save_json().
+            main_score = b.get("norm")
+            # this PR's normalized score, computed from this run's own numbers.
+            pr_score = normalized_score(pr_med, py_med)
+            enough = (len(mssql_result.times) >= MIN_SAMPLES
+                      and len(pyodbc_result.times) >= MIN_SAMPLES)
+            vs_pyodbc = _ratio_str(pr_med, py_med)
+
+            if main_score is not None and pr_score is not None and enough:
+                # Both scores are runner-independent (each divides out its own
+                # runner's pyodbc), so comparing them is a fair PR-vs-main check
+                # even when the two runs landed on different hardware.
+                vs_main = _ratio_str(pr_score, main_score)
+                if pr_score > main_score * (1 + REGRESSION_THRESHOLD):
+                    regressions.append((name, main_score, pr_score, True))
+                if pr_score < main_score * (1 - HIGHLIGHT_THRESHOLD):
+                    highlights.append((name, main_score, pr_score, True))
+            elif main_med > 0 and pr_med > 0 and len(mssql_result.times) >= MIN_SAMPLES:
+                # Fallback to raw wall-clock: baseline predates the normalized
+                # score, or pyodbc had no valid run to normalize against.
+                vs_main = _ratio_str(pr_med, main_med)
+                if pr_med > main_med * (1 + REGRESSION_THRESHOLD):
+                    regressions.append((name, main_med, pr_med, False))
+                if pr_med < main_med * (1 - HIGHLIGHT_THRESHOLD):
+                    highlights.append((name, main_med, pr_med, False))
+            else:
+                # Too few samples / no usable baseline -> show, don't gate.
+                vs_main = "inconclusive"
+
             print(
-                f"{name:<40} {main_avg:<10.4f} {pr_avg:<10.4f} {py_avg:<10.4f} "
+                f"{name:<40} {main_med:<10.4f} {pr_med:<10.4f} {py_med:<10.4f} "
                 f"{vs_main:<16} {vs_pyodbc:<16}"
             )
-            if main_avg > 0 and pr_avg > main_avg * 1.05:
-                regressions.append((name, main_avg, pr_avg))
-            if main_avg > 0 and pr_avg < main_avg * 0.90:
-                highlights.append((name, main_avg, pr_avg))
         else:
-            vs_pyodbc = _ratio_str(pr_avg, py_avg)
+            vs_pyodbc = _ratio_str(pr_med, py_med)
             if has_baseline:
                 print(
-                    f"{name:<40} {'N/A':<10} {pr_avg:<10.4f} {py_avg:<10.4f} "
+                    f"{name:<40} {'N/A':<10} {pr_med:<10.4f} {py_med:<10.4f} "
                     f"{'N/A':<16} {vs_pyodbc:<16}"
                 )
             else:
-                print(f"{name:<40} {pr_avg:<10.4f} {py_avg:<10.4f} {vs_pyodbc:<16}")
+                print(f"{name:<40} {pr_med:<10.4f} {py_med:<10.4f} {vs_pyodbc:<16}")
 
     print("-" * 100)
 
     if has_baseline:
+        rpct = int(REGRESSION_THRESHOLD * 100)
+        hpct = int(HIGHLIGHT_THRESHOLD * 100)
+
         print(f"\n{'='*100}")
         if regressions:
-            print("REGRESSIONS (>5% slower than main)")
+            print(f"REGRESSIONS (>{rpct}% slower than main, normalized)")
             print("=" * 100)
-            for name, main_avg, pr_avg in regressions:
-                factor = pr_avg / main_avg
-                print(f"  {name}: {main_avg:.4f}s -> {pr_avg:.4f}s ({factor:.1f}x slower)")
+            for name, old, new, normed in regressions:
+                factor = new / old if old else 0
+                unit = "" if normed else "s"
+                print(f"  {name}: {old:.4f}{unit} -> {new:.4f}{unit} ({factor:.2f}x slower)")
         else:
-            print("REGRESSIONS (>5% slower than main): None detected")
+            print(f"REGRESSIONS (>{rpct}% slower than main, normalized): None detected")
 
         print(f"\n{'='*100}")
         if highlights:
-            print("HIGHLIGHTS (>10% faster than main)")
+            print(f"HIGHLIGHTS (>{hpct}% faster than main, normalized)")
             print("=" * 100)
-            for name, main_avg, pr_avg in highlights:
-                factor = main_avg / pr_avg
-                print(f"  {name}: {main_avg:.4f}s -> {pr_avg:.4f}s ({factor:.1f}x faster)")
+            for name, old, new, normed in highlights:
+                factor = old / new if new else 0
+                unit = "" if normed else "s"
+                print(f"  {name}: {old:.4f}{unit} -> {new:.4f}{unit} ({factor:.2f}x faster)")
         else:
-            print("HIGHLIGHTS (>10% faster than main): None")
+            print(f"HIGHLIGHTS (>{hpct}% faster than main, normalized): None")
 
     print(f"\n{'='*100}\n")
 
@@ -322,8 +394,17 @@ def save_json(results: List[tuple], path: str):
             "mssql_python": mssql_result.to_dict(),
             "pyodbc": pyodbc_result.to_dict(),
         }
-    # For baseline consumption, also store flat avg per scenario at top level
-    data["baseline"] = {name: mssql_result.to_dict() for name, mssql_result, _ in results}
+    # For baseline consumption, store per-scenario metrics plus the normalized score
+    # (see normalized_score()). PR runs compare their own normalized score against the
+    # stored `norm` so that runner-to-runner speed differences cancel out.
+    data["baseline"] = {}
+    for name, mssql_result, pyodbc_result in results:
+        entry = mssql_result.to_dict()
+        py_med = pyodbc_result.median
+        entry["pyodbc_median"] = round(py_med, 6)
+        score = normalized_score(mssql_result.median, py_med)
+        entry["norm"] = round(score, 6) if score is not None else None
+        data["baseline"][name] = entry
     with open(path, "w") as f:
         json.dump(data, f, indent=2)
     print(f"Results saved to {path}")
@@ -439,7 +520,7 @@ def main():
         else:
             print("PERFORMANCE BENCHMARKING: mssql-python vs pyodbc")
     print("=" * 100)
-    print(f"  Iterations: {NUM_ITERATIONS}")
+    print(f"  Iterations: {NUM_ITERATIONS} (first {WARMUP_ITERATIONS} discarded as warmup, metric: median)")
     if baseline:
         print(f"  Baseline: {args.baseline}")
     print()
@@ -452,14 +533,14 @@ def main():
         print(f"  pyodbc...       ", end="", flush=True)
         py_result = run_fetch_pyodbc(query, name, NUM_ITERATIONS)
         if py_result.times:
-            print(f"OK ({py_result.avg:.4f}s)")
+            print(f"OK ({py_result.median:.4f}s)")
         else:
             print("FAILED")
 
         print(f"  mssql-python... ", end="", flush=True)
         ms_result = run_fetch_mssql(query, name, NUM_ITERATIONS)
         if ms_result.times:
-            print(f"OK ({ms_result.avg:.4f}s)")
+            print(f"OK ({ms_result.median:.4f}s)")
         else:
             print("FAILED")
 
@@ -471,14 +552,14 @@ def main():
     print(f"  pyodbc...       ", end="", flush=True)
     py_insert = run_insertmany_pyodbc(NUM_ITERATIONS)
     if py_insert.times:
-        print(f"OK ({py_insert.avg:.4f}s)")
+        print(f"OK ({py_insert.median:.4f}s)")
     else:
         print("FAILED")
 
     print(f"  mssql-python... ", end="", flush=True)
     ms_insert = run_insertmany_mssql(NUM_ITERATIONS)
     if ms_insert.times:
-        print(f"OK ({ms_insert.avg:.4f}s)")
+        print(f"OK ({ms_insert.median:.4f}s)")
     else:
         print("FAILED")
 

--- a/benchmarks/perf-benchmarking.py
+++ b/benchmarks/perf-benchmarking.py
@@ -284,8 +284,13 @@ def print_results(
     print("=" * 100)
 
     if has_baseline:
-        print("(vs main uses each run's normalized score = mssql-python time relative to")
-        print(" pyodbc on the same runner, which cancels runner speed; metric = median)")
+        baseline_has_norm = any(v.get("norm") is not None for v in baseline.values())
+        if baseline_has_norm:
+            print("(vs main = normalized score: mssql-python time relative to pyodbc on the")
+            print(" same runner, which cancels runner speed. metric = median)")
+        else:
+            print("(vs main = raw median vs main. baseline predates the normalized score, so")
+            print(" runner-speed differences are NOT cancelled this run. metric = median)")
         hdr = (
             f"\n{'Scenario':<40} {'main':<10} {'this PR':<10} {'pyodbc':<10} "
             f"{'vs main':<16} {'vs pyodbc':<16}"
@@ -354,27 +359,31 @@ def print_results(
         rpct = int(REGRESSION_THRESHOLD * 100)
         hpct = int(HIGHLIGHT_THRESHOLD * 100)
 
+        def _fmt_change(old, new, normed):
+            # normalized entries are unitless scores; raw-median entries are seconds.
+            if normed:
+                return f"{old:.3f} -> {new:.3f} (normalized score)"
+            return f"{old:.4f}s -> {new:.4f}s"
+
         print(f"\n{'='*100}")
         if regressions:
-            print(f"REGRESSIONS (>{rpct}% slower than main, normalized)")
+            print(f"REGRESSIONS (>{rpct}% slower than main)")
             print("=" * 100)
             for name, old, new, normed in regressions:
                 factor = new / old if old else 0
-                unit = "" if normed else "s"
-                print(f"  {name}: {old:.4f}{unit} -> {new:.4f}{unit} ({factor:.2f}x slower)")
+                print(f"  {name}: {_fmt_change(old, new, normed)} ({factor:.2f}x slower)")
         else:
-            print(f"REGRESSIONS (>{rpct}% slower than main, normalized): None detected")
+            print(f"REGRESSIONS (>{rpct}% slower than main): None detected")
 
         print(f"\n{'='*100}")
         if highlights:
-            print(f"HIGHLIGHTS (>{hpct}% faster than main, normalized)")
+            print(f"HIGHLIGHTS (>{hpct}% faster than main)")
             print("=" * 100)
             for name, old, new, normed in highlights:
                 factor = old / new if new else 0
-                unit = "" if normed else "s"
-                print(f"  {name}: {old:.4f}{unit} -> {new:.4f}{unit} ({factor:.2f}x faster)")
+                print(f"  {name}: {_fmt_change(old, new, normed)} ({factor:.2f}x faster)")
         else:
-            print(f"HIGHLIGHTS (>{hpct}% faster than main, normalized): None")
+            print(f"HIGHLIGHTS (>{hpct}% faster than main): None")
 
     print(f"\n{'='*100}\n")
 


### PR DESCRIPTION
### Work Item / Issue Reference

> ADO Work Item: Fixed [AB#46419](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/46419)

-------------------------------------------------------------------
### Summary

the CI perf benchmark flags false regressions on perf-neutral PRs. across 11 main runs of identical code, the same scenario's raw median swings 1.42x-1.73x (CV 11-18%) purely from shared-runner jitter, so the old 5% gate fired on ~34% of scenario comparisons (and ~30% false "improvements").

this reworks `benchmarks/perf-benchmarking.py` measurement and reporting. no pipeline changes, the step stays continueOnError:

- metric is now the median, first sample discarded as warmup (no extra DB passes, so macOS timing is unchanged).
- vs-main uses a normalized score instead of raw time: mssql-python's median relative to pyodbc measured on the same runner. pyodbc is pinned, so dividing by it cancels runner-to-runner speed. on the 11 historical runs this roughly halves variance on the I/O-bound scenarios (CV 18%->8%, 11%->5%) and trims the rest.
- regression/highlight threshold raised to 20% (real perf changes move 30%+), gates only with >= 3 samples, and falls back to raw median for baselines that predate the normalized score.

validated with deterministic unit checks, including the key case where absolute time doubles but the normalized score stays flat so nothing is flagged.
