### PR TITLE
FEAT: Expose SQL Server type constants at module level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
-- Module-level `SQL_SS_TIME2` (-154), `SQL_SS_XML` (-152), and `SQL_SS_VARIANT`
-  (-150) type constants, exposing the SQL Server-specific ODBC type codes at the
-  package level for pyodbc parity (e.g. `mssql_python.SQL_SS_TIME2`). These were
-  already present in `ConstantsDDBC` but not re-exported, so consumers such as
-  Django's SQL Server backend had to fall back to a hard-coded literal.
 - New feature: Support for macOS and Linux.
 - Documentation: Added API documentation in the Wiki.
 - New `token_provider=` parameter on `connect()` / `Connection` for Microsoft

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- Module-level `SQL_SS_TIME2` (-154), `SQL_SS_XML` (-152), and `SQL_SS_VARIANT`
+  (-150) type constants, exposing the SQL Server-specific ODBC type codes at the
+  package level for pyodbc parity (e.g. `mssql_python.SQL_SS_TIME2`). These were
+  already present in `ConstantsDDBC` but not re-exported, so consumers such as
+  Django's SQL Server backend had to fall back to a hard-coded literal.
 - New feature: Support for macOS and Linux.
 - Documentation: Added API documentation in the Wiki.
 - New `token_provider=` parameter on `connect()` / `Connection` for Microsoft

