### PR TITLE
RELEASE:1.12.0

### DIFF
--- a/PyPI_Description.md
+++ b/PyPI_Description.md
@@ -35,15 +35,16 @@ PyBind11 provides:
 - Memory-safe bindings
 - Clean and Pythonic API, while performance-critical logic remains in robust, maintainable C++.
  
-## What's new in v1.11.0
+## What's new in v1.12.0
+
+### Enhancements
+
+- **Standalone `mssql-python-odbc` Package** - The bundled ODBC driver binaries are now also published as a separate, pure-data package `mssql-python-odbc` (import name `mssql_python_odbc`, version 18.6.2). `mssql-python` now depends on `mssql-python-odbc==18.6.2` and prefers the external package at import time, falling back to the still-bundled `libs/` tree so existing installs keep working (#663, #687).
 
 ### Bug Fixes
 
-- **SSH-Tunnel / In-Process Forwarder Deadlock** - The driver now releases the GIL around blocking ODBC teardown calls (`SQLFreeHandle`/`SQLFreeStmt`) and `SQLDescribeParam`, preventing deadlocks when the connection is routed through an in-process Python TCP forwarder (#604).
-- **BINARY/VARBINARY NULL Parameters in Temp Tables** - Unknown NULL parameter types are now pre-resolved before binding, with actionable `setinputsizes` guidance, fixing errors when inserting NULL binary values into temp tables or table variables (#654).
-- **Context Manager Transaction Semantics** - The `Connection` context manager now commits on clean exit and rolls back on exception (with `autocommit=False`), matching the documented behavior (#639).
-- **macOS Apple Silicon Import Failure** - Bundled macOS ODBC dylibs are now configured for all shipped architectures, so `import mssql_python` works on Apple Silicon without requiring a separate `brew install unixodbc` (#661).
-- **Service Principal Bulk Copy Freeze** - Fixed a GIL-deadlock that froze `bulkcopy` when authenticating with a service principal (#666, via `mssql_py_core` 0.1.6).
+- **Bulk Copy Connection Timeout** - `cursor.bulkcopy()` now forwards the cursor's connection timeout (from `connect(timeout=X)`) into the underlying `mssql_py_core` connection, instead of always using the hardcoded 15s default (#650).
+- **Bulk Copy of Custom CLR UDT Columns** - Fixed a `Protocol Error: Unsupported TDS type for bulk copy: 0xF0` that prevented `cursor.bulkcopy()` from loading rows into custom (non-spatial) CLR UDT columns; UDT columns are now mapped to `varbinary(max)` on the wire and the supplied bytes are streamed as the UDT's serialized form (#688, via `mssql_py_core` 0.1.7).
 
 For more information, please visit the project link on Github: https://github.com/microsoft/mssql-python
  

--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ The driver is compatible with all the Python versions >= 3.10
 > **Note:**
 > This project is now Generally Available (GA) and ready for production use. We’ve completed core functionality and incorporated feedback from the preview phase.
 > 
+> **Important Note:**
+>
+> ### ODBC Driver Distribution
+> The ODBC driver binaries used by `mssql-python` are now distributed through a dedicated companion package:
+>
+> - Package: `mssql-python-odbc`
+> - Import name: `mssql_python_odbc`
+> - Current version: **18.6.2**
+>
+> When installed, `mssql-python` automatically depends on and loads the ODBC driver binaries from `mssql-python-odbc`.
+>
+> To ensure a smooth transition, the current release retains the bundled binaries within the `libs/` directory and uses them as a fallback if the external package is unavailable. Existing installations will continue to work without modification.
+>
+> **Note:** The bundled `libs/` fallback is deprecated and will be removed in a future release. Beginning with a subsequent release, the ODBC binaries will be supplied exclusively through the `mssql-python-odbc` package. We recommend validating environments against the standalone package ahead of this change.
+
 ## Installation
  
 **Windows:** mssql-python can be installed with [pip](http://pypi.python.org/pypi/pip)

--- a/mssql_python/__init__.py
+++ b/mssql_python/__init__.py
@@ -14,7 +14,7 @@ import weakref
 from .helpers import Settings, get_settings, _settings, _settings_lock
 
 # Driver version
-__version__ = "1.11.0"
+__version__ = "1.12.0"
 
 # Exceptions
 # https://www.python.org/dev/peps/pep-0249/#exceptions

--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ package_data = {
 
 setup(
     name="mssql-python",
-    version="1.11.0",
+    version="1.12.0",
     description="A Python library for interacting with Microsoft SQL Server",
     long_description=open("PyPI_Description.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
### Work Item / Issue Reference

> [AB#46627](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/46627)

-------------------------------------------------------------------
### Summary

Release mssql-python v1.12.0.

Version bump to 1.12.0. Updates `mssql_python/__init__.py`, `setup.py`, and `PyPI_Description.md`. Bundled `mssql_py_core` bumped from 0.1.6 to 0.1.7.

#### Enhancements

- **Standalone `mssql-python-odbc` package** — ODBC driver binaries are now also published as a separate, pure-data companion package `mssql-python-odbc` (import name `mssql_python_odbc`, version 18.6.2). `mssql-python` declares it in `install_requires` and prefers the external package at import time, falling back to the still-bundled `libs/` tree so existing installs keep working (#663, #687).

#### Bug Fixes

- **Bulk copy connection timeout** — `cursor.bulkcopy()` now forwards the cursor's connection timeout (from `connect(timeout=X)`) into the underlying `mssql_py_core` connection, instead of always using the hardcoded 15s default (#650, issue #626).
- **Bulk copy of custom CLR UDT columns** — Fixed `Protocol Error: Unsupported TDS type for bulk copy: 0xF0` on `cursor.bulkcopy()` into custom (non-spatial) CLR UDT columns; UDT columns are now mapped to `varbinary(max)` on the wire (#688, via `mssql_py_core` 0.1.7, issue #667).

#### Version Bump

- `mssql_python/__init__.py`: `__version__ = "1.12.0"`
- `setup.py`: `version="1.12.0"`
- `PyPI_Description.md`: `## What's new in v1.12.0` section refreshed.