### PR TITLE
CHORE: Flaky Setup - Fail SQL Server setup loudly and dump container logs on every CI leg

### DIFF
--- a/eng/pipelines/pr-validation-pipeline.yml
+++ b/eng/pipelines/pr-validation-pipeline.yml
@@ -559,7 +559,23 @@ jobs:
           fi
           sleep 2
         done
+
+        # One last probe: the loop sleeps after its final attempt, so SQL can
+        # become reachable in that window and would otherwise be missed.
+        if docker exec sqlserver \
+          /opt/mssql-tools18/bin/sqlcmd \
+          -S localhost -U SA -P "$DB_PASSWORD" \
+          -C -Q "SELECT 1"; then
+          echo "[sql] SQL Server is ready."
+          return 0
+        fi
+
+        # sqlcmd only reports that the client could not connect. When the
+        # container itself exited (bad password policy, EULA, OOM, port clash)
+        # the reason is in the container's own log, so surface it here.
         echo "[sql] SQL Server did not become ready in time." >&2
+        echo "[sql] ---- docker logs sqlserver (last 200 lines) ----" >&2
+        docker logs --tail 200 sqlserver >&2 || true
         return 1
       }
 
@@ -2510,32 +2526,15 @@ jobs:
         -d mcr.microsoft.com/mssql/server:2022-latest
 
       # Wait until SQL Server is ready
-      sql_ready=false
       for i in {1..30}; do
-        if docker exec sqlserver \
-          /opt/mssql-tools18/bin/sqlcmd \
-          -S localhost \
-          -U SA \
-          -P "$(DB_PASSWORD)" \
-          -C -Q "SELECT 1"; then
-          sql_ready=true
-          break
-        fi
-        sleep 2
-      done
-      if [ "$sql_ready" != true ]; then
-        # one last probe, in case it came up during the final sleep
         docker exec sqlserver \
           /opt/mssql-tools18/bin/sqlcmd \
           -S localhost \
           -U SA \
           -P "$(DB_PASSWORD)" \
-          -C -Q "SELECT 1" || {
-            echo "SQL Server did not become ready after 30 attempts"
-            docker logs --tail 200 sqlserver || true
-            exit 1
-          }
-      fi
+          -C -Q "SELECT 1" && break
+        sleep 2
+      done
     displayName: 'Start SQL Server container'
     env:
       DB_PASSWORD: $(DB_PASSWORD)

--- a/eng/pipelines/pr-validation-pipeline.yml
+++ b/eng/pipelines/pr-validation-pipeline.yml
@@ -784,6 +784,7 @@ jobs:
       
       # Wait for SQL Server to be ready
       echo "Waiting for SQL Server to start..."
+      sql_ready=false
       for i in {1..60}; do
         if docker exec sqlserver-$(distroName) \
           /opt/mssql-tools18/bin/sqlcmd \
@@ -792,11 +793,28 @@ jobs:
           -P "$(DB_PASSWORD)" \
           -C -Q "SELECT 1" >/dev/null 2>&1; then
           echo "SQL Server is ready!"
+          sql_ready=true
           break
         fi
         echo "Waiting... ($i/60)"
         sleep 2
       done
+      if [ "$sql_ready" != true ]; then
+        # the loop sleeps after its final attempt, so probe once more
+        if docker exec sqlserver-$(distroName) \
+          /opt/mssql-tools18/bin/sqlcmd \
+          -S localhost \
+          -U SA \
+          -P "$(DB_PASSWORD)" \
+          -C -Q "SELECT 1" >/dev/null 2>&1; then
+          echo "SQL Server is ready!"
+        else
+          echo "SQL Server did not become ready after 60 attempts"
+          echo "---- docker logs sqlserver-$(distroName) (last 200 lines) ----"
+          docker logs --tail 200 sqlserver-$(distroName) || true
+          exit 1
+        fi
+      fi
       
       # Create test database
       docker exec sqlserver-$(distroName) \
@@ -1113,6 +1131,7 @@ jobs:
       
       # Wait for SQL Server to be ready
       echo "Waiting for SQL Server to start..."
