### PR TITLE
CHORE: Couple mssql-python to mssql-python-odbc==18.6.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -191,6 +191,7 @@ setup(
     # Add dependencies
     install_requires=[
         "azure-identity>=1.12.0",  # Azure authentication library
+        "mssql-python-odbc==18.6.2",  # ODBC Driver 18 binaries (standalone package)
     ],
     extras_require={
         "pyarrow": ["pyarrow>=14.0.0"],

--- a/setup.py
+++ b/setup.py
@@ -122,8 +122,13 @@ class CustomBdistWheel(bdist_wheel):
 # Package discovery
 # ---------------------------------------------------------------------------
 
-# Find all packages in the current directory
-packages = find_packages()
+# Find all packages in the current directory.
+# Exclude mssql_python_odbc: it is shipped exclusively by the standalone
+# mssql-python-odbc distribution (see setup_odbc.py) and pulled in via
+# install_requires. Shipping it here too would make two distributions own the
+# same import directory (install-order file overwrites; uninstall of one can
+# remove files the other needs).
+packages = find_packages(exclude=["mssql_python_odbc", "mssql_python_odbc.*"])
 
 # Get platform info using consolidated function
 arch, platform_tag = get_platform_info()


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below 
For external contributors: Insert Github Issue number below
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> [AB#46586](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/46586)

-------------------------------------------------------------------
### Summary
This pull request updates the packaging configuration in `setup.py` to improve dependency management and avoid conflicts between distributions. The main changes ensure that the `mssql_python_odbc` package is no longer included directly in this distribution, but is instead required as an explicit dependency.

**Dependency management improvements:**

* Updated the `find_packages` call to exclude the `mssql_python_odbc` package and its submodules, preventing duplicate ownership of the same import directory and potential uninstall issues.
* Added `mssql-python-odbc==18.6.2` to `install_requires`, ensuring the required ODBC driver binaries are installed as a dependency rather than bundled directly.