--- a/mssql_python/__init__.py
+++ b/mssql_python/__init__.py
@@ -179,6 +179,10 @@ from .constants import (  # noqa: F401
     SQL_TYPE_TIMESTAMP,
     SQL_GUID,
     SQL_XML,
+    # SQL Server-specific type constants (pyodbc parity)
+    SQL_SS_TIME2,
+    SQL_SS_XML,
+    SQL_SS_VARIANT,
     # Connection attribute constants
     SQL_ATTR_ACCESS_MODE,
     SQL_ATTR_CONNECTION_TIMEOUT,
@@ -388,6 +392,10 @@ __all__ = [
     "SQL_TYPE_TIMESTAMP",
     "SQL_GUID",
     "SQL_XML",
+    # SQL Server-specific type constants (pyodbc parity)
+    "SQL_SS_TIME2",
+    "SQL_SS_XML",
+    "SQL_SS_VARIANT",
     # Connection attribute constants
     "SQL_ATTR_ACCESS_MODE",
     "SQL_ATTR_CONNECTION_TIMEOUT",

--- a/mssql_python/constants.py
+++ b/mssql_python/constants.py
@@ -594,6 +594,10 @@ _DDBC_PUBLIC_API = {
     "SQL_TYPE_TIMESTAMP",
     "SQL_GUID",
     "SQL_XML",
+    # SQL Server-specific type constants (pyodbc parity)
+    "SQL_SS_TIME2",
+    "SQL_SS_XML",
+    "SQL_SS_VARIANT",
     # Connection attribute constants (ODBC-standard, driver-independent only)
     "SQL_ATTR_ACCESS_MODE",
     "SQL_ATTR_CONNECTION_TIMEOUT",

--- a/mssql_python/mssql_python.pyi
+++ b/mssql_python/mssql_python.pyi
@@ -383,6 +383,10 @@ SQL_LONGVARBINARY: int
 SQL_DATE: int
 SQL_TIME: int
 SQL_TIMESTAMP: int
+# SQL Server-specific type constants (pyodbc parity)
+SQL_SS_TIME2: int
+SQL_SS_XML: int
+SQL_SS_VARIANT: int
 SQL_WMETADATA: int
 
 # Connection Attribute Constants

--- a/tests/test_003_connection.py
+++ b/tests/test_003_connection.py
@@ -3550,6 +3550,28 @@ def test_set_attr_constants_access():
         assert not hasattr(mssql_python, const_name), f"{const_name} should NOT be public API"
 
 
+def test_sql_server_type_constants_public_api():
+    """SQL Server-specific ODBC type constants must be exposed at the package level.
+
+    pyodbc exposes SQL_SS_TIME2, SQL_SS_XML, and SQL_SS_VARIANT as module-level
+    attributes. mssql_python must match so drop-in consumers (e.g. Django's SQL
+    Server backend, which reads Database.SQL_SS_TIME2) don't need a fallback.
+    """
+    expected = {
+        "SQL_SS_TIME2": -154,
+        "SQL_SS_XML": -152,
+        "SQL_SS_VARIANT": -150,
+    }
+    for const_name, const_value in expected.items():
+        assert hasattr(
+            mssql_python, const_name
+        ), f"{const_name} should be public API (pyodbc parity)"
+        assert (
+            getattr(mssql_python, const_name) == const_value
+        ), f"{const_name} should equal {const_value}"
+        assert const_name in mssql_python.__all__, f"{const_name} should be in __all__"
+
+
 def test_set_attr_basic_functionality(db_connection):
     """Test basic set_attr functionality with ODBC-standard attributes."""
     try:

--- a/tests/test_003_connection.py
+++ b/tests/test_003_connection.py
@@ -3493,11 +3493,11 @@ def test_connection_searchescape_consistency(db_connection):
 
 
 def test_set_attr_constants_access():
-    """Test that only relevant connection attribute constants are accessible.
+    """Test that only supported constants are accessible.
 
     This test distinguishes between driver-independent (ODBC standard) and
     driver-manager–dependent (may not be supported everywhere) constants.
-    Only ODBC-standard, cross-platform constants should be public API.
+    ODBC-standard and supported SQL Server-specific constants should be public API.
     """
     # ODBC-standard, driver-independent constants (should be public)
     odbc_attr_constants = [
@@ -3516,6 +3516,11 @@ def test_set_attr_constants_access():
         "SQL_MODE_READ_WRITE",
         "SQL_MODE_READ_ONLY",
     ]
+    sql_server_type_constants = {
+        "SQL_SS_TIME2": -154,
+        "SQL_SS_XML": -152,
+        "SQL_SS_VARIANT": -150,
+    }
 
     # Driver-manager–dependent or rarely supported constants (should NOT be public API)
     dm_attr_constants = [
@@ -3537,39 +3542,20 @@ def test_set_attr_constants_access():
     ]
     dm_value_constants = ["SQL_CD_TRUE", "SQL_CD_FALSE", "SQL_RESET_CONNECTION_YES"]
 
-    # Check ODBC-standard constants are present and int
-    for const_name in odbc_attr_constants + odbc_value_constants:
-        assert hasattr(
-            mssql_python, const_name
-        ), f"{const_name} should be available (ODBC standard)"
+    # Check supported constants are present and int
+    public_constants = odbc_attr_constants + odbc_value_constants + list(sql_server_type_constants)
+    for const_name in public_constants:
+        assert hasattr(mssql_python, const_name), f"{const_name} should be available"
         const_value = getattr(mssql_python, const_name)
         assert isinstance(const_value, int), f"{const_name} should be an integer"
+        if const_name in sql_server_type_constants:
+            expected_value = sql_server_type_constants[const_name]
+            assert const_value == expected_value, f"{const_name} should equal {expected_value}"
+            assert const_name in mssql_python.__all__, f"{const_name} should be in __all__"
 
     # Check driver-manager–dependent constants are NOT present
     for const_name in dm_attr_constants + dm_value_constants:
         assert not hasattr(mssql_python, const_name), f"{const_name} should NOT be public API"
-
-
-def test_sql_server_type_constants_public_api():
-    """SQL Server-specific ODBC type constants must be exposed at the package level.
-
-    pyodbc exposes SQL_SS_TIME2, SQL_SS_XML, and SQL_SS_VARIANT as module-level
-    attributes. mssql_python must match so drop-in consumers (e.g. Django's SQL
-    Server backend, which reads Database.SQL_SS_TIME2) don't need a fallback.
-    """
-    expected = {
-        "SQL_SS_TIME2": -154,
-        "SQL_SS_XML": -152,
-        "SQL_SS_VARIANT": -150,
-    }
-    for const_name, const_value in expected.items():
-        assert hasattr(
-            mssql_python, const_name
-        ), f"{const_name} should be public API (pyodbc parity)"
-        assert (
-            getattr(mssql_python, const_name) == const_value
-        ), f"{const_name} should equal {const_value}"
-        assert const_name in mssql_python.__all__, f"{const_name} should be in __all__"
 
 
 def test_set_attr_basic_functionality(db_connection):

--- a/tests/test_003_connection.py
+++ b/tests/test_003_connection.py
@@ -3492,7 +3492,7 @@ def test_connection_searchescape_consistency(db_connection):
 # ==================== SET_ATTR TEST CASES ====================
 
 
-def test_set_attr_constants_access():
+def test_constants_access():
     """Test that only supported constants are accessible.
 
     This test distinguishes between driver-independent (ODBC standard) and
@@ -3541,6 +3541,7 @@ def test_set_attr_constants_access():
         "SQL_CUR_USE_DRIVER",
     ]
     dm_value_constants = ["SQL_CD_TRUE", "SQL_CD_FALSE", "SQL_RESET_CONNECTION_YES"]
+    internal_type_constants = ["SQL_SS_UDT", "SQL_DATETIMEOFFSET"]
 
     # Check supported constants are present and int
     public_constants = odbc_attr_constants + odbc_value_constants + list(sql_server_type_constants)
@@ -3553,8 +3554,8 @@ def test_set_attr_constants_access():
             assert const_value == expected_value, f"{const_name} should equal {expected_value}"
             assert const_name in mssql_python.__all__, f"{const_name} should be in __all__"
 
-    # Check driver-manager–dependent constants are NOT present
-    for const_name in dm_attr_constants + dm_value_constants:
+    # Check unsupported or intentionally internal constants are NOT present
+    for const_name in dm_attr_constants + dm_value_constants + internal_type_constants:
         assert not hasattr(mssql_python, const_name), f"{const_name} should NOT be public API"
 
 


### PR DESCRIPTION
> GitHub Issue: #763

### Summary

This pull request adds support for several SQL Server–specific type constants to align with pyodbc and clarifies which constants are part of the public API. The changes ensure these constants are available in the package, included in the module’s exports, and properly tested for presence and value.

**Public API and constant support improvements:**

* Added SQL Server–specific type constants (`SQL_SS_TIME2`, `SQL_SS_XML`, `SQL_SS_VARIANT`) to the exports in `mssql_python/__init__.py` and included them in the module’s `__all__` list for public API parity with pyodbc. [[1]](diffhunk://#diff-d95f3a67986de29f30453416b1b4c34e6a43207e9a33e2b1b80ef0c378b0a538R182-R185) [[2]](diffhunk://#diff-d95f3a67986de29f30453416b1b4c34e6a43207e9a33e2b1b80ef0c378b0a538R395-R398)
* Updated `get_info_constants()` in `mssql_python/constants.py` to include the new SQL Server–specific constants.
* Declared the new constants in the type stub file `mssql_python/mssql_python.pyi` to improve type checking and editor support.

**Testing and documentation updates:**

* Revised and renamed the test for constant accessibility in `tests/test_003_connection.py` to check that the new SQL Server–specific constants are present, have the correct values, and are included in the public API, while ensuring unsupported or internal constants remain private. [[1]](diffhunk://#diff-ca315ffd463e0f93f3d45ace0869a4a3b1e572941da6723d7e9ce028cf9d2278L3495-R3500) [[2]](diffhunk://#diff-ca315ffd463e0f93f3d45ace0869a4a3b1e572941da6723d7e9ce028cf9d2278R3519-R3523) [[3]](diffhunk://#diff-ca315ffd463e0f93f3d45ace0869a4a3b1e572941da6723d7e9ce028cf9d2278R3544-R3558)
