### PR TITLE
FIX: Decode SQL_DATABASE_NAME in Connection.getinfo()

### DIFF
--- a/mssql_python/connection.py
+++ b/mssql_python/connection.py
@@ -1880,6 +1880,7 @@ class Connection:
             # String types - these return strings in pyodbc
             string_type_constants = {
                 GetInfoConstants.SQL_DATA_SOURCE_NAME.value,
+                GetInfoConstants.SQL_DATABASE_NAME.value,
                 GetInfoConstants.SQL_DRIVER_NAME.value,
                 GetInfoConstants.SQL_DRIVER_VER.value,
                 GetInfoConstants.SQL_SERVER_NAME.value,

--- a/tests/test_003_connection.py
+++ b/tests/test_003_connection.py
@@ -2882,6 +2882,7 @@ def test_getinfo_string_encoding_utf16(db_connection):
         ("SQL_DRIVER_VER", sql_const.SQL_DRIVER_VER.value),
         ("SQL_DRIVER_NAME", sql_const.SQL_DRIVER_NAME.value),
         ("SQL_DRIVER_ODBC_VER", sql_const.SQL_DRIVER_ODBC_VER.value),
+        ("SQL_DATABASE_NAME", sql_const.SQL_DATABASE_NAME.value),
         ("SQL_SERVER_NAME", sql_const.SQL_SERVER_NAME.value),
     ]
 


### PR DESCRIPTION
### Work Item / Issue Reference

> GitHub Issue: #762

> ADO Work Item: [AB#48069](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/48069)

-------------------------------------------------------------------
### Summary

Decode `SQL_DATABASE_NAME` metadata using the same UTF-16LE path as other string-valued `SQLGetInfo` results. Extend the existing integration test to prevent embedded NUL characters from returning in the database name.