### PR TITLE
CHORE: Flaky Setup - Replace Debian ARM64 image with Python Bookworm to avoid QEMU segfault

### DIFF
--- a/eng/pipelines/pr-validation-pipeline.yml
+++ b/eng/pipelines/pr-validation-pipeline.yml
@@ -1013,7 +1013,11 @@ jobs:
         distroName: 'Ubuntu'
         archName: 'arm64'
       Debian_ARM64:
-        dockerImage: 'debian:12'
+        # Python 3.11 is preinstalled (byte-compiled natively at image-build
+        # time) so we never run the apt python3 post-install byte-compilation
+        # that SIGSEGVs (exit 139) under QEMU user-mode emulation. Still Debian
+        # 12 (bookworm) underneath, so the msodbcsql18 debian/12 repo applies.
+        dockerImage: 'python:3.11-bookworm'
         distroName: 'Debian'
         archName: 'arm64'
 
@@ -1027,20 +1031,8 @@ jobs:
 
   - script: |
       # Create a Docker container for testing on ARM64
-      #
-      # The arm64 test image runs under QEMU user-mode emulation on the x86_64
-      # agent. QEMU mishandles glibc restartable sequences (rseq) -- which
-      # modern glibc enables by default -- causing random SIGSEGVs (exit 139)
-      # when the emulated arm64 Python is invoked for apt byte-compilation
-      # during dependency installation. Disabling rseq via GLIBC_TUNABLES
-      # removes the trigger with no functional impact (rseq is only a perf
-      # optimization). Set at container creation so every subsequent
-      # `docker exec` inherits it. Applied to both matrix legs (Debian 12 /
-      # glibc 2.36 and Ubuntu 22.04 / glibc 2.35) since both share the same
-      # emulated-arm64 path and both glibc versions ship rseq.
       docker run -d --name test-container-$(distroName)-$(archName) \
         --platform linux/arm64 \
-        -e GLIBC_TUNABLES=glibc.pthread.rseq=0 \
         -v $(Build.SourcesDirectory):/workspace \
         -w /workspace \
         --network bridge \
@@ -1102,13 +1094,19 @@ jobs:
         "
       else
         # Debian ARM64
+        # Python (with pip, venv and dev headers) is already provided by the
+        # python:3.11-bookworm base image under /usr/local, so we do NOT
+        # apt-install python3* here -- the apt python3 post-install byte-
+        # compilation is what SIGSEGVs (exit 139) under QEMU emulation. pybind11
+        # comes from pip (requirements.txt); only non-Python build tools are
+        # pulled from apt, none of which depend on the Debian python3 package.
         docker exec test-container-$(distroName)-$(archName) bash -c "
           set -euo pipefail
           export DEBIAN_FRONTEND=noninteractive
           export TZ=UTC
           ln -snf /usr/share/zoneinfo/\$TZ /etc/localtime && echo \$TZ > /etc/timezone
           apt-get update
-          apt-get install -y python3 python3-pip python3-venv python3-full cmake curl wget gnupg software-properties-common build-essential python3-dev pybind11-dev
+          apt-get install -y cmake curl wget gnupg build-essential
           # Verify architecture
           uname -m
           dpkg --print-architecture

--- a/eng/pipelines/pr-validation-pipeline.yml
+++ b/eng/pipelines/pr-validation-pipeline.yml
@@ -1019,29 +1019,8 @@ jobs:
 
   steps:
   - script: |
-      # Set up Docker buildx for multi-architecture support.
-      #
-      # Register a modern, pinned QEMU (tonistiigi/binfmt qemu-v9.2.2) instead
-      # of the older multiarch/qemu-user-static image. Older QEMU user-mode
-      # emulation mishandles glibc restartable sequences (rseq), randomly
-      # SIGSEGV-ing (exit 139) the emulated arm64 Python during Debian's apt
-      # byte-compilation and forcing repeated job reruns. QEMU >= 7.2 fixes
-      # rseq emulation, eliminating the crash at the emulator level. Together
-      # with the GLIBC_TUNABLES rseq disable on the Debian container below,
-      # this gives two independent guards so the segfault can no longer occur.
-      #
-      # Uninstall any arm64 handler the agent may already have registered
-      # before installing this pinned image's QEMU. tonistiigi/binfmt's
-      # `--install` is a no-op if a handler is already registered (the kernel
-      # returns EEXIST and binfmt leaves the existing one in place), so without
-      # the uninstall we could silently keep the agent's older QEMU and defeat
-      # the fix on the Ubuntu leg. This mirrors the old `--reset`; note that
-      # tonistiigi/binfmt has no `--reset` flag (that belonged to
-      # multiarch/qemu-user-static) -- uninstall+install is the equivalent.
-      # `--uninstall arm64` maps through binfmt's arch config to the
-      # `qemu-aarch64` handler (matched by the `-aarch64` suffix) and is a
-      # harmless no-op when nothing is registered.
-      docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2 --uninstall arm64 --install arm64
+      # Set up Docker buildx for multi-architecture support
+      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       docker buildx create --name multiarch --driver docker-container --use
       docker buildx inspect --bootstrap
     displayName: 'Setup Docker buildx for ARM64 emulation'
