### PR TITLE
FIX: vendor the correct-arch mssql_py_core into Windows arm64 wheels

### DIFF
--- a/OneBranchPipelines/stages/build-windows-single-stage.yml
+++ b/OneBranchPipelines/stages/build-windows-single-stage.yml
@@ -299,6 +299,10 @@ stages:
             inputs:
               targetType: 'filePath'
               filePath: '$(Build.SourcesDirectory)\eng\scripts\install-mssql-py-core.ps1'
+              # Pass the TARGET arch so a cross-compiled arm64 wheel vendors the
+              # win_arm64 core, not the x64 host's. The installer skips its import
+              # self-check for cross-arch; arm64 bulk copy is exercised on native agents.
+              arguments: '-TargetArch $(targetArch)'
           
           # =========================
           # PHASE 2: EXTERNAL ODBC DRIVER PACKAGE

--- a/eng/scripts/install-mssql-py-core.ps1
+++ b/eng/scripts/install-mssql-py-core.ps1
@@ -10,11 +10,21 @@
 .PARAMETER OutputDir
     Temporary directory for downloaded artifacts. Cleaned up after extraction.
     Defaults to $env:TEMP\mssql-py-core-wheels.
+
+.PARAMETER TargetArch
+    Target CPU architecture ('x64' or 'arm64') for cross-compilation builds.
+    When set, the matching-arch mssql_py_core wheel is selected instead of the
+    host arch reported by platform.machine() -- required because Windows arm64
+    wheels are cross-built on an x64 host, where an unset value would vendor the
+    x64 core into the arm64 wheel. The import self-check is also skipped when the
+    target differs from the host (a cross-arch .pyd cannot load here). Defaults to
+    empty (use host arch), which is correct for native/local builds.
 #>
 
 param(
     [string]$FeedUrl = "https://pkgs.dev.azure.com/sqlclientdrivers/public/_packaging/mssql-rs_Public/nuget/v3/index.json",
-    [string]$OutputDir = "$env:TEMP\mssql-py-core-wheels"
+    [string]$OutputDir = "$env:TEMP\mssql-py-core-wheels",
+    [string]$TargetArch = ""
 )
 
 $ErrorActionPreference = 'Stop'
