### PR TITLE
FIX: make azure-core import optional in test_008_auth.py

### DIFF
--- a/tests/test_008_auth.py
+++ b/tests/test_008_auth.py
@@ -29,7 +29,11 @@ from mssql_python.auth import (
     _credential_cache_lock,
     _account_id_cache,
 )
-from azure.core.credentials import TokenCredential
+
+try:
+    from azure.core.credentials import TokenCredential
+except ImportError:  # pragma: no cover - azure-core is an optional test dependency
+    TokenCredential = None
 from mssql_python.constants import AuthType, ConstantsDDBC
 from mssql_python.exceptions import InterfaceError, OperationalError
 import secrets
@@ -1920,6 +1924,7 @@ class TestTokenProviderValidation:
 class TestTokenProviderProtocol:
     """Tests for the runtime_checkable azure.core TokenCredential protocol."""
 
+    @pytest.mark.skipif(TokenCredential is None, reason="azure-core not installed")
     def test_object_with_get_token_is_instance(self):
         """An object exposing get_token satisfies the Protocol at runtime."""
 
@@ -1929,6 +1934,7 @@ class TestTokenProviderProtocol:
 
         assert isinstance(Cred(), TokenCredential)
 
+    @pytest.mark.skipif(TokenCredential is None, reason="azure-core not installed")
     def test_object_without_get_token_is_not_instance(self):
         """An object missing get_token does not satisfy the Protocol."""
 


### PR DESCRIPTION
[AB#46836](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/46836)

### Summary

`tests/test_008_auth.py` added a top-level `from azure.core.credentials import TokenCredential` (introduced with the `token_provider` work in #603). That import runs at module-collection time — before the autouse `setup_azure_identity` fixture injects its mock `azure.*` modules into `sys.modules` — so in build/validation stages that install a minimal dependency set (no `azure-identity`/`azure-core`), pytest aborts the whole module with:

```
ModuleNotFoundError: No module named 'azure'
  tests/test_008_auth.py:32: in <module>
    from azure.core.credentials import TokenCredential
```

This wraps only that one top-level import in a `try/except ImportError` guard (falling back to `TokenCredential = None`) so the module collects even when `azure-core` is absent. The two tests in `TestTokenProviderProtocol` that genuinely need the real `runtime_checkable` Protocol are marked `@pytest.mark.skipif(TokenCredential is None, ...)`; the third scope-constant test does not use `TokenCredential` and continues to run.

All other `azure.*` imports in this file are function-local and already resolve to the fixture's `sys.modules` mocks, so no other changes are needed. When `azure-core` is installed (the normal path), behavior is unchanged and both protocol tests run.

No production code is touched — test-only hardening.
