### PR TITLE
FIX: Fixing Build-Release-Package-Pipeline failure

### DIFF
--- a/OneBranchPipelines/stages/build-linux-single-stage.yml
+++ b/OneBranchPipelines/stages/build-linux-single-stage.yml
@@ -318,6 +318,8 @@ stages:
                     echo "Setting up test environment...";
                     $PY -m pip install -q pytest;
                     cp -r /workspace/tests $TEST_DIR/ || echo "WARNING: No tests directory";
+                    # Some tests read repo-side helper scripts/workflows (e.g. .github/scripts/prepare_fork_coverage_comment.py).
+                    cp -r /workspace/.github $TEST_DIR/ || echo "WARNING: No .github directory";
                     cp /workspace/pytest.ini $TEST_DIR/ || echo "WARNING: No pytest.ini";
                     cp /workspace/requirements.txt $TEST_DIR/ || true;
                     $PY -m pip install -q -r $TEST_DIR/requirements.txt || true;
@@ -386,6 +388,8 @@ stages:
                     echo "Setting up test environment...";
                     $PY -m pip install -q pytest;
                     cp -r /workspace/tests $TEST_DIR/ || echo "WARNING: No tests directory";
+                    # Some tests read repo-side helper scripts/workflows (e.g. .github/scripts/prepare_fork_coverage_comment.py).
+                    cp -r /workspace/.github $TEST_DIR/ || echo "WARNING: No .github directory";
                     cp /workspace/pytest.ini $TEST_DIR/ || echo "WARNING: No pytest.ini";
                     cp /workspace/requirements.txt $TEST_DIR/ || true;
                     $PY -m pip install -q -r $TEST_DIR/requirements.txt || true;


### PR DESCRIPTION
### Work Item / Issue Reference  
<!-- 
IMPORTANT: Please follow the PR template guidelines below.
For mssql-python maintainers: Insert your ADO Work Item ID below 
For external contributors: Insert Github Issue number below
Only one reference is required - either GitHub issue OR ADO Work Item.
-->

<!-- mssql-python maintainers: ADO Work Item -->
> [AB#47683](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/47683)

<!-- External contributors: GitHub Issue -->


-------------------------------------------------------------------
### Summary   
<!-- Insert your summary of changes below. Minimum 10 characters required. -->  
**Symptom**
Build-Release-Package-Pipeline failed on all four Linux variants during Step 8 (pytest) with a collection-time error, before any test ran:
tests/test_fork_coverage_security.py:10: in <module>
    SPEC.loader.exec_module(coverage_comment)
E   FileNotFoundError: [Errno 2] No such file or directory:
    '/test_isolated_cp310/.github/scripts/prepare_fork_coverage_comment.py'
!!! Interrupted: 1 error during collection !!!

Combined with --maxfail=1, this aborted cp310–cp314 on:

- Linux manylinux_2_28 x86_64
- Linux manylinux_2_28 aarch64
- Linux musllinux x86_64
- Linux musllinux aarch64

**Root cause**
Two independent design assumptions collided:

- Test-side assumption. [test_fork_coverage_security.py:7] resolves helpers at module top level (collection time) via [Path(__file__).parents[1] / ".github" / "scripts" / "prepare_fork_coverage_comment.py"], and also reads [forked-pr-coverage.yml] and [pr-code-coverage.yml]. It assumes [parents[1]] is a full repo checkout.

Pipeline-side assumption. The Linux release lane in [build-linux-single-stage.yml] intentionally runs pytest from an empty isolated directory to prove the installed wheel is self-contained:

TEST_DIR="/test_isolated_${PYBIN}"
rm -rf $TEST_DIR; mkdir -p $TEST_DIR
$PY -m pip install -q "$WHEEL"
cp -r /workspace/tests $TEST_DIR/
cp /workspace/pytest.ini $TEST_DIR/
cp /workspace/requirements.txt $TEST_DIR/

Only [tests], [pytest.ini], [requirements.txt] are copied. [.github] is not — until now no test needed anything outside [tests].
[test_fork_coverage_security.py] (added by the fork-coverage hardening series culminating in PR #714) is the first test that reaches outside [tests] at import time. In the isolated layout [parents[1]]= /test_isolated_cp310/, so the .github/… lookup fell off the map. Only the Linux lane runs the empty-isolated-dir model; Windows and macOS run from $(Build.SourcesDirectory) (a real checkout), so they were unaffected — and repo-root GitHub CI was unaffected too.

**Fix:**
Make the pipeline meet the test's assumption, and drop an earlier stop-gap.

Change added to Linux release pipeline
Copy [.github] into $TEST_DIR alongside [tests], in both the manylinux branch (covers x86_64 + aarch64) and the musllinux branch (covers x86_64 + aarch64):

[build-linux-single-stage.yml:322] — manylinux bash -lc block:

[build-linux-single-stage.yml:392] — musllinux sh -lc block: same two lines.

cp -r /workspace/tests $TEST_DIR/ || echo "WARNING: No tests directory";
Some tests read repo-side helper scripts/workflows (e.g. .github/scripts/prepare_fork_coverage_comment.py).
cp -r /workspace/.github $TEST_DIR/ || echo "WARNING: No .github directory";

These are the only two code sites reached by the four failing Linux stages.
<!-- 
### PR Title Guide

> For feature requests
FEAT: (short-description)

> For non-feature requests like test case updates, config updates , dependency updates etc
CHORE: (short-description) 

> For Fix requests
FIX: (short-description)

> For doc update requests 
DOC: (short-description)

> For Formatting, indentation, or styling update
STYLE: (short-description)

> For Refactor, without any feature changes
REFACTOR: (short-description)

> For performance improvements
PERF: (short-description)

> For release related changes, without any feature changes
RELEASE: #<RELEASE_VERSION> (short-description) 

### Contribution Guidelines

External contributors:
- Create a GitHub issue first: https://github.com/microsoft/mssql-python/issues/new
- Link the GitHub issue in the "GitHub Issue" section above
- Follow the PR title format and provide a meaningful summary

mssql-python maintainers:
- Create an ADO Work Item following internal processes
- Link the ADO Work Item in the "ADO Work Item" section above  
- Follow the PR title format and provide a meaningful summary
-->