+      sql_ready=false
       for i in {1..60}; do
         if docker exec sqlserver-$(distroName)-$(archName) \
           /opt/mssql-tools18/bin/sqlcmd \
@@ -1121,11 +1140,28 @@ jobs:
           -P "$(DB_PASSWORD)" \
           -C -Q "SELECT 1" >/dev/null 2>&1; then
           echo "SQL Server is ready!"
+          sql_ready=true
           break
         fi
         echo "Waiting... ($i/60)"
         sleep 2
       done
+      if [ "$sql_ready" != true ]; then
+        # the loop sleeps after its final attempt, so probe once more
+        if docker exec sqlserver-$(distroName)-$(archName) \
+          /opt/mssql-tools18/bin/sqlcmd \
+          -S localhost \
+          -U SA \
+          -P "$(DB_PASSWORD)" \
+          -C -Q "SELECT 1" >/dev/null 2>&1; then
+          echo "SQL Server is ready!"
+        else
+          echo "SQL Server did not become ready after 60 attempts"
+          echo "---- docker logs sqlserver-$(distroName)-$(archName) (last 200 lines) ----"
+          docker logs --tail 200 sqlserver-$(distroName)-$(archName) || true
+          exit 1
+        fi
+      fi
       
       # Create test database
       docker exec sqlserver-$(distroName)-$(archName) \
@@ -1343,6 +1379,7 @@ jobs:
       
       # Wait for SQL Server to be ready
       echo "Waiting for SQL Server to start..."
+      sql_ready=false
       for i in {1..60}; do
         if docker exec sqlserver-rhel9 \
           /opt/mssql-tools18/bin/sqlcmd \
@@ -1351,11 +1388,28 @@ jobs:
           -P "$(DB_PASSWORD)" \
           -C -Q "SELECT 1" >/dev/null 2>&1; then
           echo "SQL Server is ready!"
+          sql_ready=true
           break
         fi
         echo "Waiting... ($i/60)"
         sleep 2
       done
+      if [ "$sql_ready" != true ]; then
+        # the loop sleeps after its final attempt, so probe once more
+        if docker exec sqlserver-rhel9 \
+          /opt/mssql-tools18/bin/sqlcmd \
+          -S localhost \
+          -U SA \
+          -P "$(DB_PASSWORD)" \
+          -C -Q "SELECT 1" >/dev/null 2>&1; then
+          echo "SQL Server is ready!"
+        else
+          echo "SQL Server did not become ready after 60 attempts"
+          echo "---- docker logs sqlserver-rhel9 (last 200 lines) ----"
+          docker logs --tail 200 sqlserver-rhel9 || true
+          exit 1
+        fi
+      fi
       
       # Create test database
       docker exec sqlserver-rhel9 \
@@ -1570,6 +1624,7 @@ jobs:
       
       # Wait for SQL Server to be ready
       echo "Waiting for SQL Server to start..."
+      sql_ready=false
       for i in {1..60}; do
         if docker exec sqlserver-rhel9-arm64 \
           /opt/mssql-tools18/bin/sqlcmd \
@@ -1578,11 +1633,28 @@ jobs:
           -P "$(DB_PASSWORD)" \
           -C -Q "SELECT 1" >/dev/null 2>&1; then
           echo "SQL Server is ready!"
+          sql_ready=true
           break
         fi
         echo "Waiting... ($i/60)"
         sleep 2
       done
+      if [ "$sql_ready" != true ]; then
+        # the loop sleeps after its final attempt, so probe once more
+        if docker exec sqlserver-rhel9-arm64 \
+          /opt/mssql-tools18/bin/sqlcmd \
+          -S localhost \
+          -U SA \
+          -P "$(DB_PASSWORD)" \
+          -C -Q "SELECT 1" >/dev/null 2>&1; then
+          echo "SQL Server is ready!"
+        else
+          echo "SQL Server did not become ready after 60 attempts"
+          echo "---- docker logs sqlserver-rhel9-arm64 (last 200 lines) ----"
+          docker logs --tail 200 sqlserver-rhel9-arm64 || true
+          exit 1
+        fi
+      fi
       
       # Create test database
       docker exec sqlserver-rhel9-arm64 \
