### PR TITLE
FIX: Skip source-contract tests for isolated wheel runs

### DIFF
--- a/tests/test_026_windows_dll_search.py
+++ b/tests/test_026_windows_dll_search.py
@@ -21,7 +21,14 @@ deterministic, platform-independent way to fail if the hardening is reverted.
 import re
 from pathlib import Path
 
-_LOADER_SRC = Path(__file__).resolve().parents[1] / "mssql_python" / "pybind" / "ddbc_bindings.cpp"
+import pytest
+
+_PYBIND_DIR = Path(__file__).resolve().parents[1] / "mssql_python" / "pybind"
+_LOADER_SRC = _PYBIND_DIR / "ddbc_bindings.cpp"
+pytestmark = pytest.mark.skipif(
+    not _PYBIND_DIR.is_dir(),
+    reason="requires a source checkout; isolated wheel tests omit the source tree",
+)
 
 
 def _code_without_comments(text):


### PR DESCRIPTION
### Work Item / Issue Reference

> ADO Work Item: Fixed [AB#47762](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/47762)

-------------------------------------------------------------------
### Summary

Skip the Windows DLL source-contract tests when release validation intentionally runs from an isolated wheel without the source tree. Keep the loader presence and hardening assertions active in normal source checkouts.
