### PR TITLE
FIX: Use normalized size for DAE selection

### DIFF
--- a/mssql_python/pybind/param_detect.hpp
+++ b/mssql_python/pybind/param_detect.hpp
@@ -258,9 +258,9 @@ inline void ApplyInputSizeOverride(PyObject* params, PyObject* inputSize, Py_ssi
     }
 
     info.isDAE =
-        (PyUnicode_Check(obj) && PyLongGreaterThan(columnSize, MAX_INLINE_CHAR)) ||
+        (PyUnicode_Check(obj) && info.columnSize > MAX_INLINE_CHAR) ||
         ((PyBytes_Check(obj) || PyByteArray_Check(obj)) &&
-         PyLongGreaterThan(columnSize, MAX_INLINE_BINARY));
+         info.columnSize > MAX_INLINE_BINARY);
 
     if (PyTime_Check(obj) && info.paramCType == PARAM_C_TYPE_TEXT) {
         NormalizeTimeParam(params, index, info.columnSize);

--- a/tests/test_023_execute_path_parity.py
+++ b/tests/test_023_execute_path_parity.py
@@ -341,8 +341,19 @@ def test_setinputsizes_binary_dae(cursor):
         cursor.setinputsizes(None)
 
 
+def test_setinputsizes_character_dae(cursor):
+    """Declared character sizes over 4000 stream through the native DAE path."""
+    value = "x" * 5000
+    cursor.setinputsizes([(ddbc_sql_const.SQL_LONGVARCHAR.value, len(value), 0)])
+    try:
+        cursor.execute("SELECT LEN(CAST(? AS VARCHAR(MAX)))", [value])
+        assert cursor.fetchone()[0] == len(value)
+    finally:
+        cursor.setinputsizes(None)
+
+
 def test_setinputsizes_numeric_precision_and_scale_are_clamped(cursor):
-    """Oversized numeric metadata is clamped before narrowing to ODBC types."""
+    """Clamped numeric metadata must not make short Decimal text use DAE."""
     value = decimal.Decimal("0.1")
     cursor.setinputsizes([(ddbc_sql_const.SQL_DECIMAL.value, 10**100, 10**100)])
     try:


### PR DESCRIPTION
Reference: #736

### Summary

Use normalized and clamped parameter metadata when selecting data-at-execution binding. This prevents oversized DECIMAL/NUMERIC declarations from incorrectly streaming short formatted Decimal values while preserving DAE for genuinely oversized character and binary declarations.

### Validation

- Built the x64 native extension with `mssql_python\pybind\build.bat x64`
- `python -m black --check --line-length=100 tests\test_023_execute_path_parity.py`
- `python -m pytest -q tests\test_000_dependencies.py` (35 passed, 3 skipped)
- Focused live SQL tests require `DB_CONNECTION_STRING`; unavailable in this worktree