### PR TITLE
FIX: Prevent pooled connections from retaining empty transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   before; users should call `cursor.setinputsizes()` to work around this.
 
 ### Fixed
+- **GH-754:** Pooled connections are now rolled back and restored to autocommit
+  mode before being parked. This prevents an empty transaction from remaining
+  visible on an idle SQL Server session after `Connection.close()`.
 - **GH-740:** A Python `Decimal` whose value falls in the SQL Server MONEY /
   SMALLMONEY range is now bound as `SQL_NUMERIC` with its own precision and scale
   on both `execute()` paths (native detection, and the legacy path reached when

--- a/mssql_python/connection.py
+++ b/mssql_python/connection.py
@@ -2158,6 +2158,7 @@ class Connection:
         # Close the connection even if cursor cleanup had issues
         try:
             if self._conn:
+                rollback_error = None
                 if not self.autocommit and not self._pooling:
                     # If autocommit is disabled, rollback any uncommitted changes
                     # before disconnecting a non-pooled connection. Pooled
@@ -2165,6 +2166,10 @@ class Connection:
                     # which can discard the connection and release its capacity
                     # atomically if sanitation fails.
                     logger.debug("Rolling back uncommitted changes before closing connection.")
+                    try:
+                        self._conn.rollback()
+                    except RuntimeError as e:
+                        rollback_error = e
                 # TODO: Check potential race conditions in case of multithreaded scenarios
                 # Close the connection
                 try:
@@ -2173,6 +2178,9 @@ class Connection:
                     _raise_connection_error(e)
                 finally:
                     self._conn = None
+                if rollback_error is not None:
+                    # Preserve prior DB-API error mapping after deterministic cleanup.
+                    _raise_connection_error(rollback_error)
         except Exception as e:
             logger.error(f"Error closing database connection: {e}")
             # Re-raise the connection close error as it's more critical

--- a/mssql_python/connection.py
+++ b/mssql_python/connection.py
@@ -2159,12 +2159,10 @@ class Connection:
         try:
             if self._conn:
                 rollback_error = None
-                if not self.autocommit and not self._pooling:
-                    # If autocommit is disabled, rollback any uncommitted changes
-                    # before disconnecting a non-pooled connection. Pooled
-                    # connections are rolled back by the native check-in path,
-                    # which can discard the connection and release its capacity
-                    # atomically if sanitation fails.
+                if not self.autocommit:
+                    # End caller work before native close. Pooled connections are
+                    # additionally restored to autocommit by native check-in,
+                    # which atomically discards them if sanitation fails.
                     logger.debug("Rolling back uncommitted changes before closing connection.")
                     try:
                         self._conn.rollback()

--- a/mssql_python/connection.py
+++ b/mssql_python/connection.py
@@ -2177,7 +2177,7 @@ class Connection:
                 # TODO: Check potential race conditions in case of multithreaded scenarios
                 # Close the connection
                 try:
-                    self._conn.close()
+                    self._conn.close(manual_commit and rollback_error is None)
                 except RuntimeError as e:
                     _raise_connection_error(e)
                 finally:

--- a/mssql_python/connection.py
+++ b/mssql_python/connection.py
@@ -2158,21 +2158,21 @@ class Connection:
         # Close the connection even if cursor cleanup had issues
         try:
             if self._conn:
-                if not self.autocommit:
+                if not self.autocommit and not self._pooling:
                     # If autocommit is disabled, rollback any uncommitted changes
-                    # This is important to ensure no partial transactions remain
-                    # For autocommit True, this is not necessary as each statement is
-                    # committed immediately
+                    # before disconnecting a non-pooled connection. Pooled
+                    # connections are rolled back by the native check-in path,
+                    # which can discard the connection and release its capacity
+                    # atomically if sanitation fails.
                     logger.debug("Rolling back uncommitted changes before closing connection.")
-                    try:
-                        self._conn.rollback()
-                    except RuntimeError as e:
-                        # Handle C++ layer RuntimeError with proper DB-API exception mapping
-                        _raise_connection_error(e)
                 # TODO: Check potential race conditions in case of multithreaded scenarios
                 # Close the connection
-                self._conn.close()
-                self._conn = None
+                try:
+                    self._conn.close()
+                except RuntimeError as e:
+                    _raise_connection_error(e)
+                finally:
+                    self._conn = None
         except Exception as e:
             logger.error(f"Error closing database connection: {e}")
             # Re-raise the connection close error as it's more critical

--- a/mssql_python/connection.py
+++ b/mssql_python/connection.py
@@ -2158,8 +2158,14 @@ class Connection:
         # Close the connection even if cursor cleanup had issues
         try:
             if self._conn:
+                autocommit_error = None
                 rollback_error = None
-                if not self.autocommit:
+                manual_commit = False
+                try:
+                    manual_commit = not self._conn.get_autocommit()
+                except RuntimeError as e:
+                    autocommit_error = e
+                if manual_commit:
                     # End caller work before native close. Pooled connections are
                     # additionally restored to autocommit by native check-in,
                     # which atomically discards them if sanitation fails.
@@ -2179,6 +2185,8 @@ class Connection:
                 if rollback_error is not None:
                     # Preserve prior DB-API error mapping after deterministic cleanup.
                     _raise_connection_error(rollback_error)
+                if autocommit_error is not None:
+                    _raise_connection_error(autocommit_error)
         except Exception as e:
             logger.error(f"Error closing database connection: {e}")
             # Re-raise the connection close error as it's more critical

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -211,6 +211,17 @@ void Connection::disconnect() {
     }
 }
 
