### PR TITLE
CHORE: sanitize remaining dummy connection strings to Server=localhost

### DIFF
--- a/tests/test_008_auth.py
+++ b/tests/test_008_auth.py
@@ -1708,7 +1708,7 @@ class TestTokenProviderValidation:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             conn = connect(
-                "Server=test;Database=testdb;UID=user@test.com;PWD=secret",
+                "Server=localhost;Database=testdb;UID=user@test.com;PWD=secret",
                 token_provider=mock_cred,
             )
         assert "UID=" not in conn.connection_str
@@ -2059,7 +2059,7 @@ class TestTokenProviderPooling:
         from mssql_python.pooling import PoolingManager
 
         PoolingManager._reset_for_testing()
-        conn = connect("Server=s;Database=d;UID=sa;PWD=secret")
+        conn = connect("Server=localhost;Database=d;UID=sa;PWD=secret")
         assert self._pooling_arg(mock_ddbc_conn) is True
         assert conn._pooling is True
         conn.close()
@@ -3096,7 +3096,7 @@ class TestTokenFactoryLazyAcquisition:
         mock_ddbc_conn.return_value = MagicMock()
         from mssql_python import connect
 
-        conn = connect("Server=test;Database=testdb;UID=sa;PWD=secret")
+        conn = connect("Server=localhost;Database=testdb;UID=sa;PWD=secret")
         try:
             assert conn._token_factory is None
             args, _ = mock_ddbc_conn.call_args
@@ -3216,7 +3216,7 @@ class TestRawAccessTokenPoolKey:
 
         with pytest.raises(InterfaceError, match="SQL_COPT_SS_ACCESS_TOKEN"):
             connect(
-                "Server=test;Database=testdb;UID=sa;PWD=secret",
+                "Server=localhost;Database=testdb;UID=sa;PWD=secret",
                 attrs_before={self._TOKEN_ATTR: bad_token},
             )
         # Fail closed: the guard raises before the native Connection is built.
@@ -3231,7 +3231,7 @@ class TestRawAccessTokenPoolKey:
 
         token = b"raw-access-token-bytes"
         conn = connect(
-            "Server=test;Database=testdb;UID=sa;PWD=secret",
+            "Server=localhost;Database=testdb;UID=sa;PWD=secret",
             attrs_before={self._TOKEN_ATTR: token},
         )
         try:
@@ -3247,11 +3247,11 @@ class TestRawAccessTokenPoolKey:
         from mssql_python import connect
 
         conn_a = connect(
-            "Server=test;Database=testdb;UID=sa;PWD=secret",
+            "Server=localhost;Database=testdb;UID=sa;PWD=secret",
             attrs_before={self._TOKEN_ATTR: b"token-A"},
         )
         conn_b = connect(
-            "Server=test;Database=testdb;UID=sa;PWD=secret",
+            "Server=localhost;Database=testdb;UID=sa;PWD=secret",
             attrs_before={self._TOKEN_ATTR: b"token-B"},
         )
         try:
@@ -3266,11 +3266,11 @@ class TestRawAccessTokenPoolKey:
         from mssql_python import connect
 
         conn_a = connect(
-            "Server=test;Database=testdb;UID=sa;PWD=secret",
+            "Server=localhost;Database=testdb;UID=sa;PWD=secret",
             attrs_before={self._TOKEN_ATTR: b"same-token"},
         )
         conn_b = connect(
-            "Server=test;Database=testdb;UID=sa;PWD=secret",
+            "Server=localhost;Database=testdb;UID=sa;PWD=secret",
             attrs_before={self._TOKEN_ATTR: b"same-token"},
         )
         try:
@@ -3288,7 +3288,7 @@ class TestRawAccessTokenPoolKey:
 
         token = bytearray(b"bytearray-token")
         conn = connect(
-            "Server=test;Database=testdb;UID=sa;PWD=secret",
+            "Server=localhost;Database=testdb;UID=sa;PWD=secret",
             attrs_before={self._TOKEN_ATTR: token},
         )
         try:
@@ -3313,7 +3313,7 @@ class TestRawAccessTokenPoolKey:
         from mssql_python import connect
 
         conn = connect(
-            "Server=test;Database=testdb;UID=sa;PWD=secret",
+            "Server=localhost;Database=testdb;UID=sa;PWD=secret",
             attrs_before={1256000: 30},  # some unrelated non-token attribute
         )
         try:

--- a/tests/test_024_bulkcopy_arrow.py
+++ b/tests/test_024_bulkcopy_arrow.py
@@ -383,7 +383,7 @@ class TestBulkcopyArrowDispatch:
     def test_batch_size_timeout_accept_positional(self, mock_logger):
         """D13: batch_size/timeout are positional-or-keyword (parity with bulkcopy)."""
         mock_logger.is_debug_enabled = False
-        cur = _cursor_with_conn("Server=testhost;Database=d;UID=sa;PWD=p")
+        cur = _cursor_with_conn("Server=localhost;Database=d;UID=sa;PWD=p")
         module, pyc_cursor, _, _ = _mock_pycore()
         src = pa.table({"a": [1, 2]})
 
@@ -410,7 +410,7 @@ class TestBulkcopyArrowDispatch:
     @patch("mssql_python.cursor.logger")
     def test_resources_closed_on_success(self, mock_logger):
         mock_logger.is_debug_enabled = False
-        cur = _cursor_with_conn("Server=testhost;Database=d;UID=sa;PWD=p")
+        cur = _cursor_with_conn("Server=localhost;Database=d;UID=sa;PWD=p")
         module, pyc_cursor, pyc_conn, _ = _mock_pycore()
 
         with patch.dict("sys.modules", {"mssql_py_core": module}):
@@ -422,7 +422,7 @@ class TestBulkcopyArrowDispatch:
     @patch("mssql_python.cursor.logger")
     def test_core_exception_is_reraised_and_cleaned_up(self, mock_logger):
         mock_logger.is_debug_enabled = False
-        cur = _cursor_with_conn("Server=testhost;Database=d;UID=sa;PWD=p")
+        cur = _cursor_with_conn("Server=localhost;Database=d;UID=sa;PWD=p")
         module, pyc_cursor, pyc_conn, captured = _mock_pycore(raise_exc=ValueError("boom"))
 
         with patch.dict("sys.modules", {"mssql_py_core": module}):
@@ -438,7 +438,7 @@ class TestBulkcopyArrowDispatch:
     def test_cleanup_swallows_close_errors(self, mock_logger):
         """A failing resource.close() during teardown must not mask the result."""
         mock_logger.is_debug_enabled = False
-        cur = _cursor_with_conn("Server=testhost;Database=d;UID=sa;PWD=p")
+        cur = _cursor_with_conn("Server=localhost;Database=d;UID=sa;PWD=p")
         module, pyc_cursor, pyc_conn, _ = _mock_pycore()
         pyc_cursor.close.side_effect = RuntimeError("close failed")
 


### PR DESCRIPTION
### Summary

Follow-up to #703. When the GitHub → ADO mirror re-pushes the modified test blobs, the 1ES SQL-credential push-protection detector (`SEC101/037 SqlLegacyCredentials`) re-scans the whole file and flags the **remaining** dummy `UID`/`PWD` connection strings whose `Server` points at a non-local host — not just the 7 lines fixed in #703.

This sanitizes all such strings in the two affected test files to `Server=localhost`, which is the repo convention for committed dummy credentials (`.github/copilot-instructions.md`).

No behavior change: every affected test is fully mocked (`@patch(...ddbc_bindings.Connection)` / `mssql_python.cursor`) and none of the assertions depend on the server value — they assert on pool keys, token factories, `connection_str` sanitization, and cleanup.

Scope (15 lines, `Server=<host>` → `Server=localhost`):
- `tests/test_008_auth.py` — 11 strings (`Server=test` / `Server=s`)
- `tests/test_024_bulkcopy_arrow.py` — 4 strings (`Server=testhost`)

Intentionally left unchanged:
- UID-only AD/MSI lines (no password → not a `SqlLegacyCredentials` match).
- `tests/test_010_*` / `tests/test_012_*` connection-string-parser tests, where the `tcp:server.database.windows.net` value is integral to what the parser test exercises.
- Pipeline YAMLs, which use variables (`$(DB_PASSWORD)`, `$SQL_IP`) or `localhost`/`(localdb)`/`127.0.0.1`.

[AB#46836](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/46836)