@@ -34,26 +44,37 @@ function Read-PackageVersion {
 }
 
 function Get-PlatformInfo {
-    # Single python call to get version, platform, and arch
+    # Single python call to get version, platform, and HOST arch
     $info = & python -c "import sys, platform; v = sys.version_info; print(f'cp{v.major}{v.minor} {platform.system().lower()} {platform.machine().lower()}')"
     if ($LASTEXITCODE -ne 0) { throw "Failed to detect Python platform info" }
 
     $parts = $info -split ' '
     $script:PyVersion = $parts[0]
     $script:Platform = $parts[1]
-    $script:Arch = $parts[2]
+    $hostArch = $parts[2]
 
-    Write-Host "Python: $script:PyVersion | Platform: $script:Platform | Arch: $script:Arch"
-
-    # Normalize arch tag
-    $archTag = switch -Regex ($script:Arch) {
-        'amd64|x86_64' { 'x86_64' }
-        'arm64|aarch64' { 'aarch64' }
-        default { throw "Unsupported architecture: $script:Arch" }
+    # Normalize an arch string (platform.machine() or -TargetArch) to a wheel tag.
+    function ConvertTo-ArchTag($a) {
+        switch -Regex ($a) {
+            'amd64|x86_64|x64' { return 'x86_64' }
+            'arm64|aarch64'    { return 'aarch64' }
+            default { throw "Unsupported architecture: $a" }
+        }
     }
 
+    # Select the wheel by TARGET arch, not host arch. Windows arm64 wheels are
+    # cross-built on an x64 host, where the running Python is x64 and reports the
+    # HOST via platform.machine(); without this override the installer would vendor
+    # the x64 core into the arm64 wheel. Empty -TargetArch (native/local) -> host.
+    $hostArchTag = ConvertTo-ArchTag $hostArch
+    $archTag = if ($TargetArch) { ConvertTo-ArchTag $TargetArch } else { $hostArchTag }
+    $script:IsCrossArch = ($archTag -ne $hostArchTag)
+
+    Write-Host "Python: $script:PyVersion | Platform: $script:Platform | Arch: $archTag (host: $hostArchTag, target: $(if ($TargetArch) { $TargetArch } else { '<host>' }))"
+
     $script:WheelPlatform = switch ($script:Platform) {
-        'windows' { "win_$($archTag -replace 'x86_64','amd64')" }
+        # aarch64 -> arm64 so a Windows arm64 target resolves win_arm64, not win_aarch64.
+        'windows' { "win_$($archTag -replace 'x86_64','amd64' -replace 'aarch64','arm64')" }
         'linux' { "linux_$archTag" }
         'darwin' { 'macosx_15_0_universal2' }
         default { throw "Unsupported platform: $script:Platform" }
@@ -122,6 +143,14 @@ function Install-AndVerify {
 
     & python "$ScriptDir\extract_wheel.py" $script:MatchingWheel.FullName $RepoRoot
     if ($LASTEXITCODE -ne 0) { throw "Failed to extract mssql_py_core from wheel" }
+
+    # Skip the import self-check on cross-arch builds: an arm64 .pyd cannot be
+    # loaded by the x64 Python running on the build host. The wheel is still
+    # vendored correctly and is exercised by tests on native-arch agents.
+    if ($script:IsCrossArch) {
+        Write-Host "Skipping import verification (cross-arch build: target != host)"
+        return
+    }
 
     Write-Host "Verifying import..."
     Push-Location $RepoRoot


### PR DESCRIPTION
### Work Item / Issue Reference
> [AB#47315](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/47315)

### Summary

Windows **arm64** wheels shipped a **wrong-architecture** `mssql_py_core`, breaking bulk copy on arm64.

**Root cause.** [`eng/scripts/install-mssql-py-core.ps1`](eng/scripts/install-mssql-py-core.ps1) picked the core wheel from the **host** arch (`platform.machine()`). Windows arm64 wheels are *cross-built on an x64 host*, so the installer always fetched the `win_amd64` core and `setup.py bdist_wheel` packaged it into the arm64 wheel. `validate_mssql_py_core()` only checks that a `.pyd` *exists*, not its architecture, so nothing caught it — the arm64 wheel silently shipped an x64 bulk-copy binary.

**Fix (2 files):**
- **`install-mssql-py-core.ps1`** — new `-TargetArch` parameter. When set, the core wheel is selected by the **target** arch; `aarch64` maps to `arm64` in the Windows wheel-platform tag so it resolves `win_arm64` (not `win_aarch64`); and the `import mssql_py_core` self-check is skipped on cross-arch builds (an arm64 `.pyd` cannot load in the x64 build Python). Empty `-TargetArch` keeps host behaviour, so x64 and local/native builds are unchanged.
- **`OneBranchPipelines/stages/build-windows-single-stage.yml`** — the install step now passes `-TargetArch $(targetArch)`. (`$env:ARCHITECTURE` isn't usable here — it's only `set` inline at `bdist_wheel`, *after* the installer runs.)

**Why this is complete and safe:**
- The pinned core feed (`mssql-py-core-wheels` **0.1.9**, from `eng/versions/mssql-py-core.version`) contains `win_arm64` wheels for **cp311–cp314**, which exactly matches the Windows arm64 build matrix (`3.11–3.14`; py3.10 arm64 is **not** built) — so every arm64 stage resolves a matching core. No `setup.py` change is needed.
- x64 stages: `target == host` → verify still runs, no behaviour change.

**Validation.** PowerShell AST parse is clean; the arch-selection was unit-checked on an x64 host — `arm64 → win_arm64` (cross-arch, verify skipped), `x64`/empty `→ win_amd64` (verify runs) — all present in the 0.1.9 feed. Final proof is the arm64 Windows pipeline leg producing a wheel whose vendored `mssql_py_core*.pyd` is ARM64.

**Follow-up (separate PR).** The conda `bld.bat` `mssql_py_core` strip can be dropped once these arm64 wheels flow through (the "restore path").