@@ -1801,6 +1873,7 @@ jobs:
       
       # Wait for SQL Server to be ready
       echo "Waiting for SQL Server to start..."
+      sql_ready=false
       for i in {1..60}; do
         if docker exec sqlserver-alpine \
           /opt/mssql-tools18/bin/sqlcmd \
@@ -1809,11 +1882,28 @@ jobs:
           -P "$(DB_PASSWORD)" \
           -C -Q "SELECT 1" >/dev/null 2>&1; then
           echo "SQL Server is ready!"
+          sql_ready=true
           break
         fi
         echo "Waiting... ($i/60)"
         sleep 2
       done
+      if [ "$sql_ready" != true ]; then
+        # the loop sleeps after its final attempt, so probe once more
+        if docker exec sqlserver-alpine \
+          /opt/mssql-tools18/bin/sqlcmd \
+          -S localhost \
+          -U SA \
+          -P "$(DB_PASSWORD)" \
+          -C -Q "SELECT 1" >/dev/null 2>&1; then
+          echo "SQL Server is ready!"
+        else
+          echo "SQL Server did not become ready after 60 attempts"
+          echo "---- docker logs sqlserver-alpine (last 200 lines) ----"
+          docker logs --tail 200 sqlserver-alpine || true
+          exit 1
+        fi
+      fi
       
       # Create test database
       docker exec sqlserver-alpine \
@@ -2057,6 +2147,7 @@ jobs:
       
       # Wait for SQL Server to be ready
       echo "Waiting for SQL Server to start..."
+      sql_ready=false
       for i in {1..60}; do
         if docker exec sqlserver-alpine-arm64 \
           /opt/mssql-tools18/bin/sqlcmd \
@@ -2065,11 +2156,28 @@ jobs:
           -P "$(DB_PASSWORD)" \
           -C -Q "SELECT 1" >/dev/null 2>&1; then
           echo "SQL Server is ready!"
+          sql_ready=true
           break
         fi
         echo "Waiting... ($i/60)"
         sleep 2
       done
+      if [ "$sql_ready" != true ]; then
+        # the loop sleeps after its final attempt, so probe once more
+        if docker exec sqlserver-alpine-arm64 \
+          /opt/mssql-tools18/bin/sqlcmd \
+          -S localhost \
+          -U SA \
+          -P "$(DB_PASSWORD)" \
+          -C -Q "SELECT 1" >/dev/null 2>&1; then
+          echo "SQL Server is ready!"
+        else
+          echo "SQL Server did not become ready after 60 attempts"
+          echo "---- docker logs sqlserver-alpine-arm64 (last 200 lines) ----"
+          docker logs --tail 200 sqlserver-alpine-arm64 || true
+          exit 1
+        fi
+      fi
       
       # Create test database
       docker exec sqlserver-alpine-arm64 \
@@ -2526,15 +2634,33 @@ jobs:
         -d mcr.microsoft.com/mssql/server:2022-latest
 
       # Wait until SQL Server is ready
+      sql_ready=false
       for i in {1..30}; do
-        docker exec sqlserver \
+        if docker exec sqlserver \
           /opt/mssql-tools18/bin/sqlcmd \
           -S localhost \
           -U SA \
           -P "$(DB_PASSWORD)" \
-          -C -Q "SELECT 1" && break
+          -C -Q "SELECT 1"; then
+          sql_ready=true
+          break
+        fi
         sleep 2
       done
+      if [ "$sql_ready" != true ]; then
+        # the loop sleeps after its final attempt, so probe once more
+        if ! docker exec sqlserver \
+          /opt/mssql-tools18/bin/sqlcmd \
+          -S localhost \
+          -U SA \
+          -P "$(DB_PASSWORD)" \
+          -C -Q "SELECT 1"; then
+          echo "SQL Server did not become ready after 30 attempts"
+          echo "---- docker logs sqlserver (last 200 lines) ----"
+          docker logs --tail 200 sqlserver || true
+          exit 1
+        fi
+      fi
     displayName: 'Start SQL Server container'
     env:
       DB_PASSWORD: $(DB_PASSWORD)

