### PR TITLE
CHORE: use Server=localhost in dummy test/benchmark connection strings

### DIFF
--- a/benchmarks/bench_bulkcopy_arrow.py
+++ b/benchmarks/bench_bulkcopy_arrow.py
@@ -20,7 +20,7 @@ noise (see --csv for the full record). GC is disabled around each timed call.
 
 Usage (PowerShell)
 ------------------
-    $env:DB_CONNECTION_STRING = "Server=...;Database=...;UID=...;PWD=...;TrustServerCertificate=yes;"
+    $env:DB_CONNECTION_STRING = "Server=localhost;Database=...;UID=...;PWD=...;TrustServerCertificate=yes;"
     python benchmarks\bench_bulkcopy_arrow.py
     python benchmarks\bench_bulkcopy_arrow.py --rows 1000 10000 100000 --repeats 7
     python benchmarks\bench_bulkcopy_arrow.py --profiles narrow mixed decimal

--- a/tests/test_008_auth.py
+++ b/tests/test_008_auth.py
@@ -1663,7 +1663,7 @@ class TestTokenProviderValidation:
 
         with pytest.warns(UserWarning, match="credential\\(s\\) are ignored"):
             conn = connect(
-                "Server=test;Database=testdb;UID=user@test.com;PWD=secret",
+                "Server=localhost;Database=testdb;UID=user@test.com;PWD=secret",
                 token_provider=mock_cred,
             )
         conn.close()
@@ -2932,7 +2932,7 @@ class TestConnectionPoolKey:
         mock_ddbc_conn.return_value = MagicMock()
         from mssql_python import connect
 
-        conn = connect("Server=test;Database=testdb;UID=sa;PWD=secret")
+        conn = connect("Server=localhost;Database=testdb;UID=sa;PWD=secret")
         assert conn._pool_key == ""
         # Native Connection received the empty pool key as the 4th positional arg.
         args, _ = mock_ddbc_conn.call_args
@@ -3336,7 +3336,7 @@ class TestConnectionStringNulRejection:
         from mssql_python import connect
 
         with pytest.raises(InterfaceError, match="NUL"):
-            connect("Server=test;Database=t\x00est;UID=sa;PWD=secret")
+            connect("Server=localhost;Database=t\x00est;UID=sa;PWD=secret")
         # Fail closed: rejected before any native Connection is built.
         mock_ddbc_conn.assert_not_called()
 

--- a/tests/test_024_bulkcopy_arrow.py
+++ b/tests/test_024_bulkcopy_arrow.py
@@ -236,7 +236,7 @@ class TestBuildPycoreContext:
             cur._build_pycore_context()
 
     def test_sql_auth_keeps_credentials(self):
-        cur = _cursor_with_conn("Server=testhost;Database=testdb;UID=sa;PWD=mypwd", auth_type=None)
+        cur = _cursor_with_conn("Server=localhost;Database=testdb;UID=sa;PWD=mypwd", auth_type=None)
         ctx = cur._build_pycore_context()
         assert ctx.get("user_name") == "sa"
         assert ctx.get("password") == "mypwd"
@@ -361,7 +361,7 @@ class TestBulkcopyArrowDispatch:
     @patch("mssql_python.cursor.logger")
     def test_success_returns_result_and_forwards_args(self, mock_logger):
         mock_logger.is_debug_enabled = False
-        cur = _cursor_with_conn("Server=testhost;Database=d;UID=sa;PWD=p")
+        cur = _cursor_with_conn("Server=localhost;Database=d;UID=sa;PWD=p")
         module, pyc_cursor, _, _ = _mock_pycore()
         src = pa.table({"a": [1, 2]})
 
@@ -397,7 +397,7 @@ class TestBulkcopyArrowDispatch:
     @patch("mssql_python.cursor.logger")
     def test_sensitive_fields_cleared_after_success(self, mock_logger):
         mock_logger.is_debug_enabled = False
-        cur = _cursor_with_conn("Server=testhost;Database=d;UID=sa;PWD=secret")
+        cur = _cursor_with_conn("Server=localhost;Database=d;UID=sa;PWD=secret")
         module, _, _, captured = _mock_pycore()
 
         with patch.dict("sys.modules", {"mssql_py_core": module}):


### PR DESCRIPTION
### Summary

The 1ES SQL-credential push-protection detector (`SEC101/037 SqlLegacyCredentials`) flags dummy `UID`/`PWD` connection strings whose `Server` points at a non-local host, blocking the GitHub → ADO mirror sync. This changes **only the flagged occurrences** to `Server=localhost`, which is the repo convention for committed dummy credentials (see `.github/copilot-instructions.md`).

No behavior change: the affected tests are fully mocked and none of their assertions depend on the server value; the benchmark line is a docstring usage example.

Changed lines (7 total, `Server=<host>` → `Server=localhost`):
- `tests/test_008_auth.py` — 3 lines (1666, 2935, 3339)
- `tests/test_024_bulkcopy_arrow.py` — 3 lines (239, 364, 400)
- `benchmarks/bench_bulkcopy_arrow.py` — 1 line (23, docstring example)

Identical but unflagged connection strings elsewhere in these files were intentionally left untouched to keep the diff minimal.

[AB#46836](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/46836)