@@ -1049,25 +1028,19 @@ jobs:
   - script: |
       # Create a Docker container for testing on ARM64
       #
-      # Debian 12 (glibc 2.36) intermittently segfaults (exit 139) during
-      # `apt-get install` post-install scripts when the emulated arm64 Python
-      # interpreter is invoked for byte-compilation (python3-wheel,
-      # python3-pyparsing, python3.11-venv, ...). Root cause: QEMU arm64
-      # user-mode emulation on the x86_64 agent mishandles glibc restartable
-      # sequences (rseq), which modern glibc uses by default. Disabling rseq
-      # via GLIBC_TUNABLES removes the trigger with no functional impact (rseq
-      # is only a perf optimization). Set at container creation so every
-      # subsequent `docker exec` inherits it. Ubuntu 22.04 (glibc 2.35) is not
-      # affected in practice, so only this GLIBC_TUNABLES/rseq-disable guard is
-      # scoped to the Debian leg -- the ARM64 emulation itself is shared by
-      # both matrix legs.
-      EXTRA_ENV=""
-      if [ "$(distroName)" = "Debian" ]; then
-        EXTRA_ENV="-e GLIBC_TUNABLES=glibc.pthread.rseq=0"
-      fi
+      # The arm64 test image runs under QEMU user-mode emulation on the x86_64
+      # agent. QEMU mishandles glibc restartable sequences (rseq) -- which
+      # modern glibc enables by default -- causing random SIGSEGVs (exit 139)
+      # when the emulated arm64 Python is invoked for apt byte-compilation
+      # during dependency installation. Disabling rseq via GLIBC_TUNABLES
+      # removes the trigger with no functional impact (rseq is only a perf
+      # optimization). Set at container creation so every subsequent
+      # `docker exec` inherits it. Applied to both matrix legs (Debian 12 /
+      # glibc 2.36 and Ubuntu 22.04 / glibc 2.35) since both share the same
+      # emulated-arm64 path and both glibc versions ship rseq.
       docker run -d --name test-container-$(distroName)-$(archName) \
         --platform linux/arm64 \
-        $EXTRA_ENV \
+        -e GLIBC_TUNABLES=glibc.pthread.rseq=0 \
         -v $(Build.SourcesDirectory):/workspace \
         -w /workspace \
         --network bridge \

--- a/eng/pipelines/pr-validation-pipeline.yml
+++ b/eng/pipelines/pr-validation-pipeline.yml
@@ -1029,7 +1029,19 @@ jobs:
       # rseq emulation, eliminating the crash at the emulator level. Together
       # with the GLIBC_TUNABLES rseq disable on the Debian container below,
       # this gives two independent guards so the segfault can no longer occur.
-      docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2 --install arm64
+      #
+      # Uninstall any arm64 handler the agent may already have registered
+      # before installing this pinned image's QEMU. tonistiigi/binfmt's
+      # `--install` is a no-op if a handler is already registered (the kernel
+      # returns EEXIST and binfmt leaves the existing one in place), so without
+      # the uninstall we could silently keep the agent's older QEMU and defeat
+      # the fix on the Ubuntu leg. This mirrors the old `--reset`; note that
+      # tonistiigi/binfmt has no `--reset` flag (that belonged to
+      # multiarch/qemu-user-static) -- uninstall+install is the equivalent.
+      # `--uninstall arm64` maps through binfmt's arch config to the
+      # `qemu-aarch64` handler (matched by the `-aarch64` suffix) and is a
+      # harmless no-op when nothing is registered.
+      docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2 --uninstall arm64 --install arm64
       docker buildx create --name multiarch --driver docker-container --use
       docker buildx inspect --bootstrap
     displayName: 'Setup Docker buildx for ARM64 emulation'
@@ -1046,7 +1058,9 @@ jobs:
       # via GLIBC_TUNABLES removes the trigger with no functional impact (rseq
       # is only a perf optimization). Set at container creation so every
       # subsequent `docker exec` inherits it. Ubuntu 22.04 (glibc 2.35) is not