--- a/eng/pipelines/pr-validation-pipeline.yml
+++ b/eng/pipelines/pr-validation-pipeline.yml
@@ -516,15 +516,32 @@ jobs:
         -d $(sqlServerImage)
 
       # Starting SQL Server container…
+      sql_ready=false
       for i in {1..30}; do
+        if docker exec sqlserver \
+          /opt/mssql-tools18/bin/sqlcmd \
+          -S localhost \
+          -U SA \
+          -P "$DB_PASSWORD" \
+          -C -Q "SELECT 1"; then
+          sql_ready=true
+          break
+        fi
+        sleep 2
+      done
+      if [ "$sql_ready" != true ]; then
+        # one last probe, in case it came up during the final sleep
         docker exec sqlserver \
           /opt/mssql-tools18/bin/sqlcmd \
           -S localhost \
           -U SA \
           -P "$DB_PASSWORD" \
-          -C -Q "SELECT 1" && break
-        sleep 2
-      done
+          -C -Q "SELECT 1" || {
+            echo "SQL Server did not become ready after 30 attempts"
+            docker logs --tail 200 sqlserver || true
+            exit 1
+          }
+      fi
     displayName: 'Pull & start SQL Server (Docker)'
     env:
       DB_PASSWORD: $(DB_PASSWORD)
@@ -2454,15 +2471,32 @@ jobs:
         -d mcr.microsoft.com/mssql/server:2022-latest
 
       # Wait until SQL Server is ready
+      sql_ready=false
       for i in {1..30}; do
+        if docker exec sqlserver \
+          /opt/mssql-tools18/bin/sqlcmd \
+          -S localhost \
+          -U SA \
+          -P "$(DB_PASSWORD)" \
+          -C -Q "SELECT 1"; then
+          sql_ready=true
+          break
+        fi
+        sleep 2
+      done
+      if [ "$sql_ready" != true ]; then
+        # one last probe, in case it came up during the final sleep
         docker exec sqlserver \
           /opt/mssql-tools18/bin/sqlcmd \
           -S localhost \
           -U SA \
           -P "$(DB_PASSWORD)" \
-          -C -Q "SELECT 1" && break
-        sleep 2
-      done
+          -C -Q "SELECT 1" || {
+            echo "SQL Server did not become ready after 30 attempts"
+            docker logs --tail 200 sqlserver || true
+            exit 1
+          }
+      fi
     displayName: 'Start SQL Server container'
     env:
       DB_PASSWORD: $(DB_PASSWORD)


### PR DESCRIPTION
### Work Item / Issue Reference

> ADO Work Item: Fixed [AB#47310](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/47310)

-------------------------------------------------------------------
### Summary

when SQL Server fails to come up in CI, the pipeline either does not fail at all or fails without saying why. this makes all eight readiness loops behave the same way.

two of the eight never failed. the macOS one and the CodeCoverageReport one polled in a loop whose exit status is the final `sleep 2`, so the step reported success even when every probe failed. build 166760 hit this on macOS: the container died on startup, all 30 probes logged `container ... is not running`, the step went green, and pytest then ran 32.6 minutes against a database that did not exist, erroring on every db-backed test from the 1% mark while the non-db tests passed. #723 has since fixed the macOS half as part of the setup parallelization, so what is left here is CodeCoverageReport.

the other six linux distro legs do fail, through `CREATE DATABASE TestDB` right after the loop, but you only get a sqlcmd connect error. nothing anywhere in the pipeline captures `docker logs`, so when the container exits on its own (SA password policy, EULA, OOM, port already bound) the reason is never recorded. that is why 166760's root cause is still unknown.

every site now tracks readiness in a flag, probes once more after the loop, and on failure prints the attempt count followed by `docker logs --tail 200` before exiting non-zero. the extra probe matters because the loop sleeps after its final attempt, so SQL can become reachable in that window and would otherwise be called a hard failure.

verified locally against real containers: a container that prints a startup error and exits now surfaces that error instead of only the connect failure, a healthy container is unaffected, and a container that becomes reachable only after the loop is rescued by the re-probe. healthy macOS runs use 3 to 6 of the 30 attempts, so the gate keeps roughly 5x headroom and no green run changes behaviour.