+void Connection::abandonDuringFinalization() noexcept {
+    {
+        std::lock_guard<std::mutex> lock(_childHandlesMutex);
+        _childStatementHandles.clear();
+        _allocationsSinceCompaction = 0;
+    }
+    // SqlHandle::free() already suppresses SQLFreeHandle during finalization.
+    // Clearing the shared pointer leaves process teardown to the operating system.
+    _dbcHandle.reset();
+}
+
 // TODO(microsoft): Add an exception class in C++ for error handling,
 // DB spec compliant
 void Connection::checkError(SQLRETURN ret) const {
@@ -698,15 +709,15 @@ ConnectionHandle::ConnectionHandle(const std::u16string& connStr, bool usePool,
 ConnectionHandle::~ConnectionHandle() {
     if (_conn) {
         if (isPythonFinalizing()) {
-            try {
-                _conn->disconnect();
-            } catch (...) {
-            }
+            _conn->abandonDuringFinalization();
             _conn = nullptr;
             return;
         }
         try {
-            close();
+            // A destructor cannot report sanitation errors to a caller. Discard
+            // instead of running close(), which performs logging and transaction
+            // operations that are unsafe during late object teardown.
+            ConnectionPoolManager::getInstance().discardConnection(_originPool, _conn);
         } catch (...) {
             if (_conn) {
                 try {

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -575,14 +575,17 @@ void Connection::prepareForPool() {
         ThrowStdException("Connection handle not allocated");
     }
 
-    if (!getAutocommit()) {
-        // End any caller transaction before check-in, then park the physical
-        // connection in autocommit mode. The SQL Server ODBC driver can leave
-        // an empty transaction visible after SQLEndTran while manual-commit
-        // mode remains enabled; switching modes ends that transaction.
-        rollback();
-        setAutocommit(true);
+    // Explicit BEGIN TRANSACTION is valid while ODBC autocommit is on, but
+    // SQLEndTran does not end that transaction until the connection enters
+    // manual-commit mode.
+    if (getAutocommit()) {
+        setAutocommit(false);
     }
+    rollback();
+    // The SQL Server ODBC driver can leave an empty transaction visible after
+    // SQLEndTran while manual-commit mode remains enabled, so always park the
+    // physical connection in autocommit mode.
+    setAutocommit(true);
 }
 
 void Connection::updateLastUsed() {

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -52,8 +52,14 @@ Connection::Connection(const std::u16string& conn_str, bool use_pool)
     allocateDbcHandle();
 }
 
-Connection::~Connection() {
-    disconnect();  // fallback if user forgets to disconnect
+Connection::~Connection() noexcept {
+    try {
+        disconnect();  // fallback if user forgets to disconnect
+    } catch (...) {
+        // Destructors must not propagate ODBC disconnect failures. Releasing
+        // the handle still lets SqlHandle perform SQLFreeHandle cleanup.
+        _dbcHandle.reset();
+    }
 }
 
 // Allocates connection handle
@@ -564,6 +570,21 @@ bool Connection::reset() {
     return true;
 }
 
+void Connection::prepareForPool() {
+    if (!_dbcHandle) {
+        ThrowStdException("Connection handle not allocated");
+    }
+
+    if (!getAutocommit()) {
+        // End any caller transaction before check-in, then park the physical
+        // connection in autocommit mode. The SQL Server ODBC driver can leave
+        // an empty transaction visible after SQLEndTran while manual-commit
+        // mode remains enabled; switching modes ends that transaction.
+        rollback();
+        setAutocommit(true);
+    }
+}
+
 void Connection::updateLastUsed() {
     _lastUsed = std::chrono::steady_clock::now();
 }
@@ -659,7 +680,17 @@ ConnectionHandle::ConnectionHandle(const std::u16string& connStr, bool usePool,
 
 ConnectionHandle::~ConnectionHandle() {
     if (_conn) {
-        close();
+        try {
+            close();
+        } catch (...) {
+            if (_conn) {
+                try {
+                    _conn->disconnect();
+                } catch (...) {
+                }
+            }
+            _conn = nullptr;
+        }
     }
 }
 
@@ -669,6 +700,19 @@ void ConnectionHandle::close() {
         ThrowStdException("Connection object is not initialized");
     }
     if (_usePool) {
+        try {
+            _conn->prepareForPool();
+        } catch (...) {
+            // Never retain a connection whose transaction state could not be
+            // sanitized. Discarding also releases this connection's reserved
+            // pool capacity. Preserve the original check-in error.
+            try {
+                ConnectionPoolManager::getInstance().discardConnection(_poolKey, _conn);
+            } catch (...) {
+            }
+            _conn = nullptr;
+            throw;
+        }
         ConnectionPoolManager::getInstance().returnConnection(_poolKey, _conn);
     } else {
         _conn->disconnect();

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -652,7 +652,8 @@ ConnectionHandle::ConnectionHandle(const std::u16string& connStr, bool usePool,
     PERF_TIMER("ConnectionHandle::ConnectionHandle");
     if (_usePool) {
         _conn = ConnectionPoolManager::getInstance().acquireConnection(_connStr, attrsBefore,
-                                                                       _poolKey, tokenFactory);
+                                                                       _poolKey, tokenFactory,
+                                                                       &_originPool);
         // acquireConnection returns nullptr when pooling was disabled out from
         // under us (a disable_pooling() won the race). Fall back to a non-pooled
         // connection and flip _usePool so close() disconnects it directly rather
@@ -707,13 +708,13 @@ void ConnectionHandle::close() {
             // sanitized. Discarding also releases this connection's reserved
             // pool capacity. Preserve the original check-in error.
             try {
-                ConnectionPoolManager::getInstance().discardConnection(_poolKey, _conn);
+                ConnectionPoolManager::getInstance().discardConnection(_originPool, _conn);
             } catch (...) {
             }
             _conn = nullptr;
             throw;
         }
-        ConnectionPoolManager::getInstance().returnConnection(_poolKey, _conn);
+        ConnectionPoolManager::getInstance().returnConnection(_poolKey, _originPool, _conn);
     } else {
         _conn->disconnect();
     }

--- a/mssql_python/pybind/connection/connection.cpp
+++ b/mssql_python/pybind/connection/connection.cpp
@@ -18,6 +18,17 @@
 #include "logger_bridge.hpp"
 #include "performance_counter.hpp"
 
+static bool isPythonFinalizing() {
+    if (Py_IsInitialized() == 0) {
+        return true;
+    }
+#if PY_VERSION_HEX >= 0x030D0000
+    return Py_IsFinalizing() != 0;
+#else
+    return _Py_IsFinalizing() != 0;
+#endif
+}
+
 static SqlHandlePtr getEnvHandle() {
     static SqlHandlePtr envHandle = []() -> SqlHandlePtr {
         LOG("Allocating ODBC environment handle");
@@ -119,7 +130,7 @@ void Connection::disconnect() {
     // Py_IsInitialized() is checked first: after Py_Finalize() the interpreter is
     // gone and PyGILState_Check() is unreliable, so treat "not initialized" as
     // "no GIL" and skip all Python calls. (#671 follow-up)
-    bool hasGil = Py_IsInitialized() != 0 && PyGILState_Check() != 0;
+    bool hasGil = !isPythonFinalizing() && PyGILState_Check() != 0;
     if (_dbcHandle) {
         if (hasGil) {
             LOG("Disconnecting from database");
@@ -570,7 +581,7 @@ bool Connection::reset() {
     return true;
 }
 
-void Connection::prepareForPool() {
+void Connection::prepareForPool(bool transactionAlreadyRolledBack) {
     if (!_dbcHandle) {
         ThrowStdException("Connection handle not allocated");
     }
@@ -581,7 +592,9 @@ void Connection::prepareForPool() {
     if (getAutocommit()) {
         setAutocommit(false);
     }
-    rollback();
+    if (!transactionAlreadyRolledBack) {
+        rollback();
+    }
     // The SQL Server ODBC driver can leave an empty transaction visible after
     // SQLEndTran while manual-commit mode remains enabled, so always park the
     // physical connection in autocommit mode.
@@ -684,6 +697,14 @@ ConnectionHandle::ConnectionHandle(const std::u16string& connStr, bool usePool,
 
 ConnectionHandle::~ConnectionHandle() {
     if (_conn) {
+        if (isPythonFinalizing()) {
+            try {
+                _conn->disconnect();
+            } catch (...) {
+            }
+            _conn = nullptr;
+            return;
+        }
         try {
             close();
         } catch (...) {
@@ -698,14 +719,14 @@ ConnectionHandle::~ConnectionHandle() {
     }
 }
 
-void ConnectionHandle::close() {
+void ConnectionHandle::close(bool transactionAlreadyRolledBack) {
     PERF_TIMER("ConnectionHandle::close");
     if (!_conn) {
         ThrowStdException("Connection object is not initialized");
     }
     if (_usePool) {
         try {
-            _conn->prepareForPool();
+            _conn->prepareForPool(transactionAlreadyRolledBack);
         } catch (...) {
             // Never retain a connection whose transaction state could not be
             // sanitized. Discarding also releases this connection's reserved

--- a/mssql_python/pybind/connection/connection.h
+++ b/mssql_python/pybind/connection/connection.h
@@ -40,6 +40,9 @@ class Connection {
     // Disconnect and free the connection handle.
     void disconnect();
 
+    // Relinquish native handles without ODBC calls during interpreter finalization.
+    void abandonDuringFinalization() noexcept;
+
     // Commit the current transaction.
     void commit();
 

--- a/mssql_python/pybind/connection/connection.h
+++ b/mssql_python/pybind/connection/connection.h
@@ -53,7 +53,7 @@ class Connection {
     bool getAutocommit() const;
     bool isAlive() const;
     bool reset();
-    void prepareForPool();
+    void prepareForPool(bool transactionAlreadyRolledBack = false);
     void updateLastUsed();
     std::chrono::steady_clock::time_point lastUsed() const;
 
@@ -142,7 +142,7 @@ class ConnectionHandle {
                      const py::object& tokenFactory = py::object());
     ~ConnectionHandle();
 
-    void close();
+    void close(bool transactionAlreadyRolledBack = false);
     void commit();
     void rollback();
     void setAutocommit(bool enabled);

--- a/mssql_python/pybind/connection/connection.h
+++ b/mssql_python/pybind/connection/connection.h
@@ -132,6 +132,8 @@ class Connection {
     mutable std::mutex _childHandlesMutex;
 };
 
+class ConnectionPool;
+
 class ConnectionHandle {
   public:
     ConnectionHandle(const std::u16string& connStr, bool usePool,
@@ -160,4 +162,7 @@ class ConnectionHandle {
     // Entra access-token auth so distinct identities never share a pool.
     // Empty is never stored; the ctor falls back to _connStr.
     std::u16string _poolKey;
+    // Identifies the exact pool generation that issued _conn. A weak reference
+    // prevents a checked-out connection from keeping a disabled pool alive.
+    std::weak_ptr<ConnectionPool> _originPool;
 };

--- a/mssql_python/pybind/connection/connection.h
+++ b/mssql_python/pybind/connection/connection.h
@@ -32,7 +32,7 @@ class Connection {
   public:
     Connection(const std::u16string& connStr, bool fromPool);
 
-    ~Connection();
+    ~Connection() noexcept;
 
     // Establish the connection using the stored connection string.
     void connect(const py::dict& attrs_before = py::dict());
@@ -53,6 +53,7 @@ class Connection {
     bool getAutocommit() const;
     bool isAlive() const;
     bool reset();
+    void prepareForPool();
     void updateLastUsed();
     std::chrono::steady_clock::time_point lastUsed() const;
 

--- a/mssql_python/pybind/connection/connection_pool.cpp
+++ b/mssql_python/pybind/connection/connection_pool.cpp
@@ -329,6 +329,20 @@ void ConnectionPool::release(std::shared_ptr<Connection> conn) {
     }
 }
 
+void ConnectionPool::discard(std::shared_ptr<Connection> conn) {
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        if (_current_size > 0)
+            --_current_size;
+    }
+    try {
+        conn->disconnect();
+    } catch (...) {
+        // The caller is already handling a sanitation failure. Connection's
+        // noexcept destructor still releases the ODBC handle.
+    }
+}
+
 bool ConnectionPool::canEvict() {
     std::lock_guard<std::mutex> lock(_mutex);
     // Never evict while any connection is checked out or in-flight. Reserved
@@ -502,6 +516,27 @@ void ConnectionPoolManager::returnConnection(const std::u16string& pool_key,
                     "connection failed: %s",
                     ex.what());
             }
+        }
+    }
+}
+
+void ConnectionPoolManager::discardConnection(const std::u16string& pool_key,
+                                               const std::shared_ptr<Connection> conn) {
+    std::shared_ptr<ConnectionPool> pool;
+    {
+        std::lock_guard<std::mutex> lock(_manager_mutex);
+        auto it = _pools.find(pool_key);
+        if (it != _pools.end()) {
+            pool = it->second;
+        }
+    }
+    if (pool) {
+        pool->discard(conn);
+    } else if (conn) {
+        try {
+            conn->disconnect();
+        } catch (...) {
+            // Connection's noexcept destructor still releases the ODBC handle.
         }
     }
 }

--- a/mssql_python/pybind/connection/connection_pool.cpp
+++ b/mssql_python/pybind/connection/connection_pool.cpp
@@ -402,7 +402,9 @@ ConnectionPoolManager& ConnectionPoolManager::getInstance() {
 std::shared_ptr<Connection> ConnectionPoolManager::acquireConnection(const std::u16string& connStr,
                                                                      const py::dict& attrs_before,
                                                                      const std::u16string& pool_key,
-                                                                     const py::object& token_factory) {
+                                                                     const py::object& token_factory,
+                                                                     std::weak_ptr<ConnectionPool>*
+                                                                         originating_pool) {
     PERF_TIMER("ConnectionPoolManager::acquireConnection");
     // Key the pool by pool_key when provided (identity-aware),
     // else fall back to the connection string (legacy behavior).
@@ -464,6 +466,9 @@ std::shared_ptr<Connection> ConnectionPoolManager::acquireConnection(const std::
             created = true;
         }
         pool = pool_ref;
+        if (originating_pool) {
+            *originating_pool = pool;
+        }
     }
     // Log after releasing _manager_mutex (#671): LOG() acquires the GIL, and
     // holding a native mutex across a GIL acquisition deadlocks a thread that
@@ -488,18 +493,18 @@ std::shared_ptr<Connection> ConnectionPoolManager::acquireConnection(const std::
     return pool->acquire(connStr, attrs_before, token_factory);
 }
 
-void ConnectionPoolManager::returnConnection(const std::u16string& pool_key,
-                                             const std::shared_ptr<Connection> conn) {
-    std::shared_ptr<ConnectionPool> pool;
+void ConnectionPoolManager::returnConnection(
+    const std::u16string& pool_key, const std::weak_ptr<ConnectionPool>& originating_pool,
+    const std::shared_ptr<Connection> conn) {
+    std::shared_ptr<ConnectionPool> pool = originating_pool.lock();
+    bool registered = false;
     {
         std::lock_guard<std::mutex> lock(_manager_mutex);
         auto it = _pools.find(pool_key);
-        if (it != _pools.end()) {
-            pool = it->second;
-        }
+        registered = pool && it != _pools.end() && it->second == pool;
     }
     // Call release() outside _manager_mutex to avoid deadlock.
-    if (pool) {
+    if (registered) {
         pool->release(conn);
     } else {
         // No pool is registered under this key (e.g. the pool was lazily
@@ -520,19 +525,16 @@ void ConnectionPoolManager::returnConnection(const std::u16string& pool_key,
     }
 }
 
-void ConnectionPoolManager::discardConnection(const std::u16string& pool_key,
-                                               const std::shared_ptr<Connection> conn) {
-    std::shared_ptr<ConnectionPool> pool;
-    {
-        std::lock_guard<std::mutex> lock(_manager_mutex);
-        auto it = _pools.find(pool_key);
-        if (it != _pools.end()) {
-            pool = it->second;
-        }
+void ConnectionPoolManager::discardConnection(
+    const std::weak_ptr<ConnectionPool>& originating_pool,
+    const std::shared_ptr<Connection> conn) {
+    if (!conn) {
+        return;
     }
+    std::shared_ptr<ConnectionPool> pool = originating_pool.lock();
     if (pool) {
         pool->discard(conn);
-    } else if (conn) {
+    } else {
         try {
             conn->disconnect();
         } catch (...) {

--- a/mssql_python/pybind/connection/connection_pool.h
+++ b/mssql_python/pybind/connection/connection_pool.h
@@ -34,6 +34,9 @@ class ConnectionPool {
     // Returns a connection to the pool for reuse
     void release(std::shared_ptr<Connection> conn);
 
+    // Permanently removes a checked-out connection and releases its capacity.
+    void discard(std::shared_ptr<Connection> conn);
+
     // Closes all connections in the pool, releasing resources
     void close();
 
@@ -81,6 +84,9 @@ class ConnectionPoolManager {
     // Returns a connection to its original pool, identified by pool_key
     // (the same key passed to acquireConnection).
     void returnConnection(const std::u16string& pool_key, std::shared_ptr<Connection> conn);
+
+    // Discards a connection that cannot safely be returned to its original pool.
+    void discardConnection(const std::u16string& pool_key, std::shared_ptr<Connection> conn);
 
     // Closes all pools and their connections
     void closePools();

--- a/mssql_python/pybind/connection/connection_pool.h
+++ b/mssql_python/pybind/connection/connection_pool.h
@@ -74,7 +74,8 @@ class ConnectionPoolManager {
     std::shared_ptr<Connection> acquireConnection(
         const std::u16string& conn_str, const py::dict& attrs_before = py::dict(),
         const std::u16string& pool_key = std::u16string(),
-        const py::object& token_factory = py::object());
+        const py::object& token_factory = py::object(),
+        std::weak_ptr<ConnectionPool>* originating_pool = nullptr);
 
     // Arms (true) or disarms (false) new-pool creation. Disarming, done under
     // _manager_mutex, guarantees that any acquireConnection() serialized after
@@ -83,10 +84,13 @@ class ConnectionPoolManager {
 
     // Returns a connection to its original pool, identified by pool_key
     // (the same key passed to acquireConnection).
-    void returnConnection(const std::u16string& pool_key, std::shared_ptr<Connection> conn);
+    void returnConnection(const std::u16string& pool_key,
+                          const std::weak_ptr<ConnectionPool>& originating_pool,
+                          std::shared_ptr<Connection> conn);
 
-    // Discards a connection that cannot safely be returned to its original pool.
-    void discardConnection(const std::u16string& pool_key, std::shared_ptr<Connection> conn);
+    // Discards a connection from the exact pool generation that issued it.
+    void discardConnection(const std::weak_ptr<ConnectionPool>& originating_pool,
+                           std::shared_ptr<Connection> conn);
 
     // Closes all pools and their connections
     void closePools();

--- a/mssql_python/pybind/ddbc_bindings.cpp
+++ b/mssql_python/pybind/ddbc_bindings.cpp
@@ -6094,7 +6094,8 @@ PYBIND11_MODULE(ddbc_bindings, m) {
                       const py::object&>(),
              py::arg("conn_str"), py::arg("use_pool"), py::arg("attrs_before") = py::dict(),
              py::arg("pool_key") = std::u16string(), py::arg("token_factory") = py::none())
-        .def("close", &ConnectionHandle::close, "Close the connection")
+        .def("close", &ConnectionHandle::close,
+             py::arg("transaction_already_rolled_back") = false, "Close the connection")
         .def("commit", &ConnectionHandle::commit, "Commit the current transaction")
         .def("rollback", &ConnectionHandle::rollback, "Rollback the current transaction")
         .def("set_autocommit", &ConnectionHandle::setAutocommit)

--- a/tests/test_006_exceptions.py
+++ b/tests/test_006_exceptions.py
@@ -292,7 +292,7 @@ def test_close_cleans_up_after_non_pooled_rollback_failure():
         conn.close()
 
     mock_conn.rollback.assert_called_once_with()
-    mock_conn.close.assert_called_once_with()
+    mock_conn.close.assert_called_once_with(False)
     assert conn._conn is None
     assert conn.closed
 
@@ -311,9 +311,25 @@ def test_close_cleans_up_after_autocommit_read_failure():
         conn.close()
 
     mock_conn.rollback.assert_not_called()
-    mock_conn.close.assert_called_once_with()
+    mock_conn.close.assert_called_once_with(False)
     assert conn._conn is None
     assert conn.closed
+
+
+def test_close_reports_successful_rollback_to_native_cleanup():
+    """Native pool cleanup must not repeat a successful Python rollback."""
+    from unittest.mock import MagicMock, patch
+
+    mock_conn = MagicMock()
+    mock_conn.get_autocommit.return_value = False
+
+    with patch("mssql_python.connection.ddbc_bindings.Connection", return_value=mock_conn):
+        conn = connect("Server=testserver;Database=mydb;Trusted_Connection=yes;")
+
+    conn.close()
+
+    mock_conn.rollback.assert_called_once_with()
+    mock_conn.close.assert_called_once_with(True)
 
 
 def test_truncate_error_message_successful_cases():

--- a/tests/test_006_exceptions.py
+++ b/tests/test_006_exceptions.py
@@ -276,6 +276,27 @@ def test_connect_runtime_error_mapped_to_correct_dbapi_exception():
     assert not isinstance(exc_info.value, RuntimeError)
 
 
+def test_close_cleans_up_after_non_pooled_rollback_failure():
+    """A rollback error must not defer native close to object destruction."""
+    from unittest.mock import MagicMock, patch
+
+    mock_conn = MagicMock()
+    mock_conn.get_autocommit.return_value = False
+    mock_conn.rollback.side_effect = RuntimeError("SQLSTATE:08S01:Communication link failure")
+
+    with patch("mssql_python.connection.ddbc_bindings.Connection", return_value=mock_conn):
+        conn = connect("Server=testserver;Database=mydb;Trusted_Connection=yes;")
+    conn._pooling = False
+
+    with pytest.raises(OperationalError, match="Communication link failure"):
+        conn.close()
+
+    mock_conn.rollback.assert_called_once_with()
+    mock_conn.close.assert_called_once_with()
+    assert conn._conn is None
+    assert conn.closed
+
+
 def test_truncate_error_message_successful_cases():
     """Test truncate_error_message with valid Microsoft messages for comparison."""
 

--- a/tests/test_006_exceptions.py
+++ b/tests/test_006_exceptions.py
@@ -297,6 +297,25 @@ def test_close_cleans_up_after_non_pooled_rollback_failure():
     assert conn.closed
 
 
+def test_close_cleans_up_after_autocommit_read_failure():
+    """An autocommit read error must not bypass native close and handle release."""
+    from unittest.mock import MagicMock, patch
+
+    mock_conn = MagicMock()
+    mock_conn.get_autocommit.side_effect = RuntimeError("SQLSTATE:08S01:Communication link failure")
+
+    with patch("mssql_python.connection.ddbc_bindings.Connection", return_value=mock_conn):
+        conn = connect("Server=testserver;Database=mydb;Trusted_Connection=yes;")
+
+    with pytest.raises(OperationalError, match="Communication link failure"):
+        conn.close()
+
+    mock_conn.rollback.assert_not_called()
+    mock_conn.close.assert_called_once_with()
+    assert conn._conn is None
+    assert conn.closed
+
+
 def test_truncate_error_message_successful_cases():
     """Test truncate_error_message with valid Microsoft messages for comparison."""
 

--- a/tests/test_006_exceptions.py
+++ b/tests/test_006_exceptions.py
@@ -276,7 +276,7 @@ def test_connect_runtime_error_mapped_to_correct_dbapi_exception():
     assert not isinstance(exc_info.value, RuntimeError)
 
 
-def test_close_cleans_up_after_non_pooled_rollback_failure():
+def test_close_cleans_up_after_rollback_failure():
     """A rollback error must not defer native close to object destruction."""
     from unittest.mock import MagicMock, patch
 
@@ -286,7 +286,6 @@ def test_close_cleans_up_after_non_pooled_rollback_failure():
 
     with patch("mssql_python.connection.ddbc_bindings.Connection", return_value=mock_conn):
         conn = connect("Server=testserver;Database=mydb;Trusted_Connection=yes;")
-    conn._pooling = False
 
     with pytest.raises(OperationalError, match="Communication link failure"):
         conn.close()
@@ -330,6 +329,49 @@ def test_close_reports_successful_rollback_to_native_cleanup():
 
     mock_conn.rollback.assert_called_once_with()
     mock_conn.close.assert_called_once_with(True)
+
+
+def test_autocommit_close_delegates_transaction_cleanup_to_native():
+    """Autocommit may still contain an explicit SQL transaction."""
+    from unittest.mock import MagicMock, patch
+
+    mock_conn = MagicMock()
+    mock_conn.get_autocommit.return_value = True
+
+    with patch("mssql_python.connection.ddbc_bindings.Connection", return_value=mock_conn):
+        conn = connect(
+            "Server=testserver;Database=mydb;Trusted_Connection=yes;",
+            autocommit=True,
+        )
+
+    conn.close()
+
+    mock_conn.rollback.assert_not_called()
+    mock_conn.close.assert_called_once_with(False)
+
+
+@pytest.mark.parametrize("preclose_failure", ["autocommit", "rollback"])
+def test_native_close_error_takes_precedence_over_preclose_failure(preclose_failure):
+    """The native close error wins, but the wrapper still releases its handle."""
+    from unittest.mock import MagicMock, patch
+
+    mock_conn = MagicMock()
+    if preclose_failure == "autocommit":
+        mock_conn.get_autocommit.side_effect = RuntimeError("SQLSTATE:08S01:Autocommit read failed")
+    else:
+        mock_conn.get_autocommit.return_value = False
+        mock_conn.rollback.side_effect = RuntimeError("SQLSTATE:08S01:Rollback failed")
+    mock_conn.close.side_effect = RuntimeError("SQLSTATE:08003:Native close failed")
+
+    with patch("mssql_python.connection.ddbc_bindings.Connection", return_value=mock_conn):
+        conn = connect("Server=testserver;Database=mydb;Trusted_Connection=yes;")
+
+    with pytest.raises(OperationalError, match="Native close failed"):
+        conn.close()
+
+    mock_conn.close.assert_called_once_with(False)
+    assert conn._conn is None
+    assert conn.closed
 
 
 def test_truncate_error_message_successful_cases():

--- a/tests/test_009_pooling.py
+++ b/tests/test_009_pooling.py
@@ -127,8 +127,8 @@ def test_connection_pooling_reuse_spid(conn_str):
     assert spid1 == spid2, "Connections not reused - different SPIDs"
 
 
-def test_pooled_close_leaves_no_open_transaction(conn_str):
-    """A physical connection must not retain a transaction while parked."""
+def test_pooled_close_paths_leave_no_open_transaction(conn_str):
+    """Every close path must leave the physical connection transaction-clean."""
     _run_in_subprocess(
         """
         import os
@@ -137,47 +137,73 @@ def test_pooled_close_leaves_no_open_transaction(conn_str):
 
         conn_str = os.environ["DB_CONNECTION_STRING"]
         mssql_python.pooling(enabled=True, max_size=2, idle_timeout=30)
-        subject = mssql_python.connect(conn_str)
         observer = mssql_python.connect(conn_str, autocommit=True)
         try:
-            cursor = subject.cursor()
-            cursor.execute("SELECT @@SPID")
-            subject_spid = cursor.fetchone()[0]
             observer_cursor = observer.cursor()
-            observer_cursor.execute(
-                "SELECT open_transaction_count "
-                "FROM sys.dm_exec_sessions WHERE session_id = ?",
-                [subject_spid],
-            )
-            if observer_cursor.fetchone() is None:
-                import sys
 
-                print(
-                    "Test login cannot inspect another SQL Server session",
-                    file=sys.stderr,
+            scenarios = (
+                ("direct commit", False, "SELECT 1", None, "commit"),
+                ("prepared commit", False, "SELECT CAST(? AS INT)", [1], "commit"),
+                ("explicit rollback", False, "SELECT 1", None, "rollback"),
+                ("implicit close rollback", False, "SELECT 1", None, None),
+                ("autocommit close", True, "SELECT 1", None, None),
+            )
+            expected_spid = None
+            for name, autocommit, sql, params, action in scenarios:
+                subject = mssql_python.connect(conn_str, autocommit=autocommit)
+                try:
+                    assert subject.autocommit is autocommit
+                    cursor = subject.cursor()
+                    cursor.execute("SELECT @@SPID")
+                    subject_spid = cursor.fetchone()[0]
+                    if expected_spid is None:
+                        expected_spid = subject_spid
+                    else:
+                        assert subject_spid == expected_spid, (
+                            f"{name}: expected pooled SPID {expected_spid}, got {subject_spid}"
+                        )
+
+                    observer_cursor.execute(
+                        "SELECT open_transaction_count "
+                        "FROM sys.dm_exec_sessions WHERE session_id = ?",
+                        [subject_spid],
+                    )
+                    if observer_cursor.fetchone() is None:
+                        import sys
+
+                        print(
+                            "Test login cannot inspect another SQL Server session",
+                            file=sys.stderr,
+                        )
+                        sys.exit(77)
+
+                    if params is None:
+                        cursor.execute(sql)
+                    else:
+                        cursor.execute(sql, params)
+                    cursor.fetchone()
+                    if action == "commit":
+                        subject.commit()
+                    elif action == "rollback":
+                        subject.rollback()
+                    cursor.close()
+                finally:
+                    subject.close()
+
+                observer_cursor.execute(
+                    "SELECT open_transaction_count "
+                    "FROM sys.dm_exec_sessions WHERE session_id = ?",
+                    [subject_spid],
                 )
-                sys.exit(77)
+                row = observer_cursor.fetchone()
+                assert row is not None, f"{name}: parked SQL Server session was not visible"
+                assert row[0] == 0, (
+                    f"{name}: pooled SPID {subject_spid} retained "
+                    f"open_transaction_count={row[0]}"
+                )
 
-            cursor.execute("SELECT 1")
-            cursor.fetchone()
-            subject.commit()
-            cursor.close()
-            subject.close()
-
-            observer_cursor.execute(
-                "SELECT open_transaction_count "
-                "FROM sys.dm_exec_sessions WHERE session_id = ?",
-                [subject_spid],
-            )
-            row = observer_cursor.fetchone()
-            assert row is not None, "The parked SQL Server session was not visible"
-            assert row[0] == 0, (
-                "Pooled connection retained an open transaction after close: "
-                f"SPID {subject_spid}, open_transaction_count={row[0]}"
-            )
             observer_cursor.close()
         finally:
-            subject.close()
             observer.close()
             mssql_python.pooling(enabled=False)
         """,
@@ -766,9 +792,9 @@ def test_pool_removes_invalid_connections(conn_str):
             spid, login_time = cur.fetchone()
             return (spid, login_time)
 
-        # Step 1: two distinct, autocommit connections. Autocommit avoids
-        # the implicit rollback in Connection.close(), which would
-        # otherwise fail on the killed session and leak its pool slot.
+        # Step 1: two distinct, autocommit connections. Autocommit keeps this
+        # test focused on detecting dead connections during checkout; failed
+        # manual-commit sanitation is covered separately below.
         victim = connect(conn_str)
         admin = connect(conn_str)
         victim.autocommit = True
@@ -831,6 +857,60 @@ def test_pool_removes_invalid_connections(conn_str):
             f"Pool returned the killed session {victim_id}; "
             f"saw sessions {seen_ids}"
         )
+        """,
+        conn_str,
+    )
+
+
+def test_failed_pool_sanitation_releases_capacity(conn_str):
+    """A connection discarded after failed sanitation must not consume a pool slot."""
+    _run_in_subprocess(
+        """
+        import os
+        import sys
+
+        from mssql_python import connect, pooling
+
+        conn_str = os.environ["DB_CONNECTION_STRING"]
+        pooling(max_size=2, idle_timeout=30)
+        victim = connect(conn_str)
+        admin = connect(conn_str, autocommit=True)
+
+        victim_cursor = victim.cursor()
+        victim_cursor.execute("SELECT @@SPID")
+        victim_spid = victim_cursor.fetchone()[0]
+        victim_cursor.close()
+
+        try:
+            admin.cursor().execute(f"KILL {victim_spid}")
+        except Exception as exc:
+            message = str(exc)
+            if "permission" in message.lower() or "kill" in message.lower():
+                print(
+                    f"Skipping: KILL not permitted for this login: {message}",
+                    file=sys.stderr,
+                )
+                victim.close()
+                admin.close()
+                sys.exit(77)
+            raise
+
+        try:
+            victim.close()
+        except Exception:
+            pass
+
+        admin.close()
+
+        first = connect(conn_str)
+        second = connect(conn_str)
+        try:
+            assert first.cursor().execute("SELECT 1").fetchone()[0] == 1
+            assert second.cursor().execute("SELECT 1").fetchone()[0] == 1
+        finally:
+            first.close()
+            second.close()
+            pooling(enabled=False)
         """,
         conn_str,
     )

--- a/tests/test_009_pooling.py
+++ b/tests/test_009_pooling.py
@@ -127,6 +127,64 @@ def test_connection_pooling_reuse_spid(conn_str):
     assert spid1 == spid2, "Connections not reused - different SPIDs"
 
 
+def test_pooled_close_leaves_no_open_transaction(conn_str):
+    """A physical connection must not retain a transaction while parked."""
+    _run_in_subprocess(
+        """
+        import os
+
+        import mssql_python
+
+        conn_str = os.environ["DB_CONNECTION_STRING"]
+        mssql_python.pooling(enabled=True, max_size=2, idle_timeout=30)
+        subject = mssql_python.connect(conn_str)
+        observer = mssql_python.connect(conn_str, autocommit=True)
+        try:
+            cursor = subject.cursor()
+            cursor.execute("SELECT @@SPID")
+            subject_spid = cursor.fetchone()[0]
+            observer_cursor = observer.cursor()
+            observer_cursor.execute(
+                "SELECT open_transaction_count "
+                "FROM sys.dm_exec_sessions WHERE session_id = ?",
+                [subject_spid],
+            )
+            if observer_cursor.fetchone() is None:
+                import sys
+
+                print(
+                    "Test login cannot inspect another SQL Server session",
+                    file=sys.stderr,
+                )
+                sys.exit(77)
+
+            cursor.execute("SELECT 1")
+            cursor.fetchone()
+            subject.commit()
+            cursor.close()
+            subject.close()
+
+            observer_cursor.execute(
+                "SELECT open_transaction_count "
+                "FROM sys.dm_exec_sessions WHERE session_id = ?",
+                [subject_spid],
+            )
+            row = observer_cursor.fetchone()
+            assert row is not None, "The parked SQL Server session was not visible"
+            assert row[0] == 0, (
+                "Pooled connection retained an open transaction after close: "
+                f"SPID {subject_spid}, open_transaction_count={row[0]}"
+            )
+            observer_cursor.close()
+        finally:
+            subject.close()
+            observer.close()
+            mssql_python.pooling(enabled=False)
+        """,
+        conn_str,
+    )
+
+
 def test_connection_pooling_isolation_level_reset(conn_str):
     """Test that pooling correctly resets session state for isolation level.
 

--- a/tests/test_009_pooling.py
+++ b/tests/test_009_pooling.py
@@ -224,6 +224,82 @@ def test_pooled_close_paths_leave_no_open_transaction(conn_str):
     )
 
 
+def test_autocommit_explicit_transaction_is_rolled_back_on_pool_checkin(conn_str):
+    """Autocommit normalization must not commit an explicit SQL transaction."""
+    _run_in_subprocess(
+        """
+        import os
+
+        import mssql_python
+
+        conn_str = os.environ["DB_CONNECTION_STRING"]
+        table = "pytest_pool_explicit_autocommit_transaction"
+        mssql_python.pooling(enabled=True, max_size=2, idle_timeout=30)
+        observer = mssql_python.connect(conn_str, autocommit=True)
+        try:
+            observer_cursor = observer.cursor()
+            observer_cursor.execute(f"DROP TABLE IF EXISTS {table}")
+            observer_cursor.execute(f"CREATE TABLE {table} (id INT PRIMARY KEY)")
+
+            subject = mssql_python.connect(conn_str, autocommit=True)
+            subject_cursor = subject.cursor()
+            subject_cursor.execute("SELECT @@SPID")
+            subject_spid = subject_cursor.fetchone()[0]
+            subject_cursor.execute(f"BEGIN TRANSACTION; INSERT INTO {table} VALUES (1)")
+            subject_cursor.close()
+            subject.close()
+
+            try:
+                observer_cursor.execute(
+                    "SELECT open_transaction_count "
+                    "FROM sys.dm_exec_sessions WHERE session_id = ?",
+                    [subject_spid],
+                )
+            except Exception as exc:
+                if "permission" in str(exc).lower():
+                    import sys
+
+                    print(
+                        "Test login cannot inspect another SQL Server session",
+                        file=sys.stderr,
+                    )
+                    sys.exit(77)
+                raise
+            row = observer_cursor.fetchone()
+            if row is None:
+                import sys
+
+                print(
+                    "Test login cannot inspect another SQL Server session",
+                    file=sys.stderr,
+                )
+                sys.exit(77)
+            assert row[0] == 0
+
+            observer_cursor.execute(f"SELECT COUNT(*) FROM {table}")
+            assert observer_cursor.fetchone()[0] == 0
+
+            reused = mssql_python.connect(conn_str, autocommit=True)
+            try:
+                reused_cursor = reused.cursor()
+                reused_cursor.execute("SELECT @@SPID, @@TRANCOUNT")
+                reused_spid, transaction_count = reused_cursor.fetchone()
+                assert reused_spid == subject_spid
+                assert transaction_count == 0
+                reused_cursor.close()
+            finally:
+                reused.close()
+
+            observer_cursor.execute(f"DROP TABLE {table}")
+            observer_cursor.close()
+        finally:
+            observer.close()
+            mssql_python.pooling(enabled=False)
+        """,
+        conn_str,
+    )
+
+
 def test_connection_pooling_isolation_level_reset(conn_str):
     """Test that pooling correctly resets session state for isolation level.
 
@@ -950,6 +1026,85 @@ def test_failed_pool_sanitation_releases_capacity(conn_str):
         finally:
             first.close()
             second.close()
+            pooling(enabled=False)
+        """,
+        conn_str,
+    )
+
+
+def test_old_pool_generation_cannot_enter_replacement_pool(conn_str):
+    """A stale checked-out connection must not alter its replacement pool."""
+    _run_in_subprocess(
+        """
+        import os
+
+        from mssql_python import connect, pooling
+
+        conn_str = os.environ["DB_CONNECTION_STRING"]
+        pooling(max_size=2, idle_timeout=30)
+        old = connect(conn_str, autocommit=True)
+        old_cursor = old.cursor()
+        old_cursor.execute("SELECT @@SPID")
+        old_spid = old_cursor.fetchone()[0]
+        old_cursor.close()
+
+        pooling(enabled=False)
+        pooling(enabled=True, max_size=2, idle_timeout=30)
+        first = connect(conn_str, autocommit=True)
+        second = connect(conn_str, autocommit=True)
+        try:
+            first_spid = first.cursor().execute("SELECT @@SPID").fetchone()[0]
+            second_spid = second.cursor().execute("SELECT @@SPID").fetchone()[0]
+            assert first_spid != second_spid
+            assert old_spid not in (first_spid, second_spid)
+
+            old.close()
+
+            try:
+                third = connect(conn_str, autocommit=True)
+            except Exception as exc:
+                assert "pool" in str(exc).lower()
+            else:
+                third.close()
+                raise AssertionError(
+                    "Stale connection entered or decremented the replacement pool"
+                )
+        finally:
+            old.close()
+            first.close()
+            second.close()
+            pooling(enabled=False)
+        """,
+        conn_str,
+    )
+
+
+def test_unclosed_native_handle_destructor_releases_pool_capacity(conn_str):
+    """Native destructor fallback must discard its checked-out pool slot."""
+    _run_in_subprocess(
+        """
+        import gc
+        import os
+
+        import mssql_python
+        from mssql_python import connect, pooling
+
+        conn_str = os.environ["DB_CONNECTION_STRING"]
+        pooling(max_size=1, idle_timeout=30)
+        wrapper = connect(conn_str, autocommit=True)
+        native = wrapper._conn
+        wrapper._conn = None
+        wrapper._closed = True
+        mssql_python._active_connections.discard(wrapper)
+        del wrapper
+        del native
+        gc.collect()
+
+        replacement = connect(conn_str, autocommit=True)
+        try:
+            assert replacement.cursor().execute("SELECT 1").fetchone()[0] == 1
+        finally:
+            replacement.close()
             pooling(enabled=False)
         """,
         conn_str,

--- a/tests/test_009_pooling.py
+++ b/tests/test_009_pooling.py
@@ -132,6 +132,7 @@ def test_pooled_close_paths_leave_no_open_transaction(conn_str):
     _run_in_subprocess(
         """
         import os
+        import sys
 
         import mssql_python
 
@@ -140,6 +141,23 @@ def test_pooled_close_paths_leave_no_open_transaction(conn_str):
         observer = mssql_python.connect(conn_str, autocommit=True)
         try:
             observer_cursor = observer.cursor()
+
+            def open_transaction_count(session_id):
+                try:
+                    observer_cursor.execute(
+                        "SELECT open_transaction_count "
+                        "FROM sys.dm_exec_sessions WHERE session_id = ?",
+                        [session_id],
+                    )
+                except Exception as exc:
+                    if "permission" in str(exc).lower():
+                        print(
+                            "Test login cannot inspect another SQL Server session",
+                            file=sys.stderr,
+                        )
+                        sys.exit(77)
+                    raise
+                return observer_cursor.fetchone()
 
             scenarios = (
                 ("direct commit", False, "SELECT 1", None, "commit"),
@@ -163,14 +181,7 @@ def test_pooled_close_paths_leave_no_open_transaction(conn_str):
                             f"{name}: expected pooled SPID {expected_spid}, got {subject_spid}"
                         )
 
-                    observer_cursor.execute(
-                        "SELECT open_transaction_count "
-                        "FROM sys.dm_exec_sessions WHERE session_id = ?",
-                        [subject_spid],
-                    )
-                    if observer_cursor.fetchone() is None:
-                        import sys
-
+                    if open_transaction_count(subject_spid) is None:
                         print(
                             "Test login cannot inspect another SQL Server session",
                             file=sys.stderr,
@@ -190,12 +201,7 @@ def test_pooled_close_paths_leave_no_open_transaction(conn_str):
                 finally:
                     subject.close()
 
-                observer_cursor.execute(
-                    "SELECT open_transaction_count "
-                    "FROM sys.dm_exec_sessions WHERE session_id = ?",
-                    [subject_spid],
-                )
-                row = observer_cursor.fetchone()
+                row = open_transaction_count(subject_spid)
                 assert row is not None, f"{name}: parked SQL Server session was not visible"
                 assert row[0] == 0, (
                     f"{name}: pooled SPID {subject_spid} retained "
@@ -868,6 +874,7 @@ def test_failed_pool_sanitation_releases_capacity(conn_str):
         """
         import os
         import sys
+        import time
 
         from mssql_python import connect, pooling
 
@@ -895,10 +902,22 @@ def test_failed_pool_sanitation_releases_capacity(conn_str):
                 sys.exit(77)
             raise
 
+        deadline = time.monotonic() + 10
+        while True:
+            try:
+                victim.cursor().execute("SELECT 1").fetchone()
+            except Exception:
+                break
+            if time.monotonic() >= deadline:
+                raise AssertionError("KILL did not terminate the victim connection")
+            time.sleep(0.05)
+
         try:
             victim.close()
         except Exception:
             pass
+        else:
+            raise AssertionError("Expected pooled sanitation to fail after KILL")
 
         admin.close()
 

--- a/tests/test_009_pooling.py
+++ b/tests/test_009_pooling.py
@@ -888,8 +888,18 @@ def test_failed_pool_sanitation_releases_capacity(conn_str):
         import time
 
         from mssql_python import connect, pooling
+        from mssql_python.connection_string_builder import _ConnectionStringBuilder
+        from mssql_python.connection_string_parser import _ConnectionStringParser
 
         conn_str = os.environ["DB_CONNECTION_STRING"]
+        parsed = _ConnectionStringParser(validate_keywords=True)._parse(conn_str)
+        normalized = {}
+        for key, value in parsed.items():
+            canonical = _ConnectionStringParser.normalize_key(key)
+            if canonical not in normalized:
+                normalized[canonical] = value
+        normalized["ConnectRetryCount"] = "0"
+        conn_str = _ConnectionStringBuilder(normalized).build()
         pooling(max_size=2, idle_timeout=30)
         victim = connect(conn_str)
         admin = connect(conn_str, autocommit=True)

--- a/tests/test_009_pooling.py
+++ b/tests/test_009_pooling.py
@@ -165,6 +165,13 @@ def test_pooled_close_paths_leave_no_open_transaction(conn_str):
                 ("explicit rollback", False, "SELECT 1", None, "rollback"),
                 ("implicit close rollback", False, "SELECT 1", None, None),
                 ("autocommit close", True, "SELECT 1", None, None),
+                (
+                    "explicit transaction in autocommit",
+                    True,
+                    "BEGIN TRANSACTION; SELECT 1",
+                    None,
+                    None,
+                ),
             )
             expected_spid = None
             for name, autocommit, sql, params, action in scenarios:
@@ -841,8 +848,12 @@ def test_pool_removes_invalid_connections(conn_str):
         # login_time, so the identity check below catches the only
         # failure mode that matters.
 
-        # Step 3: return both to the pool.
-        victim.close()
+        # Step 3: close both. Sanitation of the killed connection should fail,
+        # discard it, and may surface that connection error to the caller.
+        try:
+            victim.close()
+        except Exception:
+            pass
         admin.close()
 
         # Step 4: re-acquire from the pool. Each must be working; the


### PR DESCRIPTION
> [AB#48076](https://sqlclientdrivers.visualstudio.com/c6d89619-62de-46a0-8b46-70b92a84d85e/_workitems/edit/48076)

### Summary

Sanitize physical connections before returning them to the pool by rolling back and restoring autocommit mode. Connections that cannot be sanitized are discarded without consuming pool capacity.

Adds regression coverage that inspects the parked SQL Server session from a separate connection and verifies `open_transaction_count` is zero.