-      # affected in practice, so this is scoped strictly to the Debian leg.
+      # affected in practice, so only this GLIBC_TUNABLES/rseq-disable guard is
+      # scoped to the Debian leg -- the ARM64 emulation itself is shared by
+      # both matrix legs.
       EXTRA_ENV=""
       if [ "$(distroName)" = "Debian" ]; then
         EXTRA_ENV="-e GLIBC_TUNABLES=glibc.pthread.rseq=0"

--- a/eng/pipelines/pr-validation-pipeline.yml
+++ b/eng/pipelines/pr-validation-pipeline.yml
@@ -1019,16 +1019,41 @@ jobs:
 
   steps:
   - script: |
-      # Set up Docker buildx for multi-architecture support
-      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      # Set up Docker buildx for multi-architecture support.
+      #
+      # Register a modern, pinned QEMU (tonistiigi/binfmt qemu-v9.2.2) instead
+      # of the older multiarch/qemu-user-static image. Older QEMU user-mode
+      # emulation mishandles glibc restartable sequences (rseq), randomly
+      # SIGSEGV-ing (exit 139) the emulated arm64 Python during Debian's apt
+      # byte-compilation and forcing repeated job reruns. QEMU >= 7.2 fixes
+      # rseq emulation, eliminating the crash at the emulator level. Together
+      # with the GLIBC_TUNABLES rseq disable on the Debian container below,
+      # this gives two independent guards so the segfault can no longer occur.
+      docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2 --install arm64
       docker buildx create --name multiarch --driver docker-container --use
       docker buildx inspect --bootstrap
     displayName: 'Setup Docker buildx for ARM64 emulation'
 
   - script: |
       # Create a Docker container for testing on ARM64
+      #
+      # Debian 12 (glibc 2.36) intermittently segfaults (exit 139) during
+      # `apt-get install` post-install scripts when the emulated arm64 Python
+      # interpreter is invoked for byte-compilation (python3-wheel,
+      # python3-pyparsing, python3.11-venv, ...). Root cause: QEMU arm64
+      # user-mode emulation on the x86_64 agent mishandles glibc restartable
+      # sequences (rseq), which modern glibc uses by default. Disabling rseq
+      # via GLIBC_TUNABLES removes the trigger with no functional impact (rseq
+      # is only a perf optimization). Set at container creation so every
+      # subsequent `docker exec` inherits it. Ubuntu 22.04 (glibc 2.35) is not
+      # affected in practice, so this is scoped strictly to the Debian leg.
+      EXTRA_ENV=""
+      if [ "$(distroName)" = "Debian" ]; then
+        EXTRA_ENV="-e GLIBC_TUNABLES=glibc.pthread.rseq=0"
+      fi
       docker run -d --name test-container-$(distroName)-$(archName) \
         --platform linux/arm64 \
+        $EXTRA_ENV \
         -v $(Build.SourcesDirectory):/workspace \
         -w /workspace \
         --network bridge \


### PR DESCRIPTION
### Summary

The Debian ARM64 leg of the PR validation pipeline SIGSEGVs (exit 139) during
the apt `Setting up python3` post-install byte-compilation under QEMU user-mode
emulation on the x86_64 hosted agent. This is an emulator-level crash in the
Debian `python3` package's post-install script, not something the guest can
suppress: build 167144 ran a `GLIBC_TUNABLES=glibc.pthread.rseq=0` guard and
still crashed at exactly the same point, disproving the earlier rseq theory.

This change avoids the crashing operation entirely instead of trying to make
QEMU emulate it correctly:

- The Debian ARM64 leg now runs on `python:3.11-bookworm` (Debian 12 + CPython
  3.11 already installed and byte-compiled **natively** at image-build time)
  instead of `debian:12`.
- The Debian branch of "Install basic dependencies" no longer apt-installs the
  `python3*` packages (the trigger). Python — with pip, venv and dev headers —
  comes from `/usr/local`; `pybind11` comes from pip (already in
  `requirements.txt`); CMake auto-detects both from the active interpreter, so
  the apt `python3-dev`/`pybind11-dev` packages are redundant. Only non-Python
  build tools (`cmake curl wget gnupg build-essential`) are apt-installed, none
  of which depend on the Debian `python3` package. `software-properties-common`
  was unused (the ODBC repo is added via `curl` + `dpkg -i`, not
  `add-apt-repository`).
- The ineffective `GLIBC_TUNABLES` rseq guard is removed.

The Ubuntu ARM64 leg is unchanged (it does not crash). Pytest subprocess
segfaults under QEMU are a separate concern and will be `skipif`-guarded.

[AB#47276](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/47276